### PR TITLE
Remove need for `instance.` prefix in Inventory keys

### DIFF
--- a/plugins/inventory/instance.py
+++ b/plugins/inventory/instance.py
@@ -187,7 +187,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def _add_hostvars_for_instances(self) -> None:
         """Add hostvars for instances in the dynamic inventory."""
         for instance in self.instances:
-            hostvars = {'instance': instance._raw_json}
+            hostvars = instance._raw_json
             for hostvar_key in hostvars:
                 self.inventory.set_variable(
                     instance.label,

--- a/tests/integration/targets/instance_inventory/playbooks/teardown.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/teardown.yml
@@ -22,3 +22,4 @@
       loop:
         - filter.instance.yml
         - nofilter.instance.yml
+        - keyedgroups.instance.yml

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_keyedgroups.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_keyedgroups.yml
@@ -8,4 +8,4 @@
     - name: Test inventory without filter
       assert:
         that:
-          - "'ansible-test-inventory' in hostvars"
+          - "groups['cool_group'] | list | length > 0"

--- a/tests/integration/targets/instance_inventory/runme.sh
+++ b/tests/integration/targets/instance_inventory/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#set -eux
+set -eux
 
 # Create testing instance
 ansible-playbook playbooks/setup_instance.yml "$@"
@@ -12,6 +12,10 @@ ANSIBLE_INVENTORY=nofilter.instance.yml ansible-playbook playbooks/test_inventor
 # Test an inventory with a filter
 ansible-playbook playbooks/create_inventory.yml --extra-vars "template=filter.instance.yml" "$@"
 ANSIBLE_INVENTORY=filter.instance.yml ansible-playbook playbooks/test_inventory_filter.yml "$@"
+
+# Test an inventory with keyed groups filter
+ansible-playbook playbooks/create_inventory.yml --extra-vars "template=keyedgroups.instance.yml" "$@"
+ANSIBLE_INVENTORY=keyedgroups.instance.yml ansible-playbook playbooks/test_inventory_keyedgroups.yml "$@"
 
 # Clean up
 ansible-playbook playbooks/teardown.yml "$@"

--- a/tests/integration/targets/instance_inventory/templates/keyedgroups.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/keyedgroups.instance.yml
@@ -1,0 +1,7 @@
+plugin: linode.cloud.instance
+api_token: '{{ api_token }}'
+keyed_groups:
+  - key: tags
+    separator: ''
+groups:
+  cool_group: "'ansible-inventory-node' in (tags|list)"


### PR DESCRIPTION
This change allows inventory keys to be referenced directly rather than with an `instance.` prefix. (e.g. `instance.tags` -> `tags`)