### PR TITLE
Add documentation validation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Run Documentation Validation
+
+on: [push, pull_request]
+
+jobs:
+  run-docs-validation:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install packages
+        run: sudo apt-get install -y make
+
+      - name: setup python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: install dependencies
+        run: pip3 install ansible-doc-extractor==0.1.6
+
+      - name: make temp directory
+        run: mkdir tmp
+
+      - name: generate new docs
+        run: DOCS_PATH=tmp/docs make gendocs
+
+      - name: compare results
+        run: diff -qr docs tmp/docs
+
+      - name: clean up
+        run: rm -rf tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.tar.gz
+tmp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 COLLECTIONS_PATH ?= ~/.ansible/collections
+DOCS_PATH ?= docs
 
 TEST_ARGS := -v
 INTEGRATION_CONFIG := tests/integration/integration_config.yml
@@ -13,9 +14,9 @@ install: clean build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
 gendocs:
-	mkdir -p docs
-	rm -f docs/*
-	ansible-doc-extractor --template=template/module.rst.j2 docs plugins/modules/*.py
+	mkdir -p $(DOCS_PATH)
+	rm -f $(DOCS_PATH)/*
+	ansible-doc-extractor --template=template/module.rst.j2 $(DOCS_PATH) plugins/modules/*.py
 
 integration-test: $(INTEGRATION_CONFIG)
 	ansible-test integration $(TEST_ARGS)


### PR DESCRIPTION
Adds `docs` workflow that runs on pull requests and commits. The workflow fails if CI-generated docs do not match with the repo's docs.