### PR TITLE
Use ansible-specdoc for documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,16 +21,27 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip install -r requirements-dev.txt ansible-core
+        run: pip install -r requirements-dev.txt -r requirements.txt ansible-core
 
+      - name: install collection
+        run: make install
+
+      - name: copy other files to installed collection
+        run: cp -r Makefile template scripts ~/.ansible/collections/ansible_collections/linode/cloud/
+
+        # There is not currently a way to set the working directory for subsequent steps
       - name: make temp directory
         run: mkdir tmp
+        working-directory: /home/runner/.ansible/collections/ansible_collections/linode/cloud
 
       - name: generate new docs
         run: DOCS_PATH=tmp/docs make gendocs
+        working-directory: /home/runner/.ansible/collections/ansible_collections/linode/cloud
 
       - name: compare results
         run: diff -qr docs tmp/docs
+        working-directory: /home/runner/.ansible/collections/ansible_collections/linode/cloud
 
       - name: clean up
         run: rm -rf tmp
+        working-directory: /home/runner/.ansible/collections/ansible_collections/linode/cloud

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,4 +11,5 @@ disable=protected-access,
         too-many-arguments,
         too-few-public-methods,
         duplicate-code,
-        too-many-lines
+        too-many-lines,
+        anomalous-backslash-in-string

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ lint:
 	mypy plugins/modules
 	mypy plugins/inventory
 
-gendocs:
+gendocsspec:
+	./scripts/specdoc_generate.sh
+
+gendocsrst:
 	mkdir -p $(DOCS_PATH)
 
 	rm -rf $(DOCS_PATH)/*
@@ -28,6 +31,8 @@ gendocs:
 
 	ansible-doc-extractor --template=template/module.rst.j2 $(DOCS_PATH)/modules plugins/modules/*.py
 	ansible-doc-extractor --template=template/module.rst.j2 $(DOCS_PATH)/inventory plugins/inventory/*.py
+
+gendocs: gendocsspec gendocsrst
 
 integration-test: $(INTEGRATION_CONFIG)
 	ansible-test integration $(TEST_ARGS)

--- a/docs/modules/firewall.rst
+++ b/docs/modules/firewall.rst
@@ -12,7 +12,7 @@ firewall
 Synopsis
 --------
 
-Manage Linode Firewalls. This endpoint is currently in beta and will only function correctly if `api_version` is set to `v4beta`.
+Manage Linode Firewalls.
 
 
 
@@ -20,114 +20,133 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 5.1.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (True, str, None)
-    The unique label to give this Firewall.
-
-
-  status (optional, str, None)
-    The status of this Firewall.
-
-
-  devices (optional, list, None)
+  devices (False, list, None)
     The devices that are attached to this Firewall.
 
 
-    id (True, str, None)
-      The unique ID of the device to attach to this Firewall.
+      id (True, int, None)
+        The unique ID of the device to attach to this Firewall.
 
 
-    type (optional, str, linode)
-      The type of device to be attached to this Firewall.
-
-
-
-  rules (optional, dict, None)
-    The inbound and outbound access rules to apply to the Firewall.
-
-
-    inbound_policy (True, str, None)
-      The default behavior for inbound traffic.
-
-
-    outbound_policy (True, str, None)
-      The default behavior for outbound traffic.
-
-
-    inbound (optional, list, None)
-      A list of rules for inbound traffic.
-
-
-      label (True, str, None)
-        The label of this rule.
-
-
-      action (True, str, None)
-        Controls whether traffic is accepted or dropped by this rule.
-
-
-      description (optional, str, None)
-        The description of this rule.
-
-
-      addresses (optional, list, None)
-        Allowed IPv4 or IPv6 addresses.
-
-
-        ipv4 (optional, list, None)
-          A list of IPv4 addresses or networks.
-
-          Must be in IP/mask format.
-
-
-        ipv6 (optional, list, None)
-          A list of IPv4 addresses or networks.
-
-          Must be in IP/mask format.
+      type (False, str, linode)
+        The type of device to be attached to this Firewall.
 
 
 
-
-    outbound (optional, list, None)
-      A list of rules for outbound traffic.
-
-
-      label (True, str, None)
-        The label of this rule.
+  label (False, str, None)
+    The unique label to give this Firewall.
 
 
-      action (True, str, None)
-        Controls whether traffic is accepted or dropped by this rule.
+  rules (False, dict, None)
+    The inbound and outbound access rules to apply to this Firewall.
 
 
-      description (optional, str, None)
-        The description of this rule.
+      inbound (False, list, None)
+        A list of rules for inbound traffic.
 
 
-      addresses (optional, list, None)
-        Allowed IPv4 or IPv6 addresses.
+          action (True, str, None)
+            Controls whether traffic is accepted or dropped by this rule.
 
 
-        ipv4 (optional, list, None)
-          A list of IPv4 addresses or networks.
-
-          Must be in IP/mask format.
+          addresses (False, dict, None)
+            Allowed IPv4 or IPv6 addresses.
 
 
-        ipv6 (optional, list, None)
-          A list of IPv4 addresses or networks.
+              ipv4 (False, list, None)
+                A list of IPv4 addresses or networks.
 
-          Must be in IP/mask format.
+                Must be in IP/mask format.
+
+
+              ipv6 (False, list, None)
+                A list of IPv4 addresses or networks.
+
+                Must be in IP/mask format.
 
 
 
+          description (False, str, None)
+            A description for this rule.
+
+
+          label (True, str, None)
+            The label of this rule.
+
+
+          ports (False, str, None)
+            A string representing the port or ports on which traffic will be allowed.
+
+            See https://www.linode.com/docs/api/networking/#firewall-create
+
+
+          protocol (False, str, None)
+            The type of network traffic to allow.
+
+
+
+      inbound_policy (False, str, None)
+        The default behavior for inbound traffic.
+
+
+      outbound (False, list, None)
+        A list of rules for outbound traffic.
+
+
+          action (True, str, None)
+            Controls whether traffic is accepted or dropped by this rule.
+
+
+          addresses (False, dict, None)
+            Allowed IPv4 or IPv6 addresses.
+
+
+              ipv4 (False, list, None)
+                A list of IPv4 addresses or networks.
+
+                Must be in IP/mask format.
+
+
+              ipv6 (False, list, None)
+                A list of IPv4 addresses or networks.
+
+                Must be in IP/mask format.
+
+
+
+          description (False, str, None)
+            A description for this rule.
+
+
+          label (True, str, None)
+            The label of this rule.
+
+
+          ports (False, str, None)
+            A string representing the port or ports on which traffic will be allowed.
+
+            See https://www.linode.com/docs/api/networking/#firewall-create
+
+
+          protocol (False, str, None)
+            The type of network traffic to allow.
+
+
+
+      outbound_policy (False, str, None)
+        The default behavior for outbound traffic.
+
+
+
+  status (False, str, None)
+    The status of this Firewall.
 
 
 

--- a/docs/modules/firewall_info.rst
+++ b/docs/modules/firewall_info.rst
@@ -12,7 +12,7 @@ firewall_info
 Synopsis
 --------
 
-Get info about a Linode Firewall. This endpoint is currently in beta and will only function correctly if `api_version` is set to `v4beta`.
+Get info about a Linode Firewall.
 
 
 
@@ -20,20 +20,19 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 5.1.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (optional, string, None)
-    The Firewall’s label.
-
-
-  id (optional, int, None)
+  id (False, int, None)
     The unique id of the Firewall.
+
+
+  label (False, str, None)
+    The Firewall’s label.
 
 
 

--- a/docs/modules/instance.rst
+++ b/docs/modules/instance.rst
@@ -12,7 +12,7 @@ instance
 Synopsis
 --------
 
-Manage Linode instances.
+Manage Linode Instances.
 
 
 
@@ -20,236 +20,344 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (True, string, None)
-    The unique label to give this instance.
+  authorized_keys (False, list, None)
+    A list of SSH public key parts to deploy for the root user.
 
 
-  type (optional, any, None)
-    The type or plan of this instance.
+  backup_id (False, int, None)
+    The id of the Backup to restore to the new Instance.
 
-    See https://api.linode.com/v4/linode/types
-
-
-  region (True, str, None)
-    The location to deploy the instance in.
-
-    See https://api.linode.com/v4/regions
+    May not be provided if “image” is given.
 
 
-  image (True, str, None)
-    The image ID to deploy the instance disk from.
+  boot_config_label (False, str, None)
+    The label of the config to boot from.
+
+
+  booted (False, bool, True)
+    Whether the new Instance should be booted.
+
+    This will default to True if the Instance is deployed from an Image or Backup.
+
+
+  configs (False, list, None)
+    A list of Instance configs to apply to the Linode.
+
+    See https://www.linode.com/docs/api/linode-instances/#configuration-profile-create
+
+
+      comments (False, str, None)
+        Arbitrary User comments on this Config.
+
+
+      devices (False, dict, None)
+        The devices to map to this configuration.
+
+
+          sda (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdb (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdc (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdd (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sde (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdf (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdg (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+          sdh (False, dict, None)
+
+              disk_id (False, int, None)
+                The ID of the disk to attach to this Linode.
+
+
+              disk_label (False, str, None)
+                The label of the disk to attach to this Linode.
+
+
+              volume_id (False, int, None)
+                The ID of the volume to attach to this Linode.
+
+
+
+
+      helpers (False, dict, None)
+        Helpers enabled when booting to this Linode Config.
+
+
+          devtmpfs_automount (False, bool, None)
+            Populates the /dev directory early during boot without udev.
+
+
+          distro (False, bool, None)
+            Helps maintain correct inittab/upstart console device.
+
+
+          modules_dep (False, bool, None)
+            Creates a modules dependency file for the Kernel you run.
+
+
+          network (False, bool, None)
+            Automatically configures static networking.
+
+
+          updatedb_disabled (False, bool, None)
+            Disables updatedb cron job to avoid disk thrashing.
+
+
+
+      kernel (False, str, None)
+        A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”          .
+
+
+      label (True, str, None)
+        The label to assign to this config.
+
+
+      memory_limit (False, int, None)
+        Defaults to the total RAM of the Linode.
+
+
+      root_device (False, str, None)
+        The root device to boot.
+
+
+      run_level (False, str, None)
+        Defines the state of your Linode after booting.
+
+
+      virt_mode (False, str, None)
+        Controls the virtualization mode.
+
+
+
+  disks (False, list, None)
+    A list of Disks to create on the Linode.
+
+    See https://www.linode.com/docs/api/linode-instances/#disk-create
+
+
+      authorized_keys (False, list, None)
+        A list of SSH public key parts to deploy for the root user.
+
+
+      authorized_users (False, list, None)
+        A list of usernames.
+
+
+      filesystem (False, str, None)
+        The filesystem to create this disk with.
+
+
+      image (False, str, None)
+        An Image ID to deploy the Disk from.
+
+
+      label (True, str, None)
+        The label to give this Disk.
+
+
+      root_pass (False, str, None)
+        The root user’s password on the newly-created Linode.
+
+
+      size (True, int, None)
+        The size of the Disk in MB.
+
+
+      stackscript_data (False, dict, None)
+        An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance.
+
+        Only valid when a stackscript_id is provided.
+
+        See https://www.linode.com/docs/api/stackscripts/
+
+
+      stackscript_id (False, int, None)
+        The ID of the StackScript to use when creating the instance.
+
+        See https://www.linode.com/docs/api/stackscripts/
+
 
 
   group (False, str, None)
-    The group that the instance should be marked under. Please note, that group labelling is deprecated but still supported. The encouraged method for marking instances is to use tags.
+    The group that the instance should be marked under.
+
+    Please note, that group labelling is deprecated but still supported.
+
+    The encouraged method for marking instances is to use tags.
 
 
-  tags (False, list, None)
-    The tags that the instance should be marked under.
-
-    See https://www.linode.com/docs/api/tags/.
+  image (False, str, None)
+    The image ID to deploy the instance disk from.
 
 
-  root_pass (False, str, None)
-    The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.
+  interfaces (False, list, None)
+    A list of network interfaces to apply to the Linode.
+
+    See https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema.
+
+
+      ipam_address (False, str, None)
+        This Network Interface’s private IP address in Classless           Inter-Domain Routing (CIDR) notation.
+
+
+      label (False, str, None)
+        The name of this interface.
+
+        Required for vlan purpose interfaces.
+
+        Must be an empty string or null for public purpose interfaces.
+
+
+      purpose (True, str, None)
+        The type of interface.
+
 
 
   private_ip (False, bool, None)
     If true, the created Linode will have private networking enabled.
 
 
-  authorized_keys (False, list, None)
-    A list of SSH public key parts to deploy for the root user.
+  region (False, str, None)
+    The location to deploy the instance in.
+
+    See https://api.linode.com/v4/regions
 
 
-  stackscript_id (False, int, None)
-    The ID of the StackScript to use when creating the instance. See https://www.linode.com/docs/api/stackscripts/.
+  root_pass (False, str, None)
+    The password for the root user.
+
+    If not specified, one will be generated.
+
+    This generated password will be available in the task success JSON.
 
 
   stackscript_data (False, dict, None)
-    An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See https://www.linode.com/docs/api/stackscripts/.
+    An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance.
 
+    Only valid when a stackscript_id is provided.
 
-  configs (optional, list, None)
-    A list of Instance configs to apply to the Linode.
+    See https://www.linode.com/docs/api/stackscripts/.
 
-    See https://www.linode.com/docs/api/linode-instances/#configuration-profile-create
 
+  stackscript_id (False, int, None)
+    The ID of the StackScript to use when creating the instance.
 
-    label (True, str, None)
-      The label to assign to this config.
+    See https://www.linode.com/docs/api/stackscripts/.
 
 
-    comments (optional, str, None)
-      Arbitrary User comments on this Config.
+  type (False, str, None)
+    The unique label to give this instance.
 
 
-    devices (optional, list, None)
-      A map of devices to use in a Linode's configuration profile.
-
-
-      sda...sdh (optional, dict, None)
-        A device to be mapped to to this configuration.
-
-
-        disk_label (optional, str, None)
-          The label of the disk to attach to this Linode.
-
-
-        disk_id (optional, int, None)
-          The ID of the disk to attach to this Linode.
-
-
-        volume_id (optional, int, None)
-          The ID of the volume to attach to this Linode.
-
-
-
-
-    helpers (optional, dict, None)
-      Helpers enabled when booting to this Linode Config.
-
-
-      devtmpfs_automount (optional, bool, None)
-        Populates the /dev directory early during boot without udev.
-
-
-      distro (optional, bool, None)
-        Helps maintain correct inittab/upstart console device.
-
-
-      modules_dep (optional, bool, None)
-        Creates a modules dependency file for the Kernel you run.
-
-
-      network (optional, bool, None)
-        Automatically configures static networking.
-
-
-      updatedb_disabled (optional, bool, None)
-        Disables updatedb cron job to avoid disk thrashing.
-
-
-
-    kernel (optional, str, None)
-      A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.
-
-
-    memory_limit (optional, int, None)
-      Defaults to the total RAM of the Linode.
-
-
-    root_device (optional, int, None)
-      The root device to boot.
-
-
-    run_level (optional, str, None)
-      Defines the state of your Linode after booting.
-
-
-    virt_mode (optional, str, None)
-      Controls the virtualization mode.
-
-
-
-  disks (optional, list, None)
-    A list of Disks to create on the Linode.
-
-    See https://www.linode.com/docs/api/linode-instances/#disk-create
-
-
-    label (True, str, None)
-      The label to give this Disk.
-
-
-    size (optional, int, None)
-      The size of the Disk in MB.
-
-
-    authorized_keys (optional, list, None)
-      A list of SSH public key parts to deploy for the root user.
-
-
-    authorized_users (optional, list, None)
-      A list of usernames.
-
-
-    filesystem (optional, str, None)
-      The filesystem to create this disk with.
-
-
-    image (optional, str, None)
-      An Image ID to deploy the Disk from.
-
-
-    root_pass (optional, str, None)
-      The root user’s password on the newly-created Linode.
-
-
-    stackscript_data (optional, dict, None)
-      An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided.
-
-      See https://www.linode.com/docs/api/stackscripts/.
-
-
-    stackscript_id (optional, any, None)
-      The ID of the StackScript to use when creating the instance.
-
-      See https://www.linode.com/docs/api/stackscripts/
-
-
-
-  interfaces (optional, list, None)
-    A list of network interfaces to apply to the Linode.
-
-    VLANs are currently in beta and will only function correctly if `api_version` is set to `v4beta`.
-
-    See https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema.
-
-
-    purpose (True, str, None)
-      The type of interface.
-
-
-    label (optional, str, None)
-      The name of this interface.
-
-      Required for vlan purpose interfaces.
-
-      Must be an empty string or null for public purpose interfaces.
-
-
-    ipam_address (optional, str, None)
-      This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.
-
-
-
-  booted (optional, any, None)
-    Whether the new Instance should be booted. This will default to True if the Instance is deployed from an Image or Backup.
-
-
-  backup_id (optional, any, None)
-    The id of the Backup to restore to the new Instance. May not be provided if “image” is given.
-
-
-  wait (optional, bool, True)
+  wait (False, bool, True)
     Wait for the instance to have status `running` before returning.
 
 
-  wait_timeout (optional, int, 240)
+  wait_timeout (False, int, 240)
     The amount of time, in seconds, to wait for an instance to have status `running`.
-
-
-  state (optional, str, None)
-    The desired instance state.
 
 
 

--- a/docs/modules/instance_info.rst
+++ b/docs/modules/instance_info.rst
@@ -12,7 +12,7 @@ instance_info
 Synopsis
 --------
 
-Get info about a Linode instance.
+Get info about a Linode Instance.
 
 
 
@@ -20,20 +20,19 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (optional, string, None)
+  id (False, int, None)
     The instance’s label.
 
 
-  id (optional, int, None)
-    The unique id of the instance.
+  label (False, str, None)
+    The unique ID of the Instance.
 
 
 

--- a/docs/modules/nodebalancer.rst
+++ b/docs/modules/nodebalancer.rst
@@ -12,7 +12,7 @@ nodebalancer
 Synopsis
 --------
 
-Manage Linode NodeBalancers.
+Manage a Linode NodeBalancer.
 
 
 
@@ -20,114 +20,115 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (True, string, None)
-    The unique label to give this NodeBalancer
+  client_conn_throttle (False, int, None)
+    Throttle connections per second.
 
-
-  region (True, str, None)
-    The location to deploy the instance in.
-
-    See https://api.linode.com/v4/regions
+    Set to 0 (zero) to disable throttling.
 
 
   configs (False, list, None)
-    A list of configs to be added to the NodeBalancer.
+    A list of configs to apply to the NodeBalancer.
 
 
-    algorithm (optional, str, None)
-      What algorithm this NodeBalancer should use for routing traffic to backends.
+      algorithm (False, str, None)
+        What algorithm this NodeBalancer should use for routing traffic to backends.
 
 
-    check (optional, str, None)
-      The type of check to perform against backends to ensure they are serving requests.
-
-      This is used to determine if backends are up or down.
+      check (False, str, None)
+        The type of check to perform against backends to ensure they are serving requests.
 
 
-    check_attempts (optional, int, None)
-      How many times to attempt a check before considering a backend to be down.
+      check_attempts (False, int, None)
+        How many times to attempt a check before considering a backend to be down.
 
 
-    check_body (optional, str, None)
-      This value must be present in the response body of the check in order for it to pass.
+      check_body (False, str, )
+        This value must be present in the response body of the check in order for it to pass.
 
-      If this value is not present in the response body of a check request, the backend is considered to be down.
-
-
-    check_interval (optional, int, None)
-      How often, in seconds, to check that backends are up and serving requests.
+        If this value is not present in the response body of a check request, the backend is considered to be down.
 
 
-    check_passive (optional, bool, None)
-      If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.
+      check_interval (False, int, None)
+        How often, in seconds, to check that backends are up and serving requests.
 
 
-    check_path (optional, str, None)
-      The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.
+      check_passive (False, bool, None)
+        If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.
 
 
-    check_timeout (optional, int, None)
-      How long, in seconds, to wait for a check attempt before considering it failed.
+      check_path (False, str, None)
+        The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.
 
 
-    cipher_suite (optional, str, recommended)
-      What ciphers to use for SSL connections served by this NodeBalancer.
-
-      ``legacy`` is considered insecure and should only be used if necessary.
+      check_timeout (False, int, None)
+        How long, in seconds, to wait for a check attempt before considering it failed.
 
 
-    port (optional, int, None)
-      The port for the Config to listen on.
+      cipher_suite (False, str, recommended)
+        What ciphers to use for SSL connections served by this NodeBalancer.
 
 
-    protocol (optional, str, None)
-      The protocol this port is configured to serve.
+      nodes (False, list, None)
+        A list of nodes to apply to this config.
 
 
-    proxy_protocol (optional, str, None)
-      ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.
+          address (True, str, None)
+            The private IP Address where this backend can be reached.
+
+            This must be a private IP address.
 
 
-    ssl_cert (optional, str, None)
-      The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.
+          label (True, str, None)
+            The label for this node.
 
 
-    ssl_key (optional, str, None)
-      The PEM-formatted private key for the SSL certificate set in the ssl_cert field.
+          mode (False, str, None)
+            The mode this NodeBalancer should use when sending traffic to this backend.
 
 
-    stickiness (optional, str, None)
-      Controls how session stickiness is handled on this port.
+          weight (False, int, None)
+            Nodes with a higher weight will receive more traffic.
 
 
-    nodes (optional, list, None)
-      A list of Nodes to be created with the parent Config.
+
+      port (False, int, None)
+        The port this Config is for.
 
 
-      label (True, str, None)
-        The label to give to this Node.
+      protocol (False, str, None)
+        The protocol this port is configured to serve.
 
 
-      address (True, str, None)
-        The private IP Address where this backend can be reached.
+      proxy_protocol (False, str, None)
+        ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.
 
 
-      mode (optional, str, None)
-        The mode this NodeBalancer should use when sending traffic to this backend.
+      ssl_cert (False, str, None)
+        The PEM-formatted public SSL certificate (or the combined PEM-formatted           SSL certificate and Certificate Authority chain) that should be served           on this NodeBalancerConfig’s port.
 
 
-      weight (optional, int, None)
-        Nodes with a higher weight will receive more traffic.
+      ssl_key (False, str, None)
+        The PEM-formatted private key for the SSL certificate set in the ssl_cert field.
 
 
+      stickiness (False, str, None)
+        Controls how session stickiness is handled on this port.
+
+
+
+  label (False, str, None)
+    The unique label to give this NodeBalancer.
+
+
+  region (False, str, None)
+    The ID of the Region to create this NodeBalancer in.
 
 
 

--- a/docs/modules/nodebalancer_info.rst
+++ b/docs/modules/nodebalancer_info.rst
@@ -12,7 +12,7 @@ nodebalancer_info
 Synopsis
 --------
 
-Get info about a NodeBalancer.
+Get info about a Linode NodeBalancer.
 
 
 
@@ -20,20 +20,19 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (optional, string, None)
-    The label of this NodeBalancer
+  id (False, int, None)
+    The ID of this NodeBalancer.
 
 
-  id (optional, int, None)
-    The unique id of this NodeBalancer
+  label (False, str, None)
+    The label of this NodeBalancer.
 
 
 

--- a/docs/modules/object_cluster_info.rst
+++ b/docs/modules/object_cluster_info.rst
@@ -12,7 +12,7 @@ object_cluster_info
 Synopsis
 --------
 
-Get information about an Object Storage cluster.
+Get info about a Linode Object Storage Cluster.
 
 
 
@@ -20,28 +20,27 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  id (optional, string, None)
-    The unique id given to the clusters
+  domain (False, str, None)
+    The domain of the clusters.
 
 
-  region (optional, string, None)
-    The region the clusters are in
+  id (False, str, None)
+    The unique id given to the clusters.
 
 
-  domain (optional, string, None)
-    The domain of the clusters
+  region (False, str, None)
+    The region the clusters are in.
 
 
-  static_site_domain (optional, string, None)
-    The static-site domain of the clusters
+  static_site_domain (False, str, None)
+    The static-site domain of the clusters.
 
 
 

--- a/docs/modules/object_keys.rst
+++ b/docs/modules/object_keys.rst
@@ -20,33 +20,32 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (True, string, None)
-    The unique label to give this key
-
-
   access (False, list, None)
     A list of access permissions to give the key.
 
 
-    cluster (True, str, None)
-      The id of the cluster that the provided bucket exists under.
+      bucket_name (True, str, None)
+        The name of the bucket to set the key's permissions for.
 
 
-    bucket_name (True, str, None)
-      The name of the bucket to set the key's permissions for.
+      cluster (True, str, None)
+        The id of the cluster that the provided bucket exists under.
 
 
-    permissions (True, str, None)
-      The permissions to give the key.
+      permissions (True, str, None)
+        The permissions to give the key.
 
+
+
+  label (False, str, None)
+    The unique label to give this key.
 
 
 

--- a/docs/modules/vlan_info.rst
+++ b/docs/modules/vlan_info.rst
@@ -12,7 +12,7 @@ vlan_info
 Synopsis
 --------
 
-Get info about a Linode VLAN. This endpoint is currently in beta and will only function correctly if `api_version` is set to `v4beta`.
+Get info about a Linode VLAN.
 
 
 
@@ -20,15 +20,14 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (optional, string, None)
+  label (True, str, None)
     The VLAN’s label.
 
 

--- a/docs/modules/volume.rst
+++ b/docs/modules/volume.rst
@@ -12,7 +12,7 @@ volume
 Synopsis
 --------
 
-Manage Linode volumes.
+Manage a Linode Volume.
 
 
 
@@ -20,42 +20,41 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (True, string, None)
-    The Volume’s label, which is also used in the filesystem_path of the resulting volume.
+  attached (False, bool, True)
+    If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.
 
 
-  region (optional, str, None)
-    The location to deploy the volume in.
-
-    See https://api.linode.com/v4/regions
+  config_id (False, int, None)
+    When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.
 
 
-  size (optional, int, None)
-    The size of this volume, in GB.
-
-    Be aware that volumes may only be resized up after creation.
+  label (False, str, None)
+    The Volume’s label, which is also used in the filesystem_path       of the resulting volume.
 
 
-  linode_id (optional, int, None)
+  linode_id (False, int, None)
     The Linode this volume should be attached to upon creation.
 
     If not given, the volume will be created without an attachment.
 
 
-  config_id (optional, int, None)
-    When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.
+  region (False, str, None)
+    The location to deploy the volume in.
+
+    See https://api.linode.com/v4/regions
 
 
-  attached (optional, bool, None)
-    If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.
+  size (False, int, None)
+    The size of this volume, in GB.
+
+    Be aware that volumes may only be resized up after creation.
 
 
 

--- a/docs/modules/volume_info.rst
+++ b/docs/modules/volume_info.rst
@@ -12,7 +12,7 @@ volume_info
 Synopsis
 --------
 
-Get info about a Linode volume.
+Get info about a Linode Volume.
 
 
 
@@ -20,20 +20,19 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- linode_api4 >= 3.0
+- python >= 3.0
 
 
 
 Parameters
 ----------
 
-  label (optional, string, None)
-    The Volume’s label.
+  id (False, int, None)
+    The ID of the Volume.
 
 
-  id (optional, int, None)
-    The unique id of the volume.
+  label (False, str, None)
+    The label of the Volume.
 
 
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,3 +24,4 @@ build_ignore:
   - 'Makefile'
   - 'template'
   - 'tests'
+  - 'scripts'

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -18,187 +18,156 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: firewall
-description: 
-  - Manage Linode Firewalls. \
-This endpoint is currently in beta and will only function \
-correctly if `api_version` is set to `v4beta`. 
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 5.1.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Manage Linode Firewalls.
+module: firewall
 options:
-  label:
-    description:
-      - The unique label to give this Firewall.
-    required: true
-    type: str
-    
-  status:
-    description:
-      - The status of this Firewall.
-    type: str
-    choices:
-      - enabled
-      - disabled
-      - deleted
-
   devices:
     description:
-      - The devices that are attached to this Firewall.
-    type: list
+    - The devices that are attached to this Firewall.
     elements: dict
+    required: false
     suboptions:
-        id:
-          description:
-            - The unique ID of the device to attach to this Firewall.
-          type: str
-          required: true
-        type:
-          description:
-            - The type of device to be attached to this Firewall.
-          type: str
-          choices:
-            - linode
-          default: linode
-          
+      id:
+        description:
+        - The unique ID of the device to attach to this Firewall.
+        required: true
+        type: int
+      type:
+        default: linode
+        description:
+        - The type of device to be attached to this Firewall.
+        required: false
+        type: str
+    type: list
+  label:
+    description:
+    - The unique label to give this Firewall.
+    required: false
+    type: str
   rules:
     description:
-      - The inbound and outbound access rules to apply to the Firewall.
-    type: dict
+    - The inbound and outbound access rules to apply to this Firewall.
+    required: false
     suboptions:
-      inbound_policy:
-        description:
-          - The default behavior for inbound traffic.
-        type: str
-        required: true
-        choices:
-          - ACCEPT
-          - DROP
-        
-      outbound_policy:
-        description:
-          - The default behavior for outbound traffic.
-        type: str
-        required: true
-        choices:
-          - ACCEPT
-          - DROP
-          
       inbound:
         description:
-          - A list of rules for inbound traffic.
-        type: list
+        - A list of rules for inbound traffic.
         elements: dict
+        required: false
         suboptions:
-          label:
-            description:
-              - The label of this rule.
-            type: str
-            required: true
           action:
-            description:
-              - Controls whether traffic is accepted or dropped by this rule.
-            type: str
-            choices:
-              - ACCEPT
-              - DROP
+            description: &id001
+            - Controls whether traffic is accepted or dropped by this rule.
             required: true
-          description:
-            description:
-              - The description of this rule.
             type: str
           addresses:
-            description:
-              - Allowed IPv4 or IPv6 addresses.
-            type: list
-            elements: dict
+            description: &id002
+            - Allowed IPv4 or IPv6 addresses.
+            required: false
             suboptions:
               ipv4:
-                description:
-                  - A list of IPv4 addresses or networks. 
-                  - Must be in IP/mask format.
-                type: list
+                description: &id003
+                - A list of IPv4 addresses or networks.
+                - Must be in IP/mask format.
                 elements: str
+                required: false
+                type: list
               ipv6:
-                description:
-                  - A list of IPv4 addresses or networks. 
-                  - Must be in IP/mask format.
-                type: list
+                description: &id004
+                - A list of IPv4 addresses or networks.
+                - Must be in IP/mask format.
                 elements: str
-            ports:
-              description:
-                - A string representing the port or ports on which traffic will be allowed.
-                - See U(https://www.linode.com/docs/api/networking/#firewall-create)
-              type: str
-            protocol:
-              description:
-                - The type of network traffic to allow.
-              type: str
-              choices:
-                - TCP
-                - UDP
-                - ICMP
-                
+                required: false
+                type: list
+            type: dict
+          description:
+            description: &id005
+            - A description for this rule.
+            required: false
+            type: str
+          label:
+            description: &id006
+            - The label of this rule.
+            required: true
+            type: str
+          ports:
+            description: &id007
+            - A string representing the port or ports on which traffic will be allowed.
+            - See U(https://www.linode.com/docs/api/networking/#firewall-create)
+            required: false
+            type: str
+          protocol:
+            description: &id008
+            - The type of network traffic to allow.
+            required: false
+            type: str
+        type: list
+      inbound_policy:
+        description:
+        - The default behavior for inbound traffic.
+        required: false
+        type: str
       outbound:
         description:
-          - A list of rules for outbound traffic.
-        type: list
+        - A list of rules for outbound traffic.
         elements: dict
+        required: false
         suboptions:
-          label:
-            description:
-              - The label of this rule.
-            type: str
-            required: true
           action:
-            description:
-              - Controls whether traffic is accepted or dropped by this rule.
-            type: str
-            choices:
-              - ACCEPT
-              - DROP
+            description: *id001
             required: true
-          description:
-            description:
-              - The description of this rule.
             type: str
           addresses:
-            description:
-              - Allowed IPv4 or IPv6 addresses.
-            type: list
-            elements: dict
+            description: *id002
+            required: false
             suboptions:
               ipv4:
-                description:
-                  - A list of IPv4 addresses or networks. 
-                  - Must be in IP/mask format.
-                type: list
+                description: *id003
                 elements: str
+                required: false
+                type: list
               ipv6:
-                description:
-                  - A list of IPv4 addresses or networks. 
-                  - Must be in IP/mask format.
-                type: list
+                description: *id004
                 elements: str
-            ports:
-              description:
-                - A string representing the port or ports on which traffic will be allowed.
-                - See U(https://www.linode.com/docs/api/networking/#firewall-create)
-              type: str
-            protocol:
-              description:
-                - The type of network traffic to allow.
-              type: str
-              choices:
-                - TCP
-                - UDP
-                - ICMP
+                required: false
+                type: list
+            type: dict
+          description:
+            description: *id005
+            required: false
+            type: str
+          label:
+            description: *id006
+            required: true
+            type: str
+          ports:
+            description: *id007
+            required: false
+            type: str
+          protocol:
+            description: *id008
+            required: false
+            type: str
+        type: list
+      outbound_policy:
+        description:
+        - The default behavior for outbound traffic.
+        required: false
+        type: str
+    type: dict
+  status:
+    description:
+    - The status of this Firewall.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -322,37 +291,111 @@ except ImportError:
     pass
 
 linode_firewall_addresses_spec: dict = dict(
-    ipv4=dict(type='list', elements='str'),
-    ipv6=dict(type='list', elements='str')
+    ipv4=dict(type='list', elements='str',
+              description=[
+                  'A list of IPv4 addresses or networks.',
+                  'Must be in IP/mask format.'
+              ]),
+    ipv6=dict(type='list', elements='str',
+              description=[
+                  'A list of IPv4 addresses or networks.',
+                  'Must be in IP/mask format.'
+              ])
 )
 
 linode_firewall_rule_spec: dict = dict(
-    label=dict(type='str', required=True),
-    action=dict(type='str', required=True),
-    addresses=dict(type='dict', options=linode_firewall_addresses_spec),
-    description=dict(type='str'),
-    ports=dict(type='str'),
-    protocol=dict(type='str')
+    label=dict(type='str', required=True,
+               description=[
+                   'The label of this rule.'
+               ]),
+    action=dict(type='str', required=True,
+                description=[
+                    'Controls whether traffic is accepted or dropped by this rule.'
+                ]),
+    addresses=dict(type='dict', options=linode_firewall_addresses_spec,
+                   description=[
+                       'Allowed IPv4 or IPv6 addresses.'
+                   ]),
+    description=dict(type='str',
+                     description=[
+                         'A description for this rule.'
+                     ]),
+    ports=dict(type='str',
+               description=[
+                   'A string representing the port or ports on which traffic will be allowed.',
+                   'See U(https://www.linode.com/docs/api/networking/#firewall-create)'
+               ]),
+    protocol=dict(type='str',
+                  description=[
+                      'The type of network traffic to allow.'
+                  ])
 )
 
 linode_firewall_rules_spec: dict = dict(
-    inbound=dict(type='list', elements='dict', options=linode_firewall_rule_spec),
-    inbound_policy=dict(type='str'),
-    outbound=dict(type='list', elements='dict', options=linode_firewall_rule_spec),
-    outbound_policy=dict(type='str'),
+    inbound=dict(type='list', elements='dict', options=linode_firewall_rule_spec,
+                 description=[
+                     'A list of rules for inbound traffic.'
+                 ]),
+    inbound_policy=dict(type='str',
+                        description=[
+                            'The default behavior for inbound traffic.'
+                        ]),
+    outbound=dict(type='list', elements='dict', options=linode_firewall_rule_spec,
+                  description=[
+                      'A list of rules for outbound traffic.'
+                  ]),
+    outbound_policy=dict(type='str',
+                         description=[
+                             'The default behavior for outbound traffic.'
+                         ]),
 )
 
 linode_firewall_device_spec: dict = dict(
-    id=dict(type='int', required=True),
-    type=dict(type='str', default='linode')
+    id=dict(type='int', required=True,
+            description=[
+                'The unique ID of the device to attach to this Firewall.'
+            ]),
+    type=dict(type='str', default='linode',
+              description=[
+                  'The type of device to be attached to this Firewall.'
+              ])
 )
 
 linode_firewall_spec: dict = dict(
-    label=dict(type='str'),
-    devices=dict(type='list', elements='dict', options=linode_firewall_device_spec),
-    rules=dict(type='dict', options=linode_firewall_rules_spec),
-    status=dict(type='str')
+    label=dict(type='str',
+               description=[
+                    'The unique label to give this Firewall.'
+                ]),
+    devices=dict(type='list', elements='dict', options=linode_firewall_device_spec,
+                 description=[
+                     'The devices that are attached to this Firewall.'
+                 ]),
+    rules=dict(type='dict', options=linode_firewall_rules_spec,
+               description=[
+                   'The inbound and outbound access rules to apply to this Firewall.'
+               ]),
+    status=dict(type='str',
+                description=[
+                    'The status of this Firewall.'
+                ])
 )
+
+specdoc_meta = dict(
+    description=[
+        'Manage Linode Firewalls.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_firewall_spec
+)
+
 
 # Fields that can be updated on an existing Firewall
 linode_firewall_mutable: List[str] = [

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -20,28 +20,27 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: firewall_info
-description: Get info about a Linode Firewall. \
-This endpoint is currently in beta and will only function \
-correctly if `api_version` is set to `v4beta`. 
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 5.1.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode Firewall.
+module: firewall_info
 options:
-  label:
-    description:
-      - The Firewall’s label.
-    type: string
   id:
     description:
-      - The unique id of the Firewall.
+    - The unique id of the Firewall.
+    required: false
     type: int
+  label:
+    description:
+    - "The Firewall\u2019s label."
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -127,10 +126,32 @@ devices:
 
 linode_firewall_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
 
-    id=dict(type='int', required=False),
-    label=dict(type='str', required=False)
+    id=dict(type='int', required=False,
+            description=[
+                'The unique id of the Firewall.'
+            ]),
+    label=dict(type='str', required=False,
+               description=[
+                   'The Firewall’s label.'
+               ])
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode Firewall.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_firewall_info_spec
 )
 
 linode_firewall_valid_filters = [

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -21,275 +21,382 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: instance
-description: Manage Linode instances.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Manage Linode Instances.
+module: instance
 options:
-  label:
-    description:
-      - The unique label to give this instance.
-    required: true
-    type: string
-  type:
-    description:
-      - The type or plan of this instance.
-      - See U(https://api.linode.com/v4/linode/types)
-  region:
-    description:
-      - The location to deploy the instance in.
-      - See U(https://api.linode.com/v4/regions)
-    required: true
-    type: str
-  image:
-    description:
-      - The image ID to deploy the instance disk from.
-    required: true
-    type: str
-  group:
-    description:
-       - The group that the instance should be marked under. Please note, that
-        group labelling is deprecated but still supported. The encouraged
-        method for marking instances is to use tags.
-    type: str
-    required: false
-  tags:
-    description:
-      - The tags that the instance should be marked under.
-      - See U(https://www.linode.com/docs/api/tags/).
+  authorized_keys:
+    description: A list of SSH public key parts to deploy for the root user.
+    elements: str
     required: false
     type: list
-  root_pass:
+  backup_id:
     description:
-      - The password for the root user. If not specified, one will be
-        generated. This generated password will be available in the task
-        success JSON.
+    - The id of the Backup to restore to the new Instance.
+    - "May not be provided if \u201Cimage\u201D is given."
+    required: false
+    type: int
+  boot_config_label:
+    description: The label of the config to boot from.
     required: false
     type: str
-  private_ip:
+  booted:
+    default: true
     description:
-      - If true, the created Linode will have private networking enabled.
+    - Whether the new Instance should be booted.
+    - This will default to True if the Instance is deployed from an Image or Backup.
     required: false
     type: bool
-  authorized_keys:
-    description:
-      - A list of SSH public key parts to deploy for the root user.
-    required: false
-    type: list
-  stackscript_id:
-    description:
-      - The ID of the StackScript to use when creating the instance.
-        See U(https://www.linode.com/docs/api/stackscripts/).
-    type: int
-    required: false
-  stackscript_data:
-    description:
-      - An object containing arguments to any User Defined Fields present in
-        the StackScript used when creating the instance.
-        Only valid when a stackscript_id is provided.
-        See U(https://www.linode.com/docs/api/stackscripts/).
-    type: dict
-    required: false
   configs:
     description:
-      - A list of Instance configs to apply to the Linode.
-      - See U(https://www.linode.com/docs/api/linode-instances/#configuration-profile-create)
-    type: list
+    - A list of Instance configs to apply to the Linode.
+    - See U(https://www.linode.com/docs/api/linode-instances/#configuration-profile-create)
     elements: dict
+    required: false
     suboptions:
-      label:
-        description:
-          - The label to assign to this config.
-        type: str
-        required: true
       comments:
-        description:
-          - Arbitrary User comments on this Config.
+        description: Arbitrary User comments on this Config.
+        required: false
         type: str
       devices:
-        description:
-          - A map of devices to use in a Linode's configuration profile.
-        type: list
-        elements: dict
+        description: The devices to map to this configuration.
+        required: false
         suboptions:
-          sda...sdh:
-            description:
-              - A device to be mapped to to this configuration.
-            type: dict
+          sda:
+            description: []
+            required: false
             suboptions:
-              disk_label:
-                description:
-                  - The label of the disk to attach to this Linode.
-                type: str
               disk_id:
-                description:
-                  - The ID of the disk to attach to this Linode.
+                description: The ID of the disk to attach to this Linode.
+                required: false
                 type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
               volume_id:
-                description:
-                  - The ID of the volume to attach to this Linode.
+                description: The ID of the volume to attach to this Linode.
+                required: false
                 type: int
-      helpers:
-        description:
-          - Helpers enabled when booting to this Linode Config.
+            type: dict
+          sdb:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sdc:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sdd:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sde:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sdf:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sdg:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
+          sdh:
+            description: []
+            required: false
+            suboptions:
+              disk_id:
+                description: The ID of the disk to attach to this Linode.
+                required: false
+                type: int
+              disk_label:
+                description: The label of the disk to attach to this Linode.
+                required: false
+                type: str
+              volume_id:
+                description: The ID of the volume to attach to this Linode.
+                required: false
+                type: int
+            type: dict
         type: dict
+      helpers:
+        description: Helpers enabled when booting to this Linode Config.
+        required: false
         suboptions:
           devtmpfs_automount:
-            description:
-              - Populates the /dev directory early during boot without udev.
+            description: Populates the /dev directory early during boot without udev.
+            required: false
             type: bool
           distro:
-            description:
-              - Helps maintain correct inittab/upstart console device.
+            description: Helps maintain correct inittab/upstart console device.
+            required: false
             type: bool
           modules_dep:
-            description:
-              - Creates a modules dependency file for the Kernel you run.
+            description: Creates a modules dependency file for the Kernel you run.
+            required: false
             type: bool
           network:
-            description:
-              - Automatically configures static networking.
+            description: Automatically configures static networking.
+            required: false
             type: bool
           updatedb_disabled:
-            description:
-              - Disables updatedb cron job to avoid disk thrashing.
+            description: Disables updatedb cron job to avoid disk thrashing.
+            required: false
             type: bool
+        type: dict
       kernel:
-        description:
-          - A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.
+        description: "A Kernel ID to boot a Linode with. Defaults to \u201Clinode/latest-64bit\u201D\
+          ."
+        required: false
+        type: str
+      label:
+        description: The label to assign to this config.
+        required: true
         type: str
       memory_limit:
-        description:
-          - Defaults to the total RAM of the Linode.
+        description: Defaults to the total RAM of the Linode.
+        required: false
         type: int
       root_device:
-        description:
-          - The root device to boot.
-        type: int
+        description: The root device to boot.
+        required: false
+        type: str
       run_level:
-        description:
-          - Defines the state of your Linode after booting.
+        description: Defines the state of your Linode after booting.
+        required: false
         type: str
-        choices:
-          - default
-          - single
-          - binbash
       virt_mode:
-        description:
-          - Controls the virtualization mode.
-        type: str
         choices:
-          - paravirt
-          - fullvirt
-          
+        - paravirt
+        - fullvirt
+        description: Controls the virtualization mode.
+        required: false
+        type: str
+    type: list
   disks:
     description:
-      - A list of Disks to create on the Linode.
-      - See U(https://www.linode.com/docs/api/linode-instances/#disk-create)
-    type: list
+    - A list of Disks to create on the Linode.
+    - See U(https://www.linode.com/docs/api/linode-instances/#disk-create)
     elements: dict
+    required: false
     suboptions:
-      label:
-        description:
-          - The label to give this Disk.
-        type: str
-        required: true
-      size:
-        description:
-          - The size of the Disk in MB.
-        type: int
       authorized_keys:
-        description:
-          - A list of SSH public key parts to deploy for the root user.
-        type: list
+        description: A list of SSH public key parts to deploy for the root user.
         elements: str
+        required: false
+        type: list
       authorized_users:
-        description:
-          - A list of usernames.
-        type: list
+        description: A list of usernames.
         elements: str
+        required: false
+        type: list
       filesystem:
-        description:
-          - The filesystem to create this disk with.
+        description: The filesystem to create this disk with.
+        required: false
         type: str
       image:
-        description:
-          - An Image ID to deploy the Disk from.
+        description: An Image ID to deploy the Disk from.
+        required: false
+        type: str
+      label:
+        description: The label to give this Disk.
+        required: true
         type: str
       root_pass:
-        description:
-          - The root user’s password on the newly-created Linode.
+        description: "The root user\u2019s password on the newly-created Linode."
+        required: false
         type: str
+      size:
+        description: The size of the Disk in MB.
+        required: true
+        type: int
       stackscript_data:
         description:
-          - An object containing arguments to any User Defined Fields present in
-            the StackScript used when creating the instance.
-            Only valid when a stackscript_id is provided.
-          - See U(https://www.linode.com/docs/api/stackscripts/).
+        - An object containing arguments to any User Defined Fields present in the
+          StackScript used when creating the instance.
+        - Only valid when a stackscript_id is provided.
+        - See U(https://www.linode.com/docs/api/stackscripts/)
+        required: false
         type: dict
       stackscript_id:
         description:
-          - The ID of the StackScript to use when creating the instance. 
-          - See U(https://www.linode.com/docs/api/stackscripts/)
-        
+        - The ID of the StackScript to use when creating the instance.
+        - See U(https://www.linode.com/docs/api/stackscripts/)
+        required: false
+        type: int
+    type: list
+  group:
+    description:
+    - The group that the instance should be marked under.
+    - Please note, that group labelling is deprecated but still supported.
+    - The encouraged method for marking instances is to use tags.
+    required: false
+    type: str
+  image:
+    description: The image ID to deploy the instance disk from.
+    required: false
+    type: str
   interfaces:
     description:
-      - A list of network interfaces to apply to the Linode.
-      - VLANs are currently in beta and will only function correctly if `api_version` is set to `v4beta`.
-      - See U(https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema).
-    type: list
+    - A list of network interfaces to apply to the Linode.
+    - See U(https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema).
     elements: dict
+    required: false
     suboptions:
-      purpose:
-        description: 
-          - The type of interface.
-        choices:
-          - public
-          - vlan
+      ipam_address:
+        description: "This Network Interface\u2019s private IP address in Classless\
+          \ Inter-Domain Routing (CIDR) notation."
+        required: false
         type: str
-        required: true
       label:
         description:
-          - The name of this interface.
-          - Required for vlan purpose interfaces. 
-          - Must be an empty string or null for public purpose interfaces.
+        - The name of this interface.
+        - Required for vlan purpose interfaces.
+        - Must be an empty string or null for public purpose interfaces.
+        required: false
         type: str
-      ipam_address:
-        description:
-          - This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.
+      purpose:
+        choices:
+        - public
+        - vlan
+        description: The type of interface.
+        required: true
         type: str
-  booted:
+    type: list
+  private_ip:
+    description: If true, the created Linode will have private networking enabled.
+    required: false
+    type: bool
+  region:
     description:
-      - Whether the new Instance should be booted. 
-        This will default to True if the Instance is deployed from an Image or Backup.
-  backup_id:
+    - The location to deploy the instance in.
+    - See U(https://api.linode.com/v4/regions)
+    required: false
+    type: str
+  root_pass:
     description:
-      - The id of the Backup to restore to the new Instance. 
-        May not be provided if “image” is given.
+    - The password for the root user.
+    - If not specified, one will be generated.
+    - This generated password will be available in the task success JSON.
+    required: false
+    type: str
+  stackscript_data:
+    description:
+    - An object containing arguments to any User Defined Fields present in the StackScript
+      used when creating the instance.
+    - Only valid when a stackscript_id is provided.
+    - See U(https://www.linode.com/docs/api/stackscripts/).
+    required: false
+    type: dict
+  stackscript_id:
+    description:
+    - The ID of the StackScript to use when creating the instance.
+    - See U(https://www.linode.com/docs/api/stackscripts/).
+    required: false
+    type: int
+  type:
+    description:
+    - The unique label to give this instance.
+    required: false
+    type: str
   wait:
-    description:
-      - Wait for the instance to have status `running` before returning.
-    default: True
+    default: true
+    description: Wait for the instance to have status `running` before returning.
+    required: false
     type: bool
   wait_timeout:
-    description:
-      - The amount of time, in seconds, to wait for an instance to have status `running`.
     default: 240
+    description: The amount of time, in seconds, to wait for an instance to have status
+      `running`.
+    required: false
     type: int
-  state:
-    description:
-      - The desired instance state.
-    type: str
-    choices:
-      - present
-      - absent
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -432,21 +539,63 @@ except ImportError:
     pass
 
 linode_instance_disk_spec = dict(
-    authorized_keys=dict(type='list', elements='str'),
-    authorized_users=dict(type='list', elements='str'),
-    filesystem=dict(type='str'),
-    image=dict(type='str'),
-    label=dict(type='str', required=True),
-    root_pass=dict(type='str'),
-    size=dict(type='int', required=True),
-    stackscript_id=dict(type='int'),
-    stackscript_data=dict(type='dict')
+    authorized_keys=dict(
+        type='list', elements='str',
+        description='A list of SSH public key parts to deploy for the root user.'),
+
+    authorized_users=dict(
+        type='list', elements='str',
+        description='A list of usernames.'),
+
+    filesystem=dict(
+        type='str',
+        description='The filesystem to create this disk with.'),
+
+    image=dict(
+        type='str',
+        description='An Image ID to deploy the Disk from.'),
+
+    label=dict(
+        type='str', required=True,
+        description='The label to give this Disk.'),
+
+    root_pass=dict(
+        type='str',
+        description='The root user’s password on the newly-created Linode.'),
+
+    size=dict(
+        type='int', required=True,
+        description='The size of the Disk in MB.'),
+
+    stackscript_id=dict(
+        type='int',
+        description=[
+            'The ID of the StackScript to use when creating the instance.',
+            'See U(https://www.linode.com/docs/api/stackscripts/)'
+        ]),
+
+    stackscript_data=dict(
+        type='dict',
+        description=[
+            'An object containing arguments to any User Defined Fields present in '
+            'the StackScript used when creating the instance.',
+            'Only valid when a stackscript_id is provided.',
+            'See U(https://www.linode.com/docs/api/stackscripts/)'
+        ])
 )
 
 linode_instance_device_spec = dict(
-    disk_label=dict(type='str'),
-    disk_id=dict(type='int'),
-    volume_id=dict(type='int')
+    disk_label=dict(
+        type='str',
+        description='The label of the disk to attach to this Linode.'),
+
+    disk_id=dict(
+        type='int',
+        description='The ID of the disk to attach to this Linode.'),
+
+    volume_id=dict(
+        type='int',
+        description='The ID of the volume to attach to this Linode.')
 )
 
 linode_instance_devices_spec = dict(
@@ -461,49 +610,206 @@ linode_instance_devices_spec = dict(
 )
 
 linode_instance_helpers_spec = dict(
-    devtmpfs_automount=dict(type='bool'),
-    distro=dict(type='bool'),
-    modules_dep=dict(type='bool'),
-    network=dict(type='bool'),
-    updatedb_disabled=dict(type='bool')
+    devtmpfs_automount=dict(
+        type='bool',
+        description='Populates the /dev directory early during boot without udev.'),
+
+    distro=dict(
+        type='bool',
+        description='Helps maintain correct inittab/upstart console device.'),
+
+    modules_dep=dict(
+        type='bool',
+        description='Creates a modules dependency file for the Kernel you run.'),
+
+    network=dict(
+        type='bool',
+        description='Automatically configures static networking.'),
+
+    updatedb_disabled=dict(
+        type='bool',
+        description='Disables updatedb cron job to avoid disk thrashing.')
 )
 
 linode_instance_interface_spec = dict(
-    purpose=dict(type='str', required=True),
-    label=dict(type='str'),
-    ipam_address=dict(type='str')
+    purpose=dict(
+        type='str', required=True,
+        description='The type of interface.',
+        choices=[
+            'public',
+            'vlan'
+        ]),
+
+    label=dict(
+        type='str',
+        description=[
+            'The name of this interface.',
+            'Required for vlan purpose interfaces.',
+            'Must be an empty string or null for public purpose interfaces.'
+        ]),
+
+    ipam_address=dict(
+        type='str',
+        description='This Network Interface’s private IP address in Classless '
+                    'Inter-Domain Routing (CIDR) notation.'
+    )
 )
 
 linode_instance_config_spec = dict(
-    comments=dict(type='str'),
-    devices=dict(type='dict', options=linode_instance_devices_spec),
-    helpers=dict(type='dict', options=linode_instance_helpers_spec),
-    kernel=dict(type='str'),
-    label=dict(type='str', required=True),
-    memory_limit=dict(type='int'),
-    root_device=dict(type='str'),
-    run_level=dict(type='str'),
-    virt_mode=dict(type='str')
+    comments=dict(
+        type='str',
+        description='Arbitrary User comments on this Config.'),
+
+    devices=dict(
+        type='dict', options=linode_instance_devices_spec,
+        description='The devices to map to this configuration.'),
+
+    helpers=dict(
+        type='dict', options=linode_instance_helpers_spec,
+        description='Helpers enabled when booting to this Linode Config.'),
+
+    kernel=dict(
+        type='str',
+        description='A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.'),
+
+    label=dict(
+        type='str', required=True,
+        description='The label to assign to this config.'),
+
+    memory_limit=dict(
+        type='int',
+        description='Defaults to the total RAM of the Linode.'),
+
+    root_device=dict(
+        type='str',
+        description='The root device to boot.'),
+
+    run_level=dict(
+        type='str',
+        description='Defines the state of your Linode after booting.'),
+
+    virt_mode=dict(
+        type='str',
+        description='Controls the virtualization mode.',
+        choices=[
+            'paravirt',
+            'fullvirt'
+        ])
 )
 
 linode_instance_spec = dict(
-    type=dict(type='str'),
-    region=dict(type='str'),
-    image=dict(type='str'),
-    authorized_keys=dict(type='list', elements='str'),
-    root_pass=dict(type='str', no_log=True),
-    stackscript_id=dict(type='int'),
-    stackscript_data=dict(type='dict'),
-    private_ip=dict(type='bool'),
-    group=dict(type='str'),
-    boot_config_label=dict(type='str'),
-    configs=dict(type='list', elements='dict', options=linode_instance_config_spec),
-    disks=dict(type='list', elements='dict', options=linode_instance_disk_spec),
-    interfaces=dict(type='list', elements='dict', options=linode_instance_interface_spec),
-    booted=dict(type='bool'),
-    backup_id=dict(type='int'),
-    wait=dict(type='bool', default=True),
-    wait_timeout=dict(type='int', default=240)
+    type=dict(type='str', description=['The unique label to give this instance.']),
+    region=dict(
+        type='str',
+        description=[
+            'The location to deploy the instance in.',
+            'See U(https://api.linode.com/v4/regions)']),
+
+    image=dict(
+        type='str',
+        description='The image ID to deploy the instance disk from.'),
+
+    authorized_keys=dict(
+        type='list', elements='str',
+        description='A list of SSH public key parts to deploy for the root user.'),
+
+    root_pass=dict(
+        type='str', no_log=True,
+        description=[
+            'The password for the root user.',
+            'If not specified, one will be generated.',
+            'This generated password will be available in the task success JSON.'
+        ]),
+
+    stackscript_id=dict(
+        type='int',
+        description=[
+            'The ID of the StackScript to use when creating the instance.',
+            'See U(https://www.linode.com/docs/api/stackscripts/).'
+        ]),
+
+    stackscript_data=dict(
+        type='dict',
+        description=[
+            'An object containing arguments to any User Defined Fields present in '
+            'the StackScript used when creating the instance.',
+            'Only valid when a stackscript_id is provided.',
+            'See U(https://www.linode.com/docs/api/stackscripts/).'
+        ]),
+
+    private_ip=dict(
+        type='bool',
+        description='If true, the created Linode will have private networking enabled.'),
+
+    group=dict(
+        type='str',
+        description=[
+            'The group that the instance should be marked under.',
+            'Please note, that group labelling is deprecated but still supported.',
+            'The encouraged method for marking instances is to use tags.']),
+
+    boot_config_label=dict(type='str', description='The label of the config to boot from.'),
+
+    configs=dict(
+        type='list', elements='dict', options=linode_instance_config_spec,
+        description=[
+            'A list of Instance configs to apply to the Linode.',
+            'See U(https://www.linode.com/docs/api/linode-instances/#configuration-profile-create)'
+        ]),
+
+    disks=dict(
+        type='list', elements='dict', options=linode_instance_disk_spec,
+        description=[
+            'A list of Disks to create on the Linode.',
+            'See U(https://www.linode.com/docs/api/linode-instances/#disk-create)'
+        ]),
+
+    interfaces=dict(
+        type='list', elements='dict', options=linode_instance_interface_spec,
+        description=[
+            'A list of network interfaces to apply to the Linode.',
+            'See U(https://www.linode.com/docs/api/linode-instances/'
+            '#linode-create__request-body-schema).'
+        ]),
+
+    booted=dict(
+        type='bool', default=True,
+        description=[
+            'Whether the new Instance should be booted.',
+            'This will default to True if the Instance is deployed from an Image or Backup.'
+        ]),
+
+    backup_id=dict(
+        type='int',
+        description=[
+            'The id of the Backup to restore to the new Instance.',
+            'May not be provided if “image” is given.']),
+
+    wait=dict(
+        type='bool', default=True,
+        description='Wait for the instance to have status `running` before returning.'),
+
+    wait_timeout=dict(
+        type='int', default=240,
+        description='The amount of time, in seconds, to wait for an instance to '
+                    'have status `running`.'
+        )
+)
+
+specdoc_meta = dict(
+    description=[
+        'Manage Linode Instances.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_instance_spec
 )
 
 # Fields that can be updated on an existing instance

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -20,26 +20,27 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: instance_info
-description: Get info about a Linode instance.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode Instance.
+module: instance_info
 options:
-  label:
-    description:
-      - The instance’s label.
-    type: string
   id:
     description:
-      - The unique id of the instance.
+    - "The instance\u2019s label."
+    required: false
     type: int
+  label:
+    description:
+    - The unique ID of the Instance.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -161,16 +162,40 @@ disks:
 
 linode_instance_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
 
-    id=dict(type='int', required=False),
-    label=dict(type='str', required=False)
+    id=dict(
+        type='int', required=False,
+        description=[
+            'The instance’s label.'
+        ]),
+
+    label=dict(
+        type='str', required=False,
+        description=[
+            'The unique ID of the Instance.'
+        ])
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode Instance.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_instance_info_spec
 )
 
 linode_instance_valid_filters = [
     'id', 'label'
 ]
-
 
 class LinodeInstanceInfo(LinodeModuleBase):
     """Module for getting info about a Linode Instance"""

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -23,172 +23,168 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: nodebalancer
-description: Manage Linode NodeBalancers.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Manage a Linode NodeBalancer.
+module: nodebalancer
 options:
-  label:
+  client_conn_throttle:
     description:
-      - The unique label to give this NodeBalancer
-    required: true
-    type: string
-  region:
-    description:
-      - The location to deploy the instance in.
-      - See U(https://api.linode.com/v4/regions)
-    required: true
-    type: str
-
-  configs:
-    description:
-      - A list of configs to be added to the NodeBalancer.
+    - Throttle connections per second.
+    - Set to 0 (zero) to disable throttling.
     required: false
-    type: list
+    type: int
+  configs:
+    description: A list of configs to apply to the NodeBalancer.
     elements: dict
+    required: false
     suboptions:
       algorithm:
-        description:
-          - What algorithm this NodeBalancer should use for routing traffic to backends.
         choices:
-          - roundrobin
-          - leastconn
-          - source
+        - roundrobin
+        - leastconn
+        - source
+        description: What algorithm this NodeBalancer should use for routing traffic
+          to backends.
+        required: false
         type: str
-
       check:
-        description:
-          - The type of check to perform against backends to ensure they are serving requests.
-          - This is used to determine if backends are up or down.
         choices:
-          - none
-          - connection
-          - http
-          - http_body
+        - none
+        - connection
+        - http
+        - http_body
+        description: The type of check to perform against backends to ensure they
+          are serving requests.
+        required: false
         type: str
-
       check_attempts:
-        description:
-          - How many times to attempt a check before considering a backend to be down.
+        description: How many times to attempt a check before considering a backend
+          to be down.
+        required: false
         type: int
-
       check_body:
+        default: ''
         description:
-          - This value must be present in the response body of the check in order for it to pass.
-          - If this value is not present in the response body of a check request, the backend is considered to be down.
+        - This value must be present in the response body of the check in order for
+          it to pass.
+        - If this value is not present in the response body of a check request, the
+          backend is considered to be down.
+        required: false
         type: str
-
       check_interval:
-        description:
-          - How often, in seconds, to check that backends are up and serving requests.
+        description: How often, in seconds, to check that backends are up and serving
+          requests.
+        required: false
         type: int
-
       check_passive:
-        description:
-          - If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.
+        description: If true, any response from this backend with a 5xx status code
+          will be enough for it to be considered unhealthy and taken out of rotation.
+        required: false
         type: bool
-
       check_path:
-        description:
-          - The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.
+        description: The URL path to check on each backend. If the backend does not
+          respond to this request it is considered to be down.
+        required: false
         type: str
-
       check_timeout:
-        description:
-          - How long, in seconds, to wait for a check attempt before considering it failed.
+        description: How long, in seconds, to wait for a check attempt before considering
+          it failed.
+        required: false
         type: int
-
       cipher_suite:
-        description:
-          - What ciphers to use for SSL connections served by this NodeBalancer.
-          - C(legacy) is considered insecure and should only be used if necessary.
         choices:
-          - recommended
-          - legacy
+        - recommended
+        - legacy
         default: recommended
+        description: What ciphers to use for SSL connections served by this NodeBalancer.
+        required: false
         type: str
-
-      port:
-        description:
-          - The port for the Config to listen on.
-        type: int
-
-      protocol:
-        description:
-          - The protocol this port is configured to serve.
-        choices:
-          - http
-          - https
-          - tcp
-        type: str
-
-      proxy_protocol:
-        description:
-          - ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.
-        choices:
-          - none
-          - v1
-          - v2
-        type: str
-
-      ssl_cert:
-        description:
-          - The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.
-        type: str
-
-      ssl_key:
-        description:
-          - The PEM-formatted private key for the SSL certificate set in the ssl_cert field.
-        type: str
-
-      stickiness:
-        description:
-          - Controls how session stickiness is handled on this port.
-        choices:
-          - none
-          - table
-          - http_cookie
-        type: str
-
       nodes:
-        description:
-          - A list of Nodes to be created with the parent Config.
-        type: list
+        description: A list of nodes to apply to this config.
         elements: dict
+        required: false
         suboptions:
-          label:
-            description:
-              - The label to give to this Node.
-            type: str
-            required: true
-
           address:
             description:
-              - The private IP Address where this backend can be reached.
-            type: str
+            - The private IP Address where this backend can be reached.
+            - This must be a private IP address.
             required: true
-
-          mode:
-            description:
-              - The mode this NodeBalancer should use when sending traffic to this backend.
-            choices:
-              - accept
-              - reject
-              - drain
-              - backup
             type: str
-
+          label:
+            description: The label for this node.
+            required: true
+            type: str
+          mode:
+            choices:
+            - accept
+            - reject
+            - drain
+            - backup
+            description: The mode this NodeBalancer should use when sending traffic
+              to this backend.
+            required: false
+            type: str
           weight:
-            description:
-              - Nodes with a higher weight will receive more traffic.
+            description: Nodes with a higher weight will receive more traffic.
+            required: false
             type: int
+        type: list
+      port:
+        description: The port this Config is for.
+        required: false
+        type: int
+      protocol:
+        choices:
+        - http
+        - https
+        - tcp
+        description: The protocol this port is configured to serve.
+        required: false
+        type: str
+      proxy_protocol:
+        choices:
+        - none
+        - v1
+        - v2
+        description: ProxyProtocol is a TCP extension that sends initial TCP connection
+          information such as source/destination IPs and ports to backend devices.
+        required: false
+        type: str
+      ssl_cert:
+        description: "The PEM-formatted public SSL certificate (or the combined PEM-formatted\
+          \ SSL certificate and Certificate Authority chain) that should be served\
+          \ on this NodeBalancerConfig\u2019s port."
+        required: false
+        type: str
+      ssl_key:
+        description: The PEM-formatted private key for the SSL certificate set in
+          the ssl_cert field.
+        required: false
+        type: str
+      stickiness:
+        choices:
+        - none
+        - table
+        - http_cookie
+        description: Controls how session stickiness is handled on this port.
+        required: false
+        type: str
+    type: list
+  label:
+    description: The unique label to give this NodeBalancer.
+    required: false
+    type: str
+  region:
+    description: The ID of the Region to create this NodeBalancer in.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -292,35 +288,148 @@ nodes:
 '''
 
 linode_nodes_spec = dict(
-    label=dict(type='str', required=True),
-    address=dict(type='str', required=True),
-    weight=dict(type='int', required=False),
-    mode=dict(type='str', required=False),
+    label=dict(
+        type='str', required=True,
+        description='The label for this node.'),
+
+    address=dict(
+        type='str', required=True,
+        description=[
+            'The private IP Address where this backend can be reached.',
+            'This must be a private IP address.'
+        ]),
+
+    weight=dict(
+        type='int', required=False,
+        description='Nodes with a higher weight will receive more traffic.',
+    ),
+
+    mode=dict(
+        type='str', required=False,
+        description='The mode this NodeBalancer should use when sending traffic to this backend.',
+        choices=['accept', 'reject', 'drain', 'backup']),
+
 )
 
 linode_configs_spec = dict(
-    algorithm=dict(type='str', required=False),
-    check=dict(type='str', required=False),
-    check_attempts=dict(type='int', required=False),
-    check_body=dict(type='str', required=False, default=''),
-    check_interval=dict(type='int', required=False),
-    check_passive=dict(type='bool', required=False),
-    check_path=dict(type='str', required=False),
-    check_timeout=dict(type='int', required=False),
-    cipher_suite=dict(type='str', required=False, default='recommended'),
-    port=dict(type='int', required=False),
-    protocol=dict(type='str', required=False),
-    proxy_protocol=dict(type='str', required=False),
-    ssl_cert=dict(type='str', required=False),
-    ssl_key=dict(type='str', required=False),
-    stickiness=dict(type='str', required=False),
-    nodes=dict(type='list', required=False, elements='dict', options=linode_nodes_spec)
+    algorithm=dict(
+        type='str', required=False,
+        description='What algorithm this NodeBalancer should use for routing traffic to backends.',
+        choices=['roundrobin', 'leastconn', 'source']),
+
+    check=dict(
+        type='str', required=False,
+        description='The type of check to perform against backends to ensure they are '
+                    'serving requests.',
+        choices=['none', 'connection', 'http', 'http_body']),
+
+    check_attempts=dict(
+        type='int', required=False,
+        description='How many times to attempt a check before considering a backend to be down.'),
+
+    check_body=dict(
+        type='str', required=False, default='',
+        description=[
+            'This value must be present in the response body of the check in order for it to pass.',
+            'If this value is not present in the response body of a check request, the backend is '
+            'considered to be down.'
+        ]),
+
+    check_interval=dict(
+        type='int', required=False,
+        description='How often, in seconds, to check that backends are up and serving requests.'),
+
+    check_passive=dict(
+        type='bool', required=False,
+        description='If true, any response from this backend with a 5xx status code will be enough '
+                    'for it to be considered unhealthy and taken out of rotation.'),
+
+    check_path=dict(
+        type='str', required=False,
+        description='The URL path to check on each backend. If the backend does '
+                    'not respond to this request it is considered to be down.'),
+
+    check_timeout=dict(
+        type='int', required=False,
+        description='How long, in seconds, to wait for a check attempt before considering it '
+                    'failed.'),
+
+    cipher_suite=dict(
+        type='str', required=False, default='recommended',
+        description='What ciphers to use for SSL connections served by this NodeBalancer.',
+        choices=['recommended', 'legacy']),
+
+    port=dict(
+        type='int', required=False,
+        description='The port this Config is for.'),
+
+    protocol=dict(
+        type='str', required=False,
+        description='The protocol this port is configured to serve.',
+        choices=['http', 'https', 'tcp']),
+
+    proxy_protocol=dict(
+        type='str', required=False,
+        description='ProxyProtocol is a TCP extension that sends initial TCP connection '
+                    'information such as source/destination IPs and ports to backend devices.',
+        choices=['none', 'v1', 'v2']),
+
+    ssl_cert=dict(
+        type='str', required=False,
+        description='The PEM-formatted public SSL certificate (or the combined '
+                    'PEM-formatted SSL certificate and Certificate Authority chain) '
+                    'that should be served on this NodeBalancerConfig’s port.'),
+
+    ssl_key=dict(
+        type='str', required=False,
+        description='The PEM-formatted private key for the SSL certificate '
+                    'set in the ssl_cert field.'),
+
+    stickiness=dict(
+        type='str', required=False,
+        description='Controls how session stickiness is handled on this port.',
+        choices=['none', 'table', 'http_cookie']),
+
+    nodes=dict(
+        type='list', required=False, elements='dict', options=linode_nodes_spec,
+        description='A list of nodes to apply to this config.')
 )
 
 linode_nodebalancer_spec = dict(
-    client_conn_throttle=dict(type='int'),
-    region=dict(type='str'),
-    configs=dict(type='list', elements='dict', options=linode_configs_spec)
+    label=dict(
+        type='str',
+        description='The unique label to give this NodeBalancer.'),
+
+    client_conn_throttle=dict(
+        type='int',
+        description=[
+            'Throttle connections per second.',
+            'Set to 0 (zero) to disable throttling.'
+        ]),
+
+    region=dict(
+        type='str',
+        description='The ID of the Region to create this NodeBalancer in.'),
+
+    configs=dict(
+        type='list', elements='dict', options=linode_configs_spec,
+        description='A list of configs to apply to the NodeBalancer.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Manage a Linode NodeBalancer.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_nodebalancer_spec
 )
 
 linode_nodebalancer_mutable: Set[str] = {

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -20,27 +20,25 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: nodebalancer_info
-description: Get info about a NodeBalancer.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode NodeBalancer.
+module: nodebalancer_info
 options:
-  label:
-    description:
-      - The label of this NodeBalancer
-    type: string
-    
   id:
-    description:
-      - The unique id of this NodeBalancer
+    description: The ID of this NodeBalancer.
+    required: false
     type: int
+  label:
+    description: The label of this NodeBalancer.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -134,15 +132,37 @@ nodes:
 
 linode_nodebalancer_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
 
-    id=dict(type='int', required=False),
-    label=dict(type='str', required=False)
+    id=dict(
+        type='int', required=False,
+        description='The ID of this NodeBalancer.'),
+
+    label=dict(
+        type='str', required=False,
+        description='The label of this NodeBalancer.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode NodeBalancer.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_nodebalancer_info_spec
 )
 
 linode_nodebalancer_valid_filters = [
     'id', 'label'
 ]
+
 
 class LinodeNodeBalancerInfo(LinodeModuleBase):
     """Module for getting info about a Linode NodeBalancer"""

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -19,33 +19,33 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
-module: object_cluster_info
-description: Get information about an Object Storage cluster.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode Object Storage Cluster.
+module: object_cluster_info
 options:
-  id:
-    description:
-      - The unique id given to the clusters
-    type: string
-  region:
-    description:
-      - The region the clusters are in
-    type: string
   domain:
-    description:
-      - The domain of the clusters
-    type: string
+    description: The domain of the clusters.
+    required: false
+    type: str
+  id:
+    description: The unique id given to the clusters.
+    required: false
+    type: str
+  region:
+    description: The region the clusters are in.
+    required: false
+    type: str
   static_site_domain:
-    description:
-      - The static-site domain of the clusters
-    type: string
+    description: The static-site domain of the clusters.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -78,13 +78,40 @@ clusters:
 
 linode_object_cluster_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
-    label=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
+    label=dict(type='str', required=False, doc_hide=True),
 
-    id=dict(type='str', required=False),
-    region=dict(type='str', required=False),
-    domain=dict(type='str', required=False),
-    static_site_domain=dict(type='str', required=False)
+    id=dict(
+        type='str', required=False,
+        description='The unique id given to the clusters.'),
+
+    region=dict(
+        type='str', required=False,
+        description='The region the clusters are in.'),
+
+    domain=dict(
+        type='str', required=False,
+        description='The domain of the clusters.'),
+
+    static_site_domain=dict(
+        type='str', required=False,
+        description='The static-site domain of the clusters.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode Object Storage Cluster.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_object_cluster_info_spec
 )
 
 linode_object_cluster_valid_filters = [

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -18,48 +18,43 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
-module: object_keys
-description: Manage Linode Object Storage Keys.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Manage Linode Object Storage Keys.
+module: object_keys
 options:
-  label:
-    description:
-      - The unique label to give this key
-    required: true
-    type: string
   access:
-    description:
-      - A list of access permissions to give the key.
-    required: false
-    type: list
+    description: A list of access permissions to give the key.
     elements: dict
+    required: false
     suboptions:
-      cluster:
-        description:
-          - The id of the cluster that the provided bucket exists under.
-        type: str
-        required: true
       bucket_name:
-        description:
-          - The name of the bucket to set the key's permissions for.
-        type: str
+        description: The name of the bucket to set the key's permissions for.
         required: true
+        type: str
+      cluster:
+        description: The id of the cluster that the provided bucket exists under.
+        required: true
+        type: str
       permissions:
-        description:
-          - The permissions to give the key.
-        type: str
-        required: true
         choices:
-          - read_only
-          - write_only
-          - read_write
+        - read_only
+        - write_only
+        - read_write
+        description: The permissions to give the key.
+        required: true
+        type: str
+    type: list
+  label:
+    description: The unique label to give this key.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -106,15 +101,45 @@ key:
 '''
 
 linode_access_spec = dict(
-    cluster=dict(type='str', required=True),
-    bucket_name=dict(type='str', required=True),
-    permissions=dict(type='str', required=True)
+    cluster=dict(
+        type='str', required=True,
+        description='The id of the cluster that the provided bucket exists under.'),
+
+    bucket_name=dict(
+        type='str', required=True,
+        description='The name of the bucket to set the key\'s permissions for.'),
+
+    permissions=dict(
+        type='str', required=True,
+        description='The permissions to give the key.',
+        choices=['read_only', 'write_only', 'read_write'])
 )
 
 linode_object_keys_spec = dict(
-    access=dict(type='list', required=False, elements='dict', options=linode_access_spec)
+    label=dict(
+        type='str',
+        description='The unique label to give this key.'),
+
+    access=dict(
+        type='list', elements='dict', options=linode_access_spec,
+        description='A list of access permissions to give the key.')
 )
 
+specdoc_meta = dict(
+    description=[
+        'Manage Linode Object Storage Keys.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_object_keys_spec
+)
 
 class LinodeObjectStorageKeys(LinodeModuleBase):
     """Module for creating and destroying Linode Object Storage Keys"""

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -18,23 +18,21 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: vlan_info
-description: Get info about a Linode VLAN. \
-This endpoint is currently in beta and will only function correctly if `api_version` is set to `v4beta`.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode VLAN.
+module: vlan_info
 options:
   label:
-    description:
-      - The VLAN’s label.
-    type: string
+    description: "The VLAN\u2019s label."
+    required: true
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -61,9 +59,27 @@ vlan:
 
 linode_vlan_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
 
-    label=dict(type='str', required=True)
+    label=dict(
+        type='str', required=True,
+        description='The VLAN’s label.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode VLAN.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_vlan_info_spec
 )
 
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -18,46 +18,54 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: volume
-description: Manage Linode volumes.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Manage a Linode Volume.
+module: volume
 options:
+  attached:
+    default: true
+    description: If true, the volume will be attached to a Linode. Otherwise, the
+      volume will be detached.
+    required: false
+    type: bool
+  config_id:
+    default: null
+    description: When creating a Volume attached to a Linode, the ID of the Linode
+      Config to include the new Volume in.
+    required: false
+    type: int
   label:
+    description: "The Volume\u2019s label, which is also used in the filesystem_path\
+      \ of the resulting volume."
+    required: false
+    type: str
+  linode_id:
+    default: null
     description:
-      - The Volume’s label, which is also used in the filesystem_path of the resulting volume.
-    required: true
-    type: string
+    - The Linode this volume should be attached to upon creation.
+    - If not given, the volume will be created without an attachment.
+    required: false
+    type: int
   region:
     description:
-      - The location to deploy the volume in.
-      - See U(https://api.linode.com/v4/regions)
+    - The location to deploy the volume in.
+    - See U(https://api.linode.com/v4/regions)
+    required: false
     type: str
   size:
+    default: null
     description:
-      - The size of this volume, in GB. 
-      - Be aware that volumes may only be resized up after creation.
+    - The size of this volume, in GB.
+    - Be aware that volumes may only be resized up after creation.
+    required: false
     type: int
-  linode_id:
-    description:
-      - The Linode this volume should be attached to upon creation. 
-      - If not given, the volume will be created without an attachment.
-    type: int
-  config_id:
-    description:
-      - When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.
-    type: int
-  attached:
-    description:
-      - If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.
-    type: bool
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -116,11 +124,57 @@ volume:
 '''
 
 linode_volume_spec = dict(
-    config_id=dict(type='int', required=False, default=None),
-    linode_id=dict(type='int', required=False, default=None),
-    region=dict(type='str', required=False),
-    size=dict(type='int', required=False, default=None),
-    attached=dict(type='bool', required=False, default=True)
+    label=dict(
+        type='str',
+        description='The Volume’s label, which is also used in the '
+                    'filesystem_path of the resulting volume.'),
+
+    config_id=dict(
+        type='int', default=None,
+        description='When creating a Volume attached to a Linode, the ID of the Linode Config '
+                    'to include the new Volume in.'),
+
+    linode_id=dict(
+        type='int', default=None,
+        description=[
+            'The Linode this volume should be attached to upon creation.',
+            'If not given, the volume will be created without an attachment.'
+        ]),
+
+    region=dict(
+        type='str',
+        description=[
+            'The location to deploy the volume in.',
+            'See U(https://api.linode.com/v4/regions)'
+        ]),
+
+    size=dict(
+        type='int', default=None,
+        description=[
+            'The size of this volume, in GB.',
+            'Be aware that volumes may only be resized up after creation.'
+        ]),
+
+    attached=dict(
+        type='bool', default=True,
+        description='If true, the volume will be attached to a Linode. '
+                    'Otherwise, the volume will be detached.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Manage a Linode Volume.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_volume_spec
 )
 
 

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -19,26 +19,25 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = '''
----
-module: volume_info
-description: Get info about a Linode volume.
-requirements:
-  - python >= 2.7
-  - linode_api4 >= 3.0
 author:
-  - Luke Murphy (@decentral1se)
-  - Charles Kenney (@charliekenney23)
-  - Phillip Campbell (@phillc)
-  - Lena Garber (@lbgarber)
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+description:
+- Get info about a Linode Volume.
+module: volume_info
 options:
-  label:
-    description:
-      - The Volume’s label.
-    type: string
   id:
-    description:
-      - The unique id of the volume.
+    description: The ID of the Volume.
+    required: false
     type: int
+  label:
+    description: The label of the Volume.
+    required: false
+    type: str
+requirements:
+- python >= 3.0
 '''
 
 EXAMPLES = '''
@@ -74,10 +73,31 @@ volume:
 
 linode_volume_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
-    state=dict(type='str', required=False),
+    state=dict(type='str', required=False, doc_hide=True),
 
-    id=dict(type='int', required=False),
-    label=dict(type='str', required=False)
+    id=dict(
+        type='int', required=False,
+        description='The ID of the Volume.'),
+
+    label=dict(
+        type='str', required=False,
+        description='The label of the Volume.')
+)
+
+specdoc_meta = dict(
+    description=[
+        'Get info about a Linode Volume.'
+    ],
+    requirements=[
+        'python >= 3.0'
+    ],
+    author=[
+        'Luke Murphy (@decentral1se)',
+        'Charles Kenney (@charliekenney23)',
+        'Phillip Campbell (@phillc)',
+        'Lena Garber (@lbgarber)'
+    ],
+    spec=linode_volume_info_spec
 )
 
 linode_volume_valid_filters = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ botocore==1.20.23
 pylint==2.7.2
 ansible-doc-extractor==0.1.7
 mypy==0.812
+ansible-specdoc==0.0.6

--- a/scripts/specdoc_generate.sh
+++ b/scripts/specdoc_generate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for f in plugins/modules/*.py
+do
+  ansible-specdoc -i "$f" -j > /dev/null || exit 1;
+done

--- a/template/module.rst.j2
+++ b/template/module.rst.j2
@@ -41,9 +41,9 @@ The below requirements are needed on the host that executes this module.
 {%     set req = spec.required | default("optional") %}
 {%     set typ = spec.type | default("any") %}
 {%     set def_val = spec.default | default("None") %}
-  {{ "  " * level }}{{ name }} ({{ req }}, {{ typ }}, {{ def_val }})
+  {{ "    " * level }}{{ name }} ({{ req }}, {{ typ }}, {{ def_val }})
 {%     for para in spec.description %}
-    {{ "  " * level }}{{ para | rst_ify }}
+    {{ "    " * level }}{{ para | rst_ify }}
 
 {%     endfor %}
 


### PR DESCRIPTION
This branch adds the ability to dynamically generation documentation from module spec. This ensures there is a single source of truth for spec documentation.

The eventual goal will be to completely remove the need to inline documentation, but for the time being inline documentation will be automatically generated.