### PR TITLE
Fix inconsistent type issue with no root password defined for instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Minor Changes
 -------------
 
 - Fix issue that would force NodeBalancer configs to be recreated.
+- Fix error on the creation of Linode instances without root password.
 
 v0.0.3
 ======

--- a/tests/integration/targets/instance/tasks/main.yaml
+++ b/tests/integration/targets/instance/tasks/main.yaml
@@ -19,6 +19,24 @@
           - create.instance.status == 'provisioning'
           - create.instance.ipv4|length > 1
 
+    - name: Create a Linode instance without a root password
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-nopass-{{ ansible_date_time.epoch }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu20.04
+        private_ip: true
+        state: present
+      register: create_nopass
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create_nopass.changed
+          - create_nopass.instance.status == 'provisioning'
+          - create_nopass.instance.ipv4|length > 1
+
     - name: Get info about the instance by id
       linode.cloud.instance_info:
         api_token: '{{ api_token }}'
@@ -55,3 +73,16 @@
         that:
           - delete.changed
           - delete.instance.id == create.instance.id
+
+    - name: Delete a Linode instance
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        label: '{{ create_nopass.instance.label }}'
+        state: absent
+      register: delete_nopass
+
+    - name: Assert instance delete succeeded
+      assert:
+        that:
+          - delete_nopass.changed
+          - delete_nopass.instance.id == create_nopass.instance.id


### PR DESCRIPTION
This pull request fixes an issue that would error if an instance was created without a root password.