### PR TITLE
Update linode_api4-python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-linode-api4==5.0.0
+linode-api4==5.0.1


### PR DESCRIPTION
Changes `requirements.txt` to use new version of `linode_api4-python` that allows for restricted Object Storage bucket keys.