### PR TITLE
Refactor modules to use self.module.params

### DIFF
--- a/docs/nodebalancer.rst
+++ b/docs/nodebalancer.rst
@@ -156,7 +156,7 @@ Examples
             nodes:
               - label: node1
                 address: 0.0.0.0:80
-                
+
     - name: Delete the NodeBalancer
       linode.cloud.nodebalancer:
         label: my-loadbalancer

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -139,7 +139,7 @@ linode_firewall_valid_filters = [
 
 
 class LinodeFirewallInfo(LinodeModuleBase):
-    """Configuration class for Linode Firewall resource"""
+    """Module for viewing info about a Linode Firewall"""
 
     def __init__(self) -> None:
         self.module_arg_spec = linode_firewall_info_spec
@@ -151,10 +151,10 @@ class LinodeFirewallInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def get_firewall_by_properties(self, spec_args: dict) -> Optional[Firewall]:
-        """Gets the Firewall with the given property in kwargs"""
+    def __get_matching_firewall(self) -> Optional[Firewall]:
+        """Gets the Firewall with the param properties"""
 
-        filter_items = {k: v for k, v in spec_args.items()
+        filter_items = {k: v for k, v in self.module.params.items()
                         if k in linode_firewall_valid_filters and v is not None}
 
         filter_statement = create_filter_and(Firewall, filter_items)
@@ -162,7 +162,7 @@ class LinodeFirewallInfo(LinodeModuleBase):
         try:
             # Special case because ID is not filterable
             if 'id' in filter_items.keys():
-                result = Firewall(self.client, spec_args.get('id'))
+                result = Firewall(self.client, self.module.params.get('id'))
                 result._api_get()  # Force lazy-loading
 
                 return result
@@ -176,7 +176,7 @@ class LinodeFirewallInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: dict) -> Optional[dict]:
         """Entrypoint for Firewall info module"""
 
-        firewall = self.get_firewall_by_properties(kwargs)
+        firewall = self.__get_matching_firewall()
 
         if firewall is None:
             self.fail('failed to get firewall')

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -156,7 +156,7 @@ linode_instance_valid_filters = [
 
 
 class LinodeInstanceInfo(LinodeModuleBase):
-    """Configuration class for Linode instance resource"""
+    """Module for getting info about a Linode Instance"""
 
     def __init__(self) -> None:
         self.module_arg_spec = linode_instance_info_spec
@@ -169,10 +169,10 @@ class LinodeInstanceInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def get_instance_by_properties(self, spec_args: dict) -> Optional[Instance]:
-        """Gets the instance with the given property in kwargs"""
+    def __get_matching_instance(self) -> Optional[Instance]:
+        params = self.module.params
 
-        filter_items = {k: v for k, v in spec_args.items()
+        filter_items = {k: v for k, v in params.items()
                         if k in linode_instance_valid_filters and v is not None}
 
         filter_statement = create_filter_and(Instance, filter_items)
@@ -180,7 +180,7 @@ class LinodeInstanceInfo(LinodeModuleBase):
         try:
             # Special case because ID is not filterable
             if 'id' in filter_items.keys():
-                result = Instance(self.client, spec_args.get('id'))
+                result = Instance(self.client, params.get('id'))
                 result._api_get()  # Force lazy-loading
 
                 return result
@@ -194,7 +194,7 @@ class LinodeInstanceInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for instance info module"""
 
-        instance = self.get_instance_by_properties(kwargs)
+        instance = self.__get_matching_instance()
 
         if instance is None:
             return self.fail('failed to get instance')

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -93,7 +93,7 @@ linode_object_cluster_valid_filters = [
 
 
 class LinodeObjectStorageClustersInfo(LinodeModuleBase):
-    """Configuration class for Linode Object Storage Clusters resource"""
+    """Module for getting info about a Linode Object Storage Cluster"""
 
     def __init__(self) -> None:
         self.module_arg_spec = linode_object_cluster_info_spec
@@ -107,10 +107,8 @@ class LinodeObjectStorageClustersInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def get_clusters_by_property(self, spec_args: dict) -> Optional[List[ObjectStorageCluster]]:
-        """Gets a list of clusters with the given property in kwargs"""
-
-        filter_items = {k: v for k, v in spec_args.items()
+    def __get_matching_cluster(self) -> Optional[List[ObjectStorageCluster]]:
+        filter_items = {k: v for k, v in self.module.params.items()
                         if k in linode_object_cluster_valid_filters and v is not None}
 
         filter_statement = create_filter_and(ObjectStorageCluster, filter_items)
@@ -118,7 +116,7 @@ class LinodeObjectStorageClustersInfo(LinodeModuleBase):
         try:
             # Special case because ID is not filterable
             if 'id' in filter_items.keys():
-                result = ObjectStorageCluster(self.client, spec_args.get('id'))
+                result = ObjectStorageCluster(self.client, self.module.params.get('id'))
                 result._api_get()  # Force lazy-loading
 
                 return [result]
@@ -132,7 +130,7 @@ class LinodeObjectStorageClustersInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Constructs and calls the Linode Object Storage Clusters module"""
 
-        clusters = self.get_clusters_by_property(kwargs)
+        clusters = self.__get_matching_cluster()
 
         if clusters is None:
             return self.fail('failed to get clusters')

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -68,7 +68,7 @@ linode_vlan_info_spec = dict(
 
 
 class LinodeVLANInfo(LinodeModuleBase):
-    """Configuration class for Linode VLAN resource"""
+    """Module for getting info about a Linode VLAN"""
 
     def __init__(self) -> None:
         self.module_arg_spec = linode_vlan_info_spec
@@ -80,9 +80,7 @@ class LinodeVLANInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def get_vlan_by_label(self, label: str) -> Optional[VLAN]:
-        """Gets the VLAN with the given property in kwargs"""
-
+    def __get_vlan_by_label(self, label: str) -> Optional[VLAN]:
         try:
             return self.client.networking.vlans(VLAN.label == label)[0]
         except IndexError:
@@ -94,8 +92,7 @@ class LinodeVLANInfo(LinodeModuleBase):
         """Entrypoint for VLAN info module"""
 
         label: str = kwargs.get('label')
-
-        vlan = self.get_vlan_by_label(label)
+        vlan = self.__get_vlan_by_label(label)
 
         if vlan is None:
             self.fail('failed to get vlan')

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -86,7 +86,7 @@ linode_volume_valid_filters = [
 
 
 class LinodeVolumeInfo(LinodeModuleBase):
-    """Configuration class for Linode volume resource"""
+    """Module for getting info about a Linode Volume"""
 
     def __init__(self) -> None:
         self.module_arg_spec = linode_volume_info_spec
@@ -100,9 +100,7 @@ class LinodeVolumeInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def get_volume_by_properties(self, spec_args: dict) -> Optional[Volume]:
-        """Gets the volume with the given property in kwargs"""
-
+    def __get_matching_volume(self, spec_args: dict) -> Optional[Volume]:
         filter_items = {k: v for k, v in spec_args.items()
                         if k in linode_volume_valid_filters and v is not None}
 
@@ -125,7 +123,7 @@ class LinodeVolumeInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for volume info module"""
 
-        volume = self.get_volume_by_properties(kwargs)
+        volume = self.__get_matching_volume(kwargs)
 
         if volume is None:
             self.fail('failed to get volume')


### PR DESCRIPTION
- Modules now use `self.module.params` rather than passing `spec_args` around