### PR TITLE
Automatically set `ansible_host` for inventory instances

### DIFF
--- a/plugins/inventory/instance.py
+++ b/plugins/inventory/instance.py
@@ -183,6 +183,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         """Add instance names to their dynamic inventory groups."""
         for instance in self.instances:
             self.inventory.add_host(instance.label, group=instance.group)
+            self.inventory.set_variable(instance.label, 'ansible_host', instance.ipv4[0])
 
     def _add_hostvars_for_instances(self) -> None:
         """Add hostvars for instances in the dynamic inventory."""

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_nofilter.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_nofilter.yml
@@ -9,3 +9,4 @@
       assert:
         that:
           - "'ansible-test-inventory' in hostvars"
+          - hostvars["ansible-test-inventory"].ansible_host|length > 0


### PR DESCRIPTION
This pull request allows for Ansible to infer an instance's host without it being explicitly defined by the user.