### PR TITLE
adding firewall_device module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Name | Description
 [linode.cloud.domain_record_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/domain_record_info.rst)|Gather info about an existing domain record.
 [linode.cloud.firewall](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall.rst)|Create and destroy Firewalls.
 [linode.cloud.firewall_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall_info.rst)|Gather info about an existing Firewall.
+[linode.cloud.firewall_device](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall_device.rst)|Manage Firewall Devices.
 [linode.cloud.instance](https://github.com/linode/ansible_linode/blob/main/docs/modules/instance.rst)|Create and destroy Linodes.
 [linode.cloud.instance_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/instance_info.rst)|Gather info about an existing Linode instance.
 [linode.cloud.nodebalancer](https://github.com/linode/ansible_linode/blob/main/docs/modules/nodebalancer.rst)|Create, destroy, and configure NodeBalancers.

--- a/docs/modules/domain.rst
+++ b/docs/modules/domain.rst
@@ -185,4 +185,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/domain_info.rst
+++ b/docs/modules/domain_info.rst
@@ -142,4 +142,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/domain_record.rst
+++ b/docs/modules/domain_record.rst
@@ -178,4 +178,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/domain_record_info.rst
+++ b/docs/modules/domain_record_info.rst
@@ -122,4 +122,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/firewall.rst
+++ b/docs/modules/firewall.rst
@@ -290,4 +290,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/firewall_device.rst
+++ b/docs/modules/firewall_device.rst
@@ -1,0 +1,130 @@
+.. _firewall_device_module:
+
+
+firewall_device
+===============
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+Manage Linode Firewall Devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 3
+
+
+
+Parameters
+----------
+
+  **device_id (Required, type=int):**
+    \• The ID for this Firewall Device. This will be the ID of the Linode Entity.
+
+
+  **device_type (Required, type=str):**
+    \• The type of Linode Entity. Currently only supports linode.
+
+    \• Options: `linode`
+
+
+  **firewall_id (Required, type=int):**
+    \• The ID of the Firewall that contains this device.
+
+
+
+
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a Firewall
+      linode.cloud.firewall:
+        label: my-firewall
+        rules:
+          inbound_policy: DROP
+        state: present
+      register: firewall_result
+
+    - name: Create an Instance
+      linode.cloud.instance:
+        label: my-instance
+        region: us-east
+        private_ip: true
+        type: g6-standard-1
+        state: present
+      register: instance_result
+
+    - name: Attach the instance to the Firewall
+      linode.cloud.firewall_device:
+        firewall_id: '{{ firewall_result.firewall.id }}'
+        device_id: '{{ instance_result.instance.id }}'
+        device_type: 'linode'
+        state: present
+
+
+
+
+Return Values
+-------------
+
+**device (returned=always, type=dict):**
+
+The Firewall Device in JSON serialized form.
+
+`Linode Response Object Documentation <https://www.linode.com/docs/api/networking/#firewall-device-view__response-samples>`_
+
+Sample Response:
+
+.. code-block:: JSON
+
+    {
+     "created": "2018-01-01T00:01:01",
+     "entity": {
+      "id": 123,
+      "label": "my-linode",
+      "type": "linode",
+      "url": "/v4/linode/instances/123"
+     },
+     "id": 123,
+     "updated": "2018-01-02T00:01:01"
+    }
+
+
+
+
+
+Status
+------
+
+
+
+
+- This module is maintained by Linode.
+
+
+
+Authors
+~~~~~~~
+
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
+

--- a/docs/modules/firewall_device.rst
+++ b/docs/modules/firewall_device.rst
@@ -27,11 +27,11 @@ The below requirements are needed on the host that executes this module.
 Parameters
 ----------
 
-  **device_id (Required, type=int):**
+  **entity_id (Required, type=int):**
     \• The ID for this Firewall Device. This will be the ID of the Linode Entity.
 
 
-  **device_type (Required, type=str):**
+  **entity_type (Required, type=str):**
     \• The type of Linode Entity. Currently only supports linode.
 
     \• Options: `linode`
@@ -73,8 +73,8 @@ Examples
     - name: Attach the instance to the Firewall
       linode.cloud.firewall_device:
         firewall_id: '{{ firewall_result.firewall.id }}'
-        device_id: '{{ instance_result.instance.id }}'
-        device_type: 'linode'
+        entity_id: '{{ instance_result.instance.id }}'
+        entity_type: 'linode'
         state: present
 
 

--- a/docs/modules/firewall_info.rst
+++ b/docs/modules/firewall_info.rst
@@ -163,4 +163,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/instance.rst
+++ b/docs/modules/instance.rst
@@ -531,4 +531,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/instance_info.rst
+++ b/docs/modules/instance_info.rst
@@ -204,4 +204,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/nodebalancer.rst
+++ b/docs/modules/nodebalancer.rst
@@ -285,4 +285,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/nodebalancer_info.rst
+++ b/docs/modules/nodebalancer_info.rst
@@ -173,4 +173,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/nodebalancer_node.rst
+++ b/docs/modules/nodebalancer_node.rst
@@ -151,4 +151,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/object_cluster_info.rst
+++ b/docs/modules/object_cluster_info.rst
@@ -110,4 +110,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/object_keys.rst
+++ b/docs/modules/object_keys.rst
@@ -119,4 +119,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/vlan_info.rst
+++ b/docs/modules/vlan_info.rst
@@ -93,4 +93,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/volume.rst
+++ b/docs/modules/volume.rst
@@ -156,4 +156,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/docs/modules/volume_info.rst
+++ b/docs/modules/volume_info.rst
@@ -106,4 +106,5 @@ Authors
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 

--- a/plugins/module_utils/linode_docs.py
+++ b/plugins/module_utils/linode_docs.py
@@ -4,7 +4,8 @@ global_authors = [
         'Luke Murphy (@decentral1se)',
         'Charles Kenney (@charliekenney23)',
         'Phillip Campbell (@phillc)',
-        'Lena Garber (@lbgarber)'
+        'Lena Garber (@lbgarber)',
+        'Jacob Riddle (@jriddle)'
 ]
 
 global_requirements = [

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode Domains.
 module: domain

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Domain.
 module: domain_info

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode Domain Records.
 - 'NOTE: Domain records are identified by their name, target, and type.'

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Domain Records.
 module: domain_record_info

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -25,6 +25,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode Firewalls.
 module: firewall

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -25,16 +25,22 @@ MODULE_SPEC = dict(
         description='The ID of the Firewall that contains this device.',
         ),
 
-    firewall_device_id=dict(
+    device_id=dict(
         type='int', required=True,
         description='The ID for this Firewall Device. This will be the ID of the Linode Entity.',
     ),
 
-    firewall_device_type=dict(
+    device_type=dict(
         type='str', required=True,
         description='The type of Linode Entity. Currently only supports linode.',
         choices=['linode'],
     ),
+
+    label=dict(
+        type='str',
+        required=False,
+        doc_hide=True,
+    )
 )
 
 specdoc_meta = dict(
@@ -65,7 +71,7 @@ class LinodeFirewallDevice(LinodeModuleBase):
         try:
             params = self.module.params
             firewall_id = params['firewall_id']
-            device_id = params['firewall_device_id']
+            device_id = params['device_id']
 
             firewall = linode_api4.Firewall(self.client, firewall_id)
             for device in firewall.devices:
@@ -76,13 +82,13 @@ class LinodeFirewallDevice(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg='failed to get device {0}: {1}'.format(device_id, exception))
 
-    def _create_node(self) -> linode_api4.FirewallDevice:
+    def _create_device(self) -> linode_api4.FirewallDevice:
         try:
             params = copy.deepcopy(self.module.params)
 
             firewall_id = params['firewall_id']
-            device_id = params['firewall_device_id']
-            device_type = params['firewall_device_type']
+            device_id = params['device_id']
+            device_type = params['device_type']
 
             firewall = linode_api4.Firewall(self.client, firewall_id)
 
@@ -93,7 +99,7 @@ class LinodeFirewallDevice(LinodeModuleBase):
             return device
         except Exception as exception:
             return self.fail(msg='failed to create firewall device {0}: {1}'
-                             .format(self.module.params.get('firewall_device_id'), exception))
+                             .format(self.module.params.get('device_id'), exception))
 
     def _handle_present(self) -> None:
         device = self._get_device()
@@ -115,7 +121,7 @@ class LinodeFirewallDevice(LinodeModuleBase):
 
             device.delete()
             self.register_action('Deleted firewall device {0}'
-                                 .format(self.module.params.get('firewall_device_id')))
+                                 .format(self.module.params.get('device_id')))
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for firewall_device module"""
@@ -148,20 +154,21 @@ description:
 - Manage Linode Firewall Devices.
 module: firewall_device
 options:
+  device_id:
+    description: The ID for this Firewall Device. This will be the ID of the Linode
+      Entity.
+    required: true
+    type: int
+  device_type:
+    choices:
+    - linode
+    description: The type of Linode Entity. Currently only supports linode.
+    required: true
+    type: str
   firewall_id:
     description: The ID of the Firewall that contains this device.
     required: true
     type: int
-  firewall_device_id:
-    description: The ID for this Firewall Device. This will be the ID of the Linode Entity.
-    required: true
-    type: int
-  firewall_device_type:
-    choices:
-    - linode
-    description: The ID of the Firewall that contains this device.
-    required: true
-    type: string
 requirements:
 - python >= 3
 '''
@@ -186,9 +193,9 @@ EXAMPLES = '''
 
 - name: Attach the instance to the Firewall
   linode.cloud.firewall_device:
-    firewall_id: firewall_result.firewall.id
-    firewall_device_id: instance_result.instance.id
-    firewall_device_type: 'linode'
+    firewall_id: '{{ firewall_result.firewall.id }}'
+    device_id: '{{ instance_result.instance.id }}'
+    device_type: 'linode'
     state: present
 '''
 

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -25,12 +25,12 @@ MODULE_SPEC = dict(
         description='The ID of the Firewall that contains this device.',
         ),
 
-    device_id=dict(
+    entity_id=dict(
         type='int', required=True,
         description='The ID for this Firewall Device. This will be the ID of the Linode Entity.',
     ),
 
-    device_type=dict(
+    entity_type=dict(
         type='str', required=True,
         description='The type of Linode Entity. Currently only supports linode.',
         choices=['linode'],
@@ -71,35 +71,35 @@ class LinodeFirewallDevice(LinodeModuleBase):
         try:
             params = self.module.params
             firewall_id = params['firewall_id']
-            device_id = params['device_id']
+            entity_id = params['entity_id']
 
             firewall = linode_api4.Firewall(self.client, firewall_id)
             for device in firewall.devices:
-                if device.id == device_id:
+                if device.id == entity_id:
                     return device
 
             return None
         except Exception as exception:
-            return self.fail(msg='failed to get device {0}: {1}'.format(device_id, exception))
+            return self.fail(msg='failed to get device {0}: {1}'.format(entity_id, exception))
 
     def _create_device(self) -> linode_api4.FirewallDevice:
         try:
             params = copy.deepcopy(self.module.params)
 
             firewall_id = params['firewall_id']
-            device_id = params['device_id']
-            device_type = params['device_type']
+            entity_id = params['entity_id']
+            entity_type = params['entity_type']
 
             firewall = linode_api4.Firewall(self.client, firewall_id)
 
-            device = firewall.device_create(device_id, device_type, **params)
+            device = firewall.device_create(entity_id, entity_type, **params)
             self.register_action('Created Device {}: {}'.
-                                 format(device_id, device.created))
+                                 format(entity_id, device.created))
 
             return device
         except Exception as exception:
             return self.fail(msg='failed to create firewall device {0}: {1}'
-                             .format(self.module.params.get('device_id'), exception))
+                             .format(self.module.params.get('entity_id'), exception))
 
     def _handle_present(self) -> None:
         device = self._get_device()
@@ -121,7 +121,7 @@ class LinodeFirewallDevice(LinodeModuleBase):
 
             device.delete()
             self.register_action('Deleted firewall device {0}'
-                                 .format(self.module.params.get('device_id')))
+                                 .format(self.module.params.get('entity_id')))
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for firewall_device module"""
@@ -154,12 +154,12 @@ description:
 - Manage Linode Firewall Devices.
 module: firewall_device
 options:
-  device_id:
+  entity_id:
     description: The ID for this Firewall Device. This will be the ID of the Linode
       Entity.
     required: true
     type: int
-  device_type:
+  entity_type:
     choices:
     - linode
     description: The type of Linode Entity. Currently only supports linode.
@@ -194,8 +194,8 @@ EXAMPLES = '''
 - name: Attach the instance to the Firewall
   linode.cloud.firewall_device:
     firewall_id: '{{ firewall_result.firewall.id }}'
-    device_id: '{{ instance_result.instance.id }}'
-    device_type: 'linode'
+    entity_id: '{{ instance_result.instance.id }}'
+    entity_type: 'linode'
     state: present
 '''
 

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -72,10 +72,11 @@ class LinodeFirewallDevice(LinodeModuleBase):
             params = self.module.params
             firewall_id = params['firewall_id']
             entity_id = params['entity_id']
+            entity_type = params['entity_type']
 
             firewall = linode_api4.Firewall(self.client, firewall_id)
             for device in firewall.devices:
-                if device.id == entity_id:
+                if device.entity.id == entity_id and device.entity.type == entity_type:
                     return device
 
             return None

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Domains."""
+
+# pylint: disable=unused-import
+import copy
+from typing import Optional, Any, List
+
+import linode_api4
+from linode_api4 import Domain
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
+    global_requirements
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'Linode'
+}
+
+MODULE_SPEC = dict(
+    firewall_id=dict(
+        type='int', required=True,
+        description='The ID of the Firewall that contains this device.',
+        ),
+
+    firewall_device_id=dict(
+        type='int', required=True,
+        description='The ID for this Firewall Device. This will be the ID of the Linode Entity.',
+    ),
+
+    firewall_device_type=dict(
+        type='str', required=True,
+        description='The type of Linode Entity. Currently only supports linode.',
+        choices=['linode'],
+    ),
+)
+
+specdoc_meta = dict(
+    description=[
+        'Manage Linode Firewall Devices.'
+    ],
+    requirements=global_requirements,
+    author=global_authors,
+    spec=MODULE_SPEC
+)
+
+class LinodeFirewallDevice(LinodeModuleBase):
+    """Module for managing Linode Firewall devices"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = MODULE_SPEC
+        self.required_one_of: List[str] = []
+        self.results = dict(
+            changed=False,
+            actions=[],
+            device=None,
+        )
+
+        super().__init__(module_arg_spec=self.module_arg_spec,
+                         required_one_of=self.required_one_of)
+
+    def _get_device(self) -> Optional[linode_api4.FirewallDevice]:
+        try:
+            params = self.module.params
+            firewall_id = params['firewall_id']
+            device_id = params['firewall_device_id']
+
+            firewall = linode_api4.Firewall(self.client, firewall_id)
+            for device in firewall.devices:
+                if device.id == device_id:
+                    return device
+
+            return None
+        except Exception as exception:
+            return self.fail(msg='failed to get device {0}: {1}'.format(device_id, exception))
+
+    def _create_node(self) -> linode_api4.FirewallDevice:
+        try:
+            params = copy.deepcopy(self.module.params)
+
+            firewall_id = params['firewall_id']
+            device_id = params['firewall_device_id']
+            device_type = params['firewall_device_type']
+
+            firewall = linode_api4.Firewall(self.client, firewall_id)
+
+            device = firewall.device_create(device_id, device_type, **params)
+            self.register_action('Created Device {}: {}'.
+                                 format(device_id, device.created))
+
+            return device
+        except Exception as exception:
+            return self.fail(msg='failed to create firewall device {0}: {1}'
+                             .format(self.module.params.get('firewall_device_id'), exception))
+
+    def _handle_present(self) -> None:
+        device = self._get_device()
+
+        # Create the device if it does not already exist
+        if device is None:
+            device = self._create_device()
+
+        # Force lazy-loading
+        device._api_get()
+
+        self.results['device'] = device._raw_json
+
+    def _handle_absent(self) -> None:
+        device = self._get_device()
+
+        if device is not None:
+            self.results['device'] = device._raw_json
+
+            device.delete()
+            self.register_action('Deleted firewall device {0}'
+                                 .format(self.module.params.get('firewall_device_id')))
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for firewall_device module"""
+        state = kwargs.get('state')
+
+        if state == 'absent':
+            self._handle_absent()
+            return self.results
+
+        self._handle_present()
+
+        return self.results
+
+def main() -> None:
+    """Constructs and calls the Linode Domain module"""
+    LinodeFirewallDevice()
+
+
+if __name__ == '__main__':
+    main()
+
+DOCUMENTATION='''
+author:
+- Luke Murphy (@decentral1se)
+- Charles Kenney (@charliekenney23)
+- Phillip Campbell (@phillc)
+- Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
+description:
+- Manage Linode Firewall Devices.
+module: firewall_device
+options:
+  firewall_id:
+    description: The ID of the Firewall that contains this device.
+    required: true
+    type: int
+  firewall_device_id:
+    description: The ID for this Firewall Device. This will be the ID of the Linode Entity.
+    required: true
+    type: int
+  firewall_device_type:
+    choices:
+    - linode
+    description: The ID of the Firewall that contains this device.
+    required: true
+    type: string
+requirements:
+- python >= 3
+'''
+
+EXAMPLES = '''
+- name: Create a Firewall
+  linode.cloud.firewall:
+    label: my-firewall
+    rules:
+      inbound_policy: DROP
+    state: present
+  register: firewall_result
+
+- name: Create an Instance
+  linode.cloud.instance:
+    label: my-instance
+    region: us-east
+    private_ip: true
+    type: g6-standard-1
+    state: present
+  register: instance_result
+
+- name: Attach the instance to the Firewall
+  linode.cloud.firewall_device:
+    firewall_id: firewall_result.firewall.id
+    firewall_device_id: instance_result.instance.id
+    firewall_device_type: 'linode'
+    state: present
+'''
+
+RETURN = '''
+device:
+  description: The Firewall Device in JSON serialized form.
+  linode_api_docs: "https://www.linode.com/docs/api/networking/#firewall-device-view__response-samples"
+  returned: always
+  type: dict
+  sample: {
+        "created": "2018-01-01T00:01:01",
+        "entity": {
+            "id": 123,
+            "label": "my-linode",
+            "type": "linode",
+            "url": "/v4/linode/instances/123"
+        },
+        "id": 123,
+        "updated": "2018-01-02T00:01:01"
+    }
+'''

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Firewall.
 module: firewall_info

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -28,6 +28,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode Instances.
 module: instance

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Instance.
 module: instance_info

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -32,6 +32,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage a Linode NodeBalancer.
 module: nodebalancer

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode NodeBalancer.
 module: nodebalancer_info

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -186,6 +186,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode NodeBalancer Nodes.
 module: nodebalancer_node

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -26,6 +26,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Object Storage Cluster.
 module: object_cluster_info

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -26,6 +26,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage Linode Object Storage Keys.
 module: object_keys

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -26,6 +26,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode VLAN.
 module: vlan_info

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -27,6 +27,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Manage a Linode Volume.
 module: volume

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -26,6 +26,7 @@ author:
 - Charles Kenney (@charliekenney23)
 - Phillip Campbell (@phillc)
 - Lena Garber (@lbgarber)
+- Jacob Riddle (@jriddle)
 description:
 - Get info about a Linode Volume.
 module: volume_info

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,2 @@
 [testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/Users/lgarber/Projects/ansible/ansible_collections/ven/bin/python"
+testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/usr/bin/python3"

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: firewall_device_basic
+- name: firewall_device
   block:
     - name: Create a Linode Instance
       linode.cloud.instance:
@@ -29,8 +29,8 @@
         api_token: '{{ api_token }}'
         api_version: v4beta
         firewall_id: '{{ fw.firewall.id }}'
-        device_id: '{{ inst.instance.id }}'
-        device_type: 'linode'
+        entity_id: '{{ inst.instance.id }}'
+        entity_type: 'linode'
         state: present
       register: fw_device
 
@@ -45,8 +45,8 @@
         - linode.cloud.firewall_device:
             api_token: '{{ api_token }}'
             firewall_id: '{{ fw.firewall.id }}'
-            device_id: '{{ inst.instance.id }}'
-            device_type: 'linode'
+            entity_id: '{{ inst.instance.id }}'
+            entity_type: 'linode'
             state: absent
 
         - linode.cloud.instance:

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: firewall_basic
+- name: firewall_device_basic
   block:
     - name: Create a Linode Instance
       linode.cloud.instance:
@@ -28,13 +28,13 @@
       linode.cloud.firewall_device:
         api_token: '{{ api_token }}'
         api_version: v4beta
-        firewall_id: fw.firewall.id
-        firewall_device_id: inst.instance.id
-        firewall_device_type: 'linode'
+        firewall_id: '{{ fw.firewall.id }}'
+        device_id: '{{ inst.instance.id }}'
+        device_type: 'linode'
         state: present
       register: fw_device
 
-    - name: Assert firewall created
+    - name: Assert firewall device added
       assert:
         that:
           - fw_device.changed
@@ -45,8 +45,8 @@
         - linode.cloud.firewall_device:
             api_token: '{{ api_token }}'
             firewall_id: '{{ fw.firewall.id }}'
-            firewall_device_id: '{{ inst.instance.id }}'
-            firewall_device_type: 'linode'
+            device_id: '{{ inst.instance.id }}'
+            device_type: 'linode'
             state: absent
 
         - linode.cloud.instance:

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -1,0 +1,60 @@
+- name: firewall_basic
+  block:
+    - name: Create a Linode Instance
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ ansible_date_time.epoch }}'
+        region: us-southeast
+        type: g6-standard-1
+        image: linode/alpine3.13
+        state: present
+      register: inst
+
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: 'ansible-test-{{ ansible_date_time.epoch }}'
+        devices: []
+        rules:
+          inbound: []
+          inbound_policy: DROP
+          outbound: []
+          outbound_policy: DROP
+        state: present
+      register: fw
+
+    - name: Add Device to Linode Firewall
+      linode.cloud.firewall_device:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        firewall_id: fw.firewall.id
+        firewall_device_id: inst.instance.id
+        firewall_device_type: 'linode'
+        state: present
+      register: fw_device
+
+    - name: Assert firewall created
+      assert:
+        that:
+          - fw_device.changed
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.firewall_device:
+            api_token: '{{ api_token }}'
+            firewall_id: '{{ fw.firewall.id }}'
+            firewall_device_id: '{{ inst.instance.id }}'
+            firewall_device_type: 'linode'
+            state: absent
+
+        - linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ inst.instance.label }}'
+            state: absent
+
+        - linode.cloud.firewall:
+            api_token: '{{ api_token }}'
+            label: '{{ fw.firewall.label }}'
+            state: absent

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -39,6 +39,21 @@
         that:
           - fw_device.changed
 
+    - name: Add Existing Device to Linode Firewall
+      linode.cloud.firewall_device:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        firewall_id: '{{ fw.firewall.id }}'
+        entity_id: '{{ inst.instance.id }}'
+        entity_type: 'linode'
+        state: present
+      register: fw_device2
+
+    - name: Assert firewall device not added
+      assert:
+        that:
+          - not fw_device2.changed
+
   always:
     - ignore_errors: yes
       block:


### PR DESCRIPTION
adding a module to allow altering firewall devices with an existing firewall not managed by ansible

```yaml
linode.cloud.firewall_device:
 firewall_id: 1234
 device_id: 12335465
 device_type: 'linode'
 state: present
```

```bash
make TEST_ARGS='-v firewall_device' test
```