### PR TITLE
Use single leading underscore for private method names

### DIFF
--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -151,7 +151,7 @@ class LinodeFirewallInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_matching_firewall(self) -> Optional[Firewall]:
+    def _get_matching_firewall(self) -> Optional[Firewall]:
         """Gets the Firewall with the param properties"""
 
         filter_items = {k: v for k, v in self.module.params.items()
@@ -176,7 +176,7 @@ class LinodeFirewallInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: dict) -> Optional[dict]:
         """Entrypoint for Firewall info module"""
 
-        firewall = self.__get_matching_firewall()
+        firewall = self._get_matching_firewall()
 
         if firewall is None:
             self.fail('failed to get firewall')

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -187,7 +187,7 @@ class LinodeInstanceInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_matching_instance(self) -> Optional[Instance]:
+    def _get_matching_instance(self) -> Optional[Instance]:
         params = self.module.params
 
         filter_items = {k: v for k, v in params.items()
@@ -212,7 +212,7 @@ class LinodeInstanceInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for instance info module"""
 
-        instance = self.__get_matching_instance()
+        instance = self._get_matching_instance()
 
         if instance is None:
             return self.fail('failed to get instance')

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -159,7 +159,7 @@ class LinodeNodeBalancerInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_matching_nodebalancer(self) -> Optional[NodeBalancer]:
+    def _get_matching_nodebalancer(self) -> Optional[NodeBalancer]:
         filter_items = {k: v for k, v in self.module.params.items()
                         if k in linode_nodebalancer_valid_filters and v is not None}
 
@@ -179,7 +179,7 @@ class LinodeNodeBalancerInfo(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg='failed to get nodebalancer {0}'.format(exception))
 
-    def __get_node_by_label(self, config: NodeBalancerConfig, label: str) \
+    def _get_node_by_label(self, config: NodeBalancerConfig, label: str) \
             -> Optional[NodeBalancerNode]:
         try:
             return config.nodes(NodeBalancerNode.label == label)[0]
@@ -192,7 +192,7 @@ class LinodeNodeBalancerInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for NodeBalancer Info module"""
 
-        node_balancer = self.__get_matching_nodebalancer()
+        node_balancer = self._get_matching_nodebalancer()
 
         if node_balancer is None:
             return self.fail('failed to get nodebalancer')

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -107,7 +107,7 @@ class LinodeObjectStorageClustersInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_matching_cluster(self) -> Optional[List[ObjectStorageCluster]]:
+    def _get_matching_cluster(self) -> Optional[List[ObjectStorageCluster]]:
         filter_items = {k: v for k, v in self.module.params.items()
                         if k in linode_object_cluster_valid_filters and v is not None}
 
@@ -130,7 +130,7 @@ class LinodeObjectStorageClustersInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Constructs and calls the Linode Object Storage Clusters module"""
 
-        clusters = self.__get_matching_cluster()
+        clusters = self._get_matching_cluster()
 
         if clusters is None:
             return self.fail('failed to get clusters')

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -133,7 +133,7 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_key_by_label(self, label: str) -> Optional[ObjectStorageKeys]:
+    def _get_key_by_label(self, label: str) -> Optional[ObjectStorageKeys]:
         try:
             # For some reason we can't filter on label here
             keys = self.client.object_storage.keys()
@@ -151,7 +151,7 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
             return self.fail(msg='failed to get object storage key {0}: {1}'
                              .format(label, exception))
 
-    def __create_key(self, label: str, bucket_access: Union[dict, List[dict]]) \
+    def _create_key(self, label: str, bucket_access: Union[dict, List[dict]]) \
             -> Optional[ObjectStorageKeys]:
         """Creates an Object Storage key with the given label and access"""
 
@@ -160,27 +160,27 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg='failed to create object storage key: {0}'.format(exception))
 
-    def __handle_key(self) -> None:
+    def _handle_key(self) -> None:
         """Updates the key defined in kwargs"""
 
         params = self.module.params
         label: str = params.pop('label')
         access: dict = params.get('access')
 
-        self._key = self.__get_key_by_label(label)
+        self._key = self._get_key_by_label(label)
 
         if self._key is None:
-            self._key = self.__create_key(label, bucket_access=access)
+            self._key = self._create_key(label, bucket_access=access)
             self.register_action('Created key {0}'.format(label))
 
         self.results['key'] = self._key._raw_json
 
-    def __handle_key_absent(self) -> None:
+    def _handle_key_absent(self) -> None:
         """Deletes the key defined in kwargs"""
 
         label = self.module.params.pop('label')
 
-        self._key = self.__get_key_by_label(label)
+        self._key = self._get_key_by_label(label)
 
         if self._key is not None:
             self.results['key'] = self._key._raw_json
@@ -193,10 +193,10 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
         state = kwargs.pop('state')
 
         if state == 'absent':
-            self.__handle_key_absent()
+            self._handle_key_absent()
             return self.results
 
-        self.__handle_key()
+        self._handle_key()
 
         return self.results
 

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -80,7 +80,7 @@ class LinodeVLANInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_vlan_by_label(self, label: str) -> Optional[VLAN]:
+    def _get_vlan_by_label(self, label: str) -> Optional[VLAN]:
         try:
             return self.client.networking.vlans(VLAN.label == label)[0]
         except IndexError:
@@ -92,7 +92,7 @@ class LinodeVLANInfo(LinodeModuleBase):
         """Entrypoint for VLAN info module"""
 
         label: str = kwargs.get('label')
-        vlan = self.__get_vlan_by_label(label)
+        vlan = self._get_vlan_by_label(label)
 
         if vlan is None:
             self.fail('failed to get vlan')

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -141,7 +141,7 @@ class LinodeVolume(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_volume_by_label(self, label: str) -> Optional[Volume]:
+    def _get_volume_by_label(self, label: str) -> Optional[Volume]:
         try:
             return self.client.volumes(Volume.label == label)[0]
         except IndexError:
@@ -149,7 +149,7 @@ class LinodeVolume(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg='failed to get volume {0}: {1}'.format(label, exception))
 
-    def __create_volume(self) -> Optional[Volume]:
+    def _create_volume(self) -> Optional[Volume]:
         params = self.module.params
         label = params.pop('label')
         region = params.pop('region')
@@ -161,7 +161,7 @@ class LinodeVolume(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg='failed to create volume: {0}'.format(exception))
 
-    def __handle_volume(self) -> None:
+    def _handle_volume(self) -> None:
         params = self.module.params
 
         label: str = params.get('label')
@@ -170,11 +170,11 @@ class LinodeVolume(LinodeModuleBase):
         config_id: int = params.get('config_id')
         attached: bool = params.pop('attached')
 
-        self._volume = self.__get_volume_by_label(label)
+        self._volume = self._get_volume_by_label(label)
 
         # Create the volume if it does not already exist
         if self._volume is None:
-            self._volume = self.__create_volume()
+            self._volume = self._create_volume()
             self.register_action('Created volume {0}'.format(label))
 
         # Resize the volume if its size does not match
@@ -201,10 +201,10 @@ class LinodeVolume(LinodeModuleBase):
 
         self.results['volume'] = self._volume._raw_json
 
-    def __handle_volume_absent(self) -> None:
+    def _handle_volume_absent(self) -> None:
         label: str = self.module.params.get('label')
 
-        self._volume = self.__get_volume_by_label(label)
+        self._volume = self._get_volume_by_label(label)
 
         if self._volume is not None:
             self.results['volume'] = self._volume._raw_json
@@ -216,10 +216,10 @@ class LinodeVolume(LinodeModuleBase):
         state = kwargs.get('state')
 
         if state == 'absent':
-            self.__handle_volume_absent()
+            self._handle_volume_absent()
             return self.results
 
-        self.__handle_volume()
+        self._handle_volume()
 
         return self.results
 

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -100,7 +100,7 @@ class LinodeVolumeInfo(LinodeModuleBase):
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
-    def __get_matching_volume(self, spec_args: dict) -> Optional[Volume]:
+    def _get_matching_volume(self, spec_args: dict) -> Optional[Volume]:
         filter_items = {k: v for k, v in spec_args.items()
                         if k in linode_volume_valid_filters and v is not None}
 
@@ -123,7 +123,7 @@ class LinodeVolumeInfo(LinodeModuleBase):
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for volume info module"""
 
-        volume = self.__get_matching_volume(kwargs)
+        volume = self._get_matching_volume(kwargs)
 
         if volume is None:
             self.fail('failed to get volume')


### PR DESCRIPTION
This change is necessary to prevent name mangling for module methods and to promote consistency with the rest of the collection.