### PR TITLE
Use `name`, `type`, and `target` to identify Domain Records 

### DIFF
--- a/docs/modules/domain_record.rst
+++ b/docs/modules/domain_record.rst
@@ -14,6 +14,8 @@ Synopsis
 
 Manage Linode Domain Records.
 
+NOTE: Domain records are identified by their name, target, and type.
+
 
 
 Requirements
@@ -37,7 +39,7 @@ Parameters
 
   **label (required=False, type=str, default=None):**
 
-  **name (required=True, type=str, default=None):**
+  **name (required=False, type=str, default=None):**
     \• The name of this Record.
 
 
@@ -63,6 +65,10 @@ Parameters
     \• An underscore (_) is prepended automatically to the submitted value for this property.
 
 
+  **record_id (required=False, type=int, default=None):**
+    \• The id of the record to modify.
+
+
   **service (required=False, type=str, default=None):**
     \• An underscore (_) is prepended and a period (.) is appended automatically to the submitted value for this property.
 
@@ -77,7 +83,7 @@ Parameters
     \• Only valid and required for CAA record requests.
 
 
-  **target (required=False, type=str, default=None):**
+  **target (required=False, type=str, default=):**
     \• The target for this Record.
 
 
@@ -104,7 +110,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Create a A record
+    - name: Create an A record
       linode.cloud.domain_record:
         domain: my-domain.com
         name: my-subdomain

--- a/docs/modules/domain_record_info.rst
+++ b/docs/modules/domain_record_info.rst
@@ -40,7 +40,7 @@ Parameters
 
 
   **name (required=False, type=str, default=None):**
-    \• The name of the subdomain.
+    \• The name of the domain record.
 
 
 
@@ -54,10 +54,12 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get info about a domain record by name
+    - name: Get info about domain records by name
       linode.cloud.domain_record_info:
         domain: my-domain.com
         name: my-subdomain
+        type: A
+        target: 0.0.0.0
 
     - name: Get info about a domain record by id
       linode.cloud.domain_info:
@@ -70,9 +72,9 @@ Examples
 Return Values
 -------------
 
-**record (returned=always, type=dict):**
+**records (returned=always, type=list):**
 
-The domain record in JSON serialized form.
+The domain records in JSON serialized form.
 
 `Linode Response Object Documentation <https://www.linode.com/docs/api/domains/#domain-record-view>`_
 
@@ -80,21 +82,23 @@ Sample Response:
 
 .. code-block:: JSON
 
-    {
-     "created": "xxxxx",
-     "id": "xxxxx",
-     "name": "xxxx",
-     "port": 0,
-     "priority": 0,
-     "protocol": null,
-     "service": null,
-     "tag": null,
-     "target": "127.0.0.1",
-     "ttl_sec": 3600,
-     "type": "A",
-     "updated": "xxxxx",
-     "weight": 55
-    }
+    [
+     {
+      "created": "xxxxx",
+      "id": "xxxxx",
+      "name": "xxxx",
+      "port": 0,
+      "priority": 0,
+      "protocol": null,
+      "service": null,
+      "tag": null,
+      "target": "127.0.0.1",
+      "ttl_sec": 3600,
+      "type": "A",
+      "updated": "xxxxx",
+      "weight": 55
+     }
+    ]
 
 
 

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -104,16 +104,6 @@
           - record2_create.record.ttl_sec == 7200
           - record2_create.record.weight == 32
 
-    - name: Get all domain records
-      linode.cloud.domain_info:
-        api_token: '{{ api_token }}'
-        domain: '{{ domain_create.domain.domain }}'
-      register: domain_info
-
-    - assert:
-        that:
-          - domain_info.records|length == 2
-
     - name: Create a duplicate record with a different target
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
@@ -153,6 +143,15 @@
           - record_dupe_update.record.ttl_sec == 300
           - record_dupe_update.record.weight == 55
 
+    - name: Get all domain records
+      linode.cloud.domain_info:
+        api_token: '{{ api_token }}'
+        domain: '{{ domain_create.domain.domain }}'
+      register: domain_info
+
+    - assert:
+        that:
+          - domain_info.records|length == 3
 
   always:
     - ignore_errors: yes
@@ -174,7 +173,9 @@
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
             domain: '{{ domain_create.domain.domain }}'
-            record_id: '{{ record2_create.record.id }}'
+            name: '{{ record2_create.record.name }}'
+            type: '{{ record2_create.record.type }}'
+            target: '{{ record2_create.record.target }}'
             state: absent
           register: record2_delete
 

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -39,9 +39,7 @@
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
         domain: '{{ domain_create.domain.domain }}'
-        name: 'sub'
-        type: 'A'
-        target: '127.0.0.4'
+        record_id: '{{ record_create.record.id }}'
         ttl_sec: 14400
         weight: 62
         state: present
@@ -49,9 +47,10 @@
 
     - assert:
         that:
+          - record_update.record.id == record_create.record.id
           - record_update.record.name == 'sub'
           - record_update.record.type == 'A'
-          - record_update.record.target == '127.0.0.4'
+          - record_update.record.target == '127.0.0.1'
           - record_update.record.ttl_sec == 14400
           - record_update.record.weight == 62
 
@@ -64,11 +63,11 @@
 
     - assert:
         that:
-          - record_info.record.name == 'sub'
-          - record_info.record.type == 'A'
-          - record_info.record.target == '127.0.0.4'
-          - record_info.record.ttl_sec == 14400
-          - record_info.record.weight == 62
+          - record_info.record[0].name == 'sub'
+          - record_info.record[0].type == 'A'
+          - record_info.record[0].target == '127.0.0.1'
+          - record_info.record[0].ttl_sec == 14400
+          - record_info.record[0].weight == 62
 
     - name: Get info about the record by id
       linode.cloud.domain_record_info:
@@ -79,11 +78,11 @@
 
     - assert:
         that:
-          - record_info_id.record.name == 'sub'
-          - record_info_id.record.type == 'A'
-          - record_info_id.record.target == '127.0.0.4'
-          - record_info_id.record.ttl_sec == 14400
-          - record_info_id.record.weight == 62
+          - record_info_id.record[0].name == 'sub'
+          - record_info_id.record[0].type == 'A'
+          - record_info_id.record[0].target == '127.0.0.1'
+          - record_info_id.record[0].ttl_sec == 14400
+          - record_info_id.record[0].weight == 62
 
     - name: Create a domain record by domain id
       linode.cloud.domain_record:
@@ -115,6 +114,46 @@
         that:
           - domain_info.records|length == 2
 
+    - name: Create a duplicate record with a different target
+      linode.cloud.domain_record:
+        api_token: '{{ api_token }}'
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'sub'
+        type: 'A'
+        target: '127.0.0.2'
+        ttl_sec: 3600
+        weight: 55
+        state: present
+      register: record_dupe_create
+
+    - assert:
+        that:
+          - record_dupe_create.record.name == 'sub'
+          - record_dupe_create.record.type == 'A'
+          - record_dupe_create.record.target == '127.0.0.2'
+          - record_dupe_create.record.ttl_sec == 3600
+          - record_dupe_create.record.weight == 55
+
+    - name: Update the record by id
+      linode.cloud.domain_record:
+        api_token: '{{ api_token }}'
+        domain: '{{ domain_create.domain.domain }}'
+        record_id: '{{ record_dupe_create.record.id }}'
+        ttl_sec: 300
+        weight: 55
+        state: present
+      register: record_dupe_update
+
+    - assert:
+        that:
+          - record_dupe_update.changed == true
+          - record_dupe_update.record.name == 'sub'
+          - record_dupe_update.record.type == 'A'
+          - record_dupe_update.record.target == '127.0.0.2'
+          - record_dupe_update.record.ttl_sec == 300
+          - record_dupe_update.record.weight == 55
+
+
   always:
     - ignore_errors: yes
       block:
@@ -122,7 +161,7 @@
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
             domain: '{{ domain_create.domain.domain }}'
-            name: '{{ record_create.record.name }}'
+            record_id: '{{ record_create.record.id }}'
             state: absent
           register: record_delete
 
@@ -135,7 +174,7 @@
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
             domain: '{{ domain_create.domain.domain }}'
-            name: '{{ record2_create.record.name }}'
+            record_id: '{{ record2_create.record.id }}'
             state: absent
           register: record2_delete
 
@@ -143,6 +182,19 @@
             that:
               - record2_delete.changed
               - record2_delete.record.id == record2_create.record.id
+
+        - name: Delete the duplicated record
+          linode.cloud.domain_record:
+            api_token: '{{ api_token }}'
+            domain: '{{ domain_create.domain.domain }}'
+            record_id: '{{ record_dupe_create.record.id }}'
+            state: absent
+          register: record_dupe_delete
+
+        - assert:
+            that:
+              - record_dupe_delete.changed
+              - record_dupe_delete.record.id == record_dupe_delete.record.id
 
         - name: Delete the domain
           linode.cloud.domain:


### PR DESCRIPTION
This change allows users to create Domain records with duplicate names and types. Additionally, users can now specify a `record_id` when updating an existing record.

#73 