### PR TITLE
Use commit hashes for action references

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,13 @@
 name: Run Documentation Validation
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   run-docs-validation:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
 
       - name: update packages
         run: sudo apt-get update -y
@@ -16,7 +16,7 @@ jobs:
         run: sudo apt-get install -y make
 
       - name: setup python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0291cefc54fa79cd1986aee8fa5ecb89ad4defea # pin@v2
         with:
           python-version: '3.x'
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
 
       - name: update packages
         run: sudo apt-get update -y
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get install -y build-essential
 
       - name: setup python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0291cefc54fa79cd1986aee8fa5ecb89ad4defea # pin@v2
         with:
           python-version: '3.x'
 
@@ -34,7 +34,8 @@ jobs:
         run: make install
 
       - name: copy makefile to installed collection
-        run: cp Makefile ~/.ansible/collections/ansible_collections/linode/cloud/Makefile
+        run: cp Makefile
+          ~/.ansible/collections/ansible_collections/linode/cloud/Makefile
 
       - name: copy tests to installed collection
         run: cp -r tests ~/.ansible/collections/ansible_collections/linode/cloud/tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,16 @@
 name: Run Linter
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
 
       - name: setup python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0291cefc54fa79cd1986aee8fa5ecb89ad4defea # pin@v2
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
- Alters all workflows to reference actions by their commit SHA rather than their version/tag
- Addresses security concerns described in [GitHub's documentation](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions)