### PR TITLE
Add Object Storage Support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: install dependencies
         run: pip3 install -r requirements-dev.txt -r requirements.txt ansible
 
+      - name: install ansible dependencies
+        run: ansible-galaxy collection install amazon.aws
+
       - name: install collection
         run: make install
 

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Object Storage Cluster info."""
+
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=unused-import
+from linode_api4 import ObjectStorageKeys, ObjectStorageCluster
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import create_filter_and
+
+DOCUMENTATION = '''
+module: object_cluster_info
+description: Get information about an Object Storage cluster.
+requirements:
+  - python >= 2.7
+  - linode_api4 >= 3.0
+author:
+  - Luke Murphy (@decentral1se)
+  - Charles Kenney (@charliekenney23)
+  - Phillip Campbell (@phillc)
+  - Lena Garber (@lbgarber)
+options:
+  id:
+    description:
+      - The unique id given to the clusters
+    type: string
+  region:
+    description:
+      - The region the clusters are in
+    type: string
+  domain:
+    description:
+      - The domain of the clusters
+    type: string
+  static_site_domain:
+    description:
+      - The static-site domain of the clusters
+    type: string
+'''
+
+EXAMPLES = '''
+- name: Get info about clusters in us-east
+  linode.cloud.object_cluster_info:
+    region: us-east
+
+- name: Get info about the cluster with id us-east-1
+  linode.cloud.object_cluster_info:
+    id: us-east-1
+'''
+
+RETURN = '''
+clusters:
+  description: The Object Storage clusters in JSON serialized form.
+  returned: Always.
+  type: list
+  elements: dict
+  sample: [
+   {
+      "domain":"us-east-1.linodeobjects.com",
+      "id":"us-east-1",
+      "region":"us-east",
+      "static_site_domain":"website-us-east-1.linodeobjects.com",
+      "status":"available"
+   }
+]
+'''
+
+linode_object_cluster_info_spec = dict(
+    # We need to overwrite attributes to exclude them as requirements
+    state=dict(type='str', required=False),
+    label=dict(type='str', required=False),
+
+    id=dict(type='str', required=False),
+    region=dict(type='str', required=False),
+    domain=dict(type='str', required=False),
+    static_site_domain=dict(type='str', required=False)
+)
+
+linode_object_cluster_valid_filters = [
+    'id', 'region', 'domain', 'static_site_domain'
+]
+
+
+class LinodeObjectStorageClustersInfo(LinodeModuleBase):
+    """Configuration class for Linode Object Storage Clusters resource"""
+
+    def __init__(self):
+        self.module_arg_spec = linode_object_cluster_info_spec
+        self.required_one_of = []
+        self.results = dict(
+            changed=False,
+            actions=[],
+            clusters=None,
+        )
+
+        super().__init__(module_arg_spec=self.module_arg_spec,
+                         required_one_of=self.required_one_of)
+
+    def get_clusters_by_property(self, **kwargs):
+        """Gets a list of clusters with the given property in kwargs"""
+
+        filter_items = {k: v for k, v in kwargs.items()
+                        if k in linode_object_cluster_valid_filters and v is not None}
+
+        filter_statement = create_filter_and(ObjectStorageCluster, filter_items)
+
+        try:
+            # Special case because ID is not filterable
+            if 'id' in filter_items.keys():
+                result = ObjectStorageCluster(self.client, kwargs.get('id'))
+                result._api_get()  # Force lazy-loading
+
+                return [result]
+
+            return self.client.object_storage.clusters(filter_statement)
+        except IndexError:
+            return None
+        except Exception as exception:
+            self.fail(msg='failed to get clusters {0}'.format(exception))
+
+
+    def exec_module(self, **kwargs):
+        """Constructs and calls the Linode Object Storage Clusters module"""
+
+        clusters = self.get_clusters_by_property(**kwargs)
+
+        if clusters is None:
+            self.fail('failed to get clusters')
+
+        self.results['clusters'] = [cluster._raw_json for cluster in clusters]
+
+        return self.results
+
+def main():
+    """Constructs and calls the Linode Object Storage Clusters module"""
+    LinodeObjectStorageClustersInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Object Storage keys."""
+
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=unused-import
+from linode_api4 import ObjectStorageKeys, ObjectStorageCluster
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+
+DOCUMENTATION = '''
+module: object_keys
+description: Manage Linode Object Storage Keys.
+requirements:
+  - python >= 2.7
+  - linode_api4 >= 3.0
+author:
+  - Luke Murphy (@decentral1se)
+  - Charles Kenney (@charliekenney23)
+  - Phillip Campbell (@phillc)
+  - Lena Garber (@lbgarber)
+options:
+  label:
+    description:
+      - The unique label to give this key
+    required: true
+    type: string
+  access:
+    description:
+      - A list of access permissions to give the key.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      cluster:
+        description:
+          - The id of the cluster that the provided bucket exists under.
+        type: str
+        required: true
+      bucket_name:
+        description:
+          - The name of the bucket to set the key's permissions for.
+        type: str
+        required: true
+      permissions:
+        description:
+          - The permissions to give the key.
+        type: str
+        required: true
+        choices:
+          - read_only
+          - write_only
+          - read_write
+'''
+
+EXAMPLES = '''
+- name: Create an Object Storage key
+  linode.cloud.object_keys:
+    label: 'my-fullaccess-key'
+    state: present
+    
+- name: Create a limited Object Storage key
+  linode.cloud.object_keys:
+    label: 'my-limited-key'
+    access:
+      - cluster: us-east-1
+        bucket_name: my-bucket
+        permissions: read_write
+    state: present
+    
+- name: Remove an object storage key
+  linode.cloud.object_keys:
+    label: 'my-key'
+    state: absent
+'''
+
+RETURN = '''
+key:
+  description: The Object Storage key in JSON serialized form.
+  returned: Always.
+  type: dict
+  sample: {
+   "access_key":"xxxxxxxxxxxxxxxxx",
+   "bucket_access":[
+      {
+         "bucket_name":"my-bucket",
+         "cluster":"us-east-1",
+         "permissions":"read_write"
+      }
+   ],
+   "id":xxxxx,
+   "label":"my-key",
+   "limited":true,
+   "secret_key":"xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+'''
+
+linode_access_spec = dict(
+    cluster=dict(type='str', required=True),
+    bucket_name=dict(type='str', required=True),
+    permissions=dict(type='str', required=True)
+)
+
+linode_object_keys_spec = dict(
+    access=dict(type='list', required=False, elements='dict', options=linode_access_spec)
+)
+
+
+class LinodeObjectStorageKeys(LinodeModuleBase):
+    """Configuration class for Linode Object Storage Keys resource"""
+
+    def __init__(self):
+        self.module_arg_spec = linode_object_keys_spec
+        self.required_one_of = ['state', 'label']
+        self.results = dict(
+            changed=False,
+            actions=[],
+            key=None,
+        )
+
+        self._key = None
+
+        super().__init__(module_arg_spec=self.module_arg_spec,
+                         required_one_of=self.required_one_of)
+
+    def get_key_by_label(self, label):
+        """Gets the Object Storage key with the given label"""
+
+        try:
+            # For some reason we can't filter on label here
+            keys = self.client.object_storage.keys()
+
+            key = None
+            for current_key in keys:
+                if current_key.label == label:
+                    key = current_key
+
+            return key
+
+        except IndexError:
+            return None
+        except Exception as exception:
+            self.fail(msg='failed to get object storage key {0}: {1}'.format(label, exception))
+
+    def create_key(self, label, bucket_access):
+        """Creates an Object Storage key with the given label and access"""
+
+        try:
+            return self.client.object_storage.keys_create(label, bucket_access=bucket_access)
+        except Exception as exception:
+            self.fail(msg='failed to create object storage key: {0}'.format(exception))
+
+    def _dict_to_bucket_access(self, access_items):
+        "Converts the given bucket_access spec items into an API compliant format"
+
+        return [self.client.object_storage.bucket_access(
+            v.get('cluster'),
+            v.get('bucket'),
+            v.get('permissions')
+        ) for v in access_items]
+
+    def __handle_key(self, **kwargs):
+        """Updates the key defined in kwargs"""
+
+        label = kwargs.pop('label')
+
+        self._key = self.get_key_by_label(label)
+
+        if self._key is None:
+            self._key = self.create_key(label, bucket_access=kwargs.get('access'))
+            self.register_action('Created key {0}'.format(label))
+
+        self.results['key'] = self._key._raw_json
+
+    def __handle_key_absent(self, **kwargs):
+        """Deletes the key defined in kwargs"""
+
+        label = kwargs.pop('label')
+
+        self._key = self.get_key_by_label(label)
+
+        if self._key is not None:
+            self.results['key'] = self._key._raw_json
+            self._key.delete()
+            self.register_action('Deleted key {0}'.format(label))
+
+
+    def exec_module(self, **kwargs):
+        """Constructs and calls the Linode Object Storage Key module"""
+
+        state = kwargs.pop('state')
+
+        if state == 'absent':
+            self.__handle_key_absent(**kwargs)
+            return self.results
+
+        self.__handle_key(**kwargs)
+
+        return self.results
+
+def main():
+    """Constructs and calls the Linode Object Storage key module"""
+    LinodeObjectStorageKeys()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/object/tasks/main.yaml
+++ b/tests/integration/targets/object/tasks/main.yaml
@@ -1,0 +1,119 @@
+- name: Run Object Storage integration tests
+  block:
+    - name: Get info about clusters in us-east
+      linode.cloud.object_cluster_info:
+        api_token: '{{ api_token }}'
+        region: us-east
+      register: info_by_region
+
+    - name: Assert cluster information is valid
+      assert:
+        that:
+          - info_by_region.clusters[0].id == 'us-east-1'
+          - info_by_region.clusters[0].region == 'us-east'
+
+    - name: Get info about cluster id us-east-1
+      linode.cloud.object_cluster_info:
+        api_token: '{{ api_token }}'
+        id: us-east-1
+      register: info_by_id
+
+    - name: Assert cluster information is valid
+      assert:
+        that:
+          - info_by_id.clusters[0].id == 'us-east-1'
+          - info_by_id.clusters[0].region == 'us-east'
+
+    - name: Create a Linode key
+      linode.cloud.object_keys:
+        api_token: '{{ api_token }}'
+        label: 'test-ansible-key-{{ ansible_date_time.epoch }}'
+        state: present
+      register: create_key
+
+    - name: Assert key created
+      assert:
+        that:
+          - create_key.changed
+          - 'not "REDACTED" in create_key.key.secret_key'
+
+    - name: Create an S3 bucket
+      amazon.aws.s3_bucket:
+        s3_url: 'http://{{ info_by_id.clusters[0].domain }}/'
+        aws_access_key: '{{ create_key.key.access_key }}'
+        aws_secret_key: '{{ create_key.key.secret_key }}'
+        name: 'test-ansible-bucket-{{ ansible_date_time.epoch }}'
+        state: present
+      register: create_bucket
+
+    - name: Assert S3 bucket created
+      assert:
+        that:
+          - create_bucket.changed
+
+    - name: Create a Linode key with access restrictions
+      linode.cloud.object_keys:
+        api_token: '{{ api_token }}'
+        label: 'test-ansible-key-access-{{ ansible_date_time.epoch }}'
+        access:
+          - cluster: us-east-1
+            bucket_name: '{{ create_bucket.name }}'
+            permissions: read_write
+          - cluster: us-east-1
+            bucket_name: '{{ create_bucket.name }}'
+            permissions: read_only
+        state: present
+      register: create_access
+
+    - name: Assert key created and access is valid
+      assert:
+        that:
+          - create_access.changed
+          - 'not "REDACTED" in create_access.key.secret_key'
+          - create_access.key.bucket_access[0].cluster == 'us-east-1'
+          - create_access.key.bucket_access[0].bucket_name == create_bucket.name
+          - create_access.key.bucket_access[0].permissions == 'read_write'
+          - create_access.key.bucket_access[1].cluster == 'us-east-1'
+          - create_access.key.bucket_access[1].bucket_name == create_bucket.name
+          - create_access.key.bucket_access[1].permissions == 'read_only'
+
+  always:
+    - name: Delete the S3 bucket
+      amazon.aws.s3_bucket:
+        s3_url: 'http://{{ info_by_id.clusters[0].domain }}/'
+        aws_access_key: '{{ create_key.key.access_key }}'
+        aws_secret_key: '{{ create_key.key.secret_key }}'
+        name: '{{ create_bucket.name }}'
+        state: absent
+      register: delete_bucket
+
+    - name: Assert S3 bucket deleted
+      assert:
+        that:
+          - delete_bucket.changed
+
+    - name: Remove the key
+      linode.cloud.object_keys:
+        api_token: '{{ api_token }}'
+        label: '{{ create_key.key.label }}'
+        state: absent
+      register: delete
+
+    - name: Assert key destroyed
+      assert:
+        that:
+          - delete.changed
+          - '"REDACTED" in delete.key.secret_key'
+
+    - name: Remove the restricted key
+      linode.cloud.object_keys:
+        api_token: '{{ api_token }}'
+        label: '{{ create_access.key.label }}'
+        state: absent
+      register: delete_access
+
+    - name: Assert restricted key destroyed
+      assert:
+        that:
+          - delete_access.changed
+          - '"REDACTED" in delete_access.key.secret_key'


### PR DESCRIPTION
This is a WIP pull request that adds support for basic Linode Object Storage functionality.

It currently has two modules:
- object_keys
- object_cluster_info

As most of the actual S3-compatible functionality should be handled by the S3 module, these should be the bare minimum for someone to set up an Object Storage instance in a playbook.