### PR TITLE
Add ignore_errors to integration test clean-up steps

### DIFF
--- a/tests/integration/targets/firewall/tasks/main.yaml
+++ b/tests/integration/targets/firewall/tasks/main.yaml
@@ -247,42 +247,44 @@
           - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
           - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
   always:
-    - name: Delete a Linode Firewall
-      linode.cloud.firewall:
-        api_token: '{{ api_token }}'
-        api_version: v4beta
-        label: '{{ create.firewall.label }}'
-        state: absent
-      register: delete
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode Firewall
+          linode.cloud.firewall:
+            api_token: '{{ api_token }}'
+            api_version: v4beta
+            label: '{{ create.firewall.label }}'
+            state: absent
+          register: delete
 
-    - name: Assert Firewall delete succeeded
-      assert:
-        that:
-          - delete.changed
-          - delete.firewall.id == create.firewall.id
+        - name: Assert Firewall delete succeeded
+          assert:
+            that:
+              - delete.changed
+              - delete.firewall.id == create.firewall.id
 
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create_instance.instance.label }}'
-        state: absent
-      register: delete_instance
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create_instance.instance.label }}'
+            state: absent
+          register: delete_instance
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete_instance.changed
-          - delete_instance.instance.id == create_instance.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create_instance.instance.id
 
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create_instance_2.instance.label }}'
-        state: absent
-      register: delete_instance_2
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create_instance_2.instance.label }}'
+            state: absent
+          register: delete_instance_2
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete_instance_2.changed
-          - delete_instance_2.instance.id == create_instance_2.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance_2.changed
+              - delete_instance_2.instance.id == create_instance_2.instance.id

--- a/tests/integration/targets/instance/tasks/main.yaml
+++ b/tests/integration/targets/instance/tasks/main.yaml
@@ -164,41 +164,43 @@
           - update_interface_noupdate.changed == false
 
   always:
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create.instance.label }}'
-        state: absent
-      register: delete
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create.instance.label }}'
+            state: absent
+          register: delete
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete.changed
-          - delete.instance.id == create.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete.changed
+              - delete.instance.id == create.instance.id
 
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create_interface.instance.label }}'
-        state: absent
-      register: delete_interface
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create_interface.instance.label }}'
+            state: absent
+          register: delete_interface
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete_interface.changed
-          - delete_interface.instance.id == create_interface.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_interface.changed
+              - delete_interface.instance.id == create_interface.instance.id
 
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ update_nopass.instance.label }}'
-        state: absent
-      register: delete_nopass
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ update_nopass.instance.label }}'
+            state: absent
+          register: delete_nopass
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete_nopass.changed
-          - delete_nopass.instance.id == update_nopass.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_nopass.changed
+              - delete_nopass.instance.id == update_nopass.instance.id

--- a/tests/integration/targets/nodebalancer/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer/tasks/main.yaml
@@ -312,69 +312,69 @@
         - "'failed' not in fake_nb_info.msg"
 
   always:
-    # Delete the NodeBalancers
-    - name: Delete the populated NodeBalancer
-      linode.cloud.nodebalancer:
-        api_token: '{{ api_token }}'
-        label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        state: absent
-      register: delete_populated
+    - ignore_errors: yes
+      block:
+        - name: Delete the populated NodeBalancer
+          linode.cloud.nodebalancer:
+            api_token: '{{ api_token }}'
+            label: '{{ create_populated_nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_populated
 
-    - name: Assert populated NodeBalancer delete
-      assert:
-        that:
-          - delete_populated.changed
-          - delete_populated.node_balancer.id == update_populated_config.node_balancer.id
+        - name: Assert populated NodeBalancer delete
+          assert:
+            that:
+              - delete_populated.changed
+              - delete_populated.node_balancer.id == update_populated_config.node_balancer.id
 
-    - name: Delete the empty NodeBalancer
-      linode.cloud.nodebalancer:
-        api_token: '{{ api_token }}'
-        label: '{{ create_empty_nodebalancer.node_balancer.label }}'
-        state: absent
-      register: delete_empty
+        - name: Delete the empty NodeBalancer
+          linode.cloud.nodebalancer:
+            api_token: '{{ api_token }}'
+            label: '{{ create_empty_nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_empty
 
-    - name: Assert empty NodeBalancer delete
-      assert:
-        that:
-          - delete_empty.changed
-          - delete_empty.node_balancer.id == delete_empty.node_balancer.id
+        - name: Assert empty NodeBalancer delete
+          assert:
+            that:
+              - delete_empty.changed
+              - delete_empty.node_balancer.id == delete_empty.node_balancer.id
 
-    # Delete the node instances
-    - name: Delete node1
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ node1_inst.instance.label }}'
-        state: absent
-      register: delete_node1
+        - name: Delete node1
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ node1_inst.instance.label }}'
+            state: absent
+          register: delete_node1
 
-    - name: Assert node1 delete
-      assert:
-        that:
-          - delete_node1.changed
-          - delete_node1.instance.id == node1_inst.instance.id
+        - name: Assert node1 delete
+          assert:
+            that:
+              - delete_node1.changed
+              - delete_node1.instance.id == node1_inst.instance.id
 
-    - name: Delete node2
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ node2_inst.instance.label }}'
-        state: absent
-      register: delete_node2
+        - name: Delete node2
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ node2_inst.instance.label }}'
+            state: absent
+          register: delete_node2
 
-    - name: Assert node2 delete
-      assert:
-        that:
-          - delete_node2.changed
-          - delete_node2.instance.id == node2_inst.instance.id
+        - name: Assert node2 delete
+          assert:
+            that:
+              - delete_node2.changed
+              - delete_node2.instance.id == node2_inst.instance.id
 
-    - name: Delete node3
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ node3_inst.instance.label }}'
-        state: absent
-      register: delete_node3
+        - name: Delete node3
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ node3_inst.instance.label }}'
+            state: absent
+          register: delete_node3
 
-    - name: Assert node3 delete
-      assert:
-        that:
-          - delete_node3.changed
-          - delete_node3.instance.id == node3_inst.instance.id
+        - name: Assert node3 delete
+          assert:
+            that:
+              - delete_node3.changed
+              - delete_node3.instance.id == node3_inst.instance.id

--- a/tests/integration/targets/object/tasks/main.yaml
+++ b/tests/integration/targets/object/tasks/main.yaml
@@ -78,42 +78,45 @@
           - create_access.key.bucket_access[1].permissions == 'read_only'
 
   always:
-    - name: Delete the S3 bucket
-      amazon.aws.s3_bucket:
-        s3_url: 'http://{{ info_by_id.clusters[0].domain }}/'
-        aws_access_key: '{{ create_key.key.access_key }}'
-        aws_secret_key: '{{ create_key.key.secret_key }}'
-        name: '{{ create_bucket.name }}'
-        state: absent
-      register: delete_bucket
+    - ignore_errors: yes
+      block:
+      - name: Delete the S3 bucket
+        amazon.aws.s3_bucket:
+          s3_url: 'http://{{ info_by_id.clusters[0].domain }}/'
+          aws_access_key: '{{ create_key.key.access_key }}'
+          aws_secret_key: '{{ create_key.key.secret_key }}'
+          name: '{{ create_bucket.name }}'
+          state: absent
+        register: delete_bucket
 
-    - name: Assert S3 bucket deleted
-      assert:
-        that:
-          - delete_bucket.changed
+      - name: Assert S3 bucket deleted
+        assert:
+          that:
+            - delete_bucket.changed
 
-    - name: Remove the key
-      linode.cloud.object_keys:
-        api_token: '{{ api_token }}'
-        label: '{{ create_key.key.label }}'
-        state: absent
-      register: delete
+      - name: Remove the key
+        linode.cloud.object_keys:
+          api_token: '{{ api_token }}'
+          label: '{{ create_key.key.label }}'
+          state: absent
+        register: delete
 
-    - name: Assert key destroyed
-      assert:
-        that:
-          - delete.changed
-          - '"REDACTED" in delete.key.secret_key'
+      - name: Assert key destroyed
+        assert:
+          that:
+            - delete.changed
+            - '"REDACTED" in delete.key.secret_key'
+            - false
 
-    - name: Remove the restricted key
-      linode.cloud.object_keys:
-        api_token: '{{ api_token }}'
-        label: '{{ create_access.key.label }}'
-        state: absent
-      register: delete_access
+      - name: Remove the restricted key
+        linode.cloud.object_keys:
+          api_token: '{{ api_token }}'
+          label: '{{ create_access.key.label }}'
+          state: absent
+        register: delete_access
 
-    - name: Assert restricted key destroyed
-      assert:
-        that:
-          - delete_access.changed
-          - '"REDACTED" in delete_access.key.secret_key'
+      - name: Assert restricted key destroyed
+        assert:
+          that:
+            - delete_access.changed
+            - '"REDACTED" in delete_access.key.secret_key'

--- a/tests/integration/targets/vlan/tasks/main.yaml
+++ b/tests/integration/targets/vlan/tasks/main.yaml
@@ -39,15 +39,17 @@
           - vlan_info.vlan.label == 'really-cool-vlan'
 
   always:
-    - name: Delete a Linode instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create_instance.instance.label }}'
-        state: absent
-      register: delete_instance
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create_instance.instance.label }}'
+            state: absent
+          register: delete_instance
 
-    - name: Assert instance delete succeeded
-      assert:
-        that:
-          - delete_instance.changed
-          - delete_instance.instance.id == create_instance.instance.id
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create_instance.instance.id

--- a/tests/integration/targets/volume/tasks/main.yaml
+++ b/tests/integration/targets/volume/tasks/main.yaml
@@ -103,39 +103,41 @@
           - not detach_volume.volume.linode_id|d(False)
 
   always:
-    - name: Delete the instance volume
-      linode.cloud.volume:
-        api_token: '{{ api_token }}'
-        label: '{{ create_volume_inst.volume.label }}'
-        state: absent
-      register: delete_volume_inst
+    - ignore_errors: yes
+      block:
+        - name: Delete the instance volume
+          linode.cloud.volume:
+            api_token: '{{ api_token }}'
+            label: '{{ create_volume_inst.volume.label }}'
+            state: absent
+          register: delete_volume_inst
 
-    - name: Assert the instance volume was deleted
-      assert:
-        that:
-          - delete_volume_inst.changed
+        - name: Assert the instance volume was deleted
+          assert:
+            that:
+              - delete_volume_inst.changed
 
-    - name: Delete the volume
-      linode.cloud.volume:
-        api_token: '{{ api_token }}'
-        label: '{{ create_volume_noinst.volume.label }}'
-        state: absent
-      register: delete_volume_noinst
+        - name: Delete the volume
+          linode.cloud.volume:
+            api_token: '{{ api_token }}'
+            label: '{{ create_volume_noinst.volume.label }}'
+            state: absent
+          register: delete_volume_noinst
 
-    - name: Assert the volume was deleted
-      assert:
-        that:
-          - delete_volume_noinst.changed
+        - name: Assert the volume was deleted
+          assert:
+            that:
+              - delete_volume_noinst.changed
 
-    - name: Delete the instance
-      linode.cloud.instance:
-        api_token: '{{ api_token }}'
-        label: '{{ create_inst.instance.label }}'
-        state: absent
-      register: delete_inst
+        - name: Delete the instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ create_inst.instance.label }}'
+            state: absent
+          register: delete_inst
 
-    - name: Assert instance delete
-      assert:
-        that:
-          - delete_inst.changed
-          - delete_inst.instance.id == create_inst.instance.id
+        - name: Assert instance delete
+          assert:
+            that:
+              - delete_inst.changed
+              - delete_inst.instance.id == create_inst.instance.id


### PR DESCRIPTION
This pull request is necessary due to the failed creation of resources causing the clean-up stage to fail early, causing resource leaking.