### PR TITLE
Default 'booted' to nil

### DIFF
--- a/docs/modules/instance.rst
+++ b/docs/modules/instance.rst
@@ -41,7 +41,7 @@ Parameters
     The label of the config to boot from.
 
 
-  booted (False, bool, True)
+  booted (False, bool, None)
     Whether the new Instance should be booted.
 
     This will default to True if the Instance is deployed from an Image or Backup.

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -46,7 +46,6 @@ options:
     required: false
     type: str
   booted:
-    default: true
     description:
     - Whether the new Instance should be booted.
     - This will default to True if the Instance is deployed from an Image or Backup.
@@ -773,7 +772,7 @@ linode_instance_spec = dict(
         ]),
 
     booted=dict(
-        type='bool', default=True,
+        type='bool',
         description=[
             'Whether the new Instance should be booted.',
             'This will default to True if the Instance is deployed from an Image or Backup.'


### PR DESCRIPTION
This default value was introduced in the documentation generation changes. If booted is set to `nil`, the collection defers boot handling to the API. This change will resolve the failing inventory integration test.