### PR TITLE
fix: Resolve missing module error with doc fragments

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -36,7 +36,7 @@ jobs:
       - run: make TEST_ARGS="-v ${{ github.event.client_payload.slash_command.tests }}" test
         if: ${{ steps.validate-tests.outputs.match == '' }}
         env:
-          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+          LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 
       - uses: actions/github-script@v5
         id: update-check-run

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ integration-test: $(INTEGRATION_CONFIG)
 test: integration-test
 
 $(INTEGRATION_CONFIG):
-	@if test "$(LINODE_API_TOKEN)" = "" ; then \
+	@if test "$(LINODE_API_TOKEN)" = "" && "$(LINODE_TOKEN)" = ""; then \
 	  echo "LINODE_API_TOKEN must be set"; \
 	  exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -19,23 +19,23 @@ PEP440 is the schema used to describe the versions of Ansible.
 ### Modules
 Name | Description
 --- | ---
-[linode.cloud.domain](docs/modules/domain.md)|Create and destroy domains.
-[linode.cloud.domain_info](docs/modules/domain_info.md)|Gather info about an existing domain.
-[linode.cloud.domain_record](docs/modules/domain_record.md)|Create and destroy domain records.
-[linode.cloud.domain_record_info](docs/modules/domain_record_info.md)|Gather info about an existing domain record.
-[linode.cloud.firewall](docs/modules/firewall.md)|Create and destroy Firewalls.
-[linode.cloud.firewall_info](docs/modules/firewall_info.md)|Gather info about an existing Firewall.
-[linode.cloud.firewall_device](docs/modules/firewall_device.md)|Manage Firewall Devices.
-[linode.cloud.instance](docs/modules/instance.md)|Create and destroy Linodes.
-[linode.cloud.instance_info](docs/modules/instance_info.md)|Gather info about an existing Linode instance.
-[linode.cloud.nodebalancer](docs/modules/nodebalancer.md)|Create, destroy, and configure NodeBalancers.
-[linode.cloud.nodebalancer_info](docs/modules/nodebalancer_info.md)|Gather info about an existing NodeBalancer.
-[linode.cloud.nodebalancer_node](docs/modules/nodebalancer_node.md)|Manage NodeBalancer nodes.
-[linode.cloud.object_cluster_info](docs/modules/object_cluster_info.md)|Gather info about Object Storage clusters.
-[linode.cloud.object_keys](docs/modules/object_keys.md)|Create and destroy Object Storage keys.
-[linode.cloud.vlan_info](docs/modules/vlan_info.md)|Gather info about an existing Linode VLAN.
-[linode.cloud.volume](docs/modules/volume.md)|Create, destroy, and attach Linode volumes.
-[linode.cloud.volume_info](docs/modules/volume_info.md)|Gather info about an existing Linode volume.
+[linode.cloud.domain](https://github.com/linode/ansible_linode/blob/main/docs/modules/domain.md)|Create and destroy domains.
+[linode.cloud.domain_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/domain_info.md)|Gather info about an existing domain.
+[linode.cloud.domain_record](https://github.com/linode/ansible_linode/blob/main/docs/modules/domain_record.md)|Create and destroy domain records.
+[linode.cloud.domain_record_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/domain_record_info.md)|Gather info about an existing domain record.
+[linode.cloud.firewall](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall.md)|Create and destroy Firewalls.
+[linode.cloud.firewall_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall_info.md)|Gather info about an existing Firewall.
+[linode.cloud.firewall_device](https://github.com/linode/ansible_linode/blob/main/docs/modules/firewall_device.md)|Manage Firewall Devices.
+[linode.cloud.instance](https://github.com/linode/ansible_linode/blob/main/docs/modules/instance.md)|Create and destroy Linodes.
+[linode.cloud.instance_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/instance_info.md)|Gather info about an existing Linode instance.
+[linode.cloud.nodebalancer](https://github.com/linode/ansible_linode/blob/main/docs/modules/nodebalancer.md)|Create, destroy, and configure NodeBalancers.
+[linode.cloud.nodebalancer_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/nodebalancer_info.md)|Gather info about an existing NodeBalancer.
+[linode.cloud.nodebalancer_node](https://github.com/linode/ansible_linode/blob/main/docs/modules/nodebalancer_node.md)|Manage NodeBalancer nodes.
+[linode.cloud.object_cluster_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/object_cluster_info.md)|Gather info about Object Storage clusters.
+[linode.cloud.object_keys](https://github.com/linode/ansible_linode/blob/main/docs/modules/object_keys.md)|Create and destroy Object Storage keys.
+[linode.cloud.vlan_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/vlan_info.md)|Gather info about an existing Linode VLAN.
+[linode.cloud.volume](https://github.com/linode/ansible_linode/blob/main/docs/modules/volume.md)|Create, destroy, and attach Linode volumes.
+[linode.cloud.volume_info](https://github.com/linode/ansible_linode/blob/main/docs/modules/volume_info.md)|Gather info about an existing Linode volume.
 
 ### Inventory
 Name | Description

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -1,6 +1,6 @@
 # domain_record_info
 
-Get info about a Linode Domain Records.
+Get info about a Linode Domain Record.
 
 
 - [Examples](#examples)

--- a/docs/modules/nodebalancer_node.md
+++ b/docs/modules/nodebalancer_node.md
@@ -20,7 +20,7 @@ Manage Linode NodeBalancer Nodes.
         protocol: http
         algorithm: roundrobin
   register: nodebalancer_result
-        
+
 - name: Create an Instance
   linode.cloud.instance:
     label: my-instance
@@ -29,12 +29,12 @@ Manage Linode NodeBalancer Nodes.
     type: g6-standard-1
     state: present
   register: instance_result
-    
+
 - name: Attach the Instance to the NodeBalancer
   linode.cloud.nodebalancer_node:
     nodebalancer_id: nodebalancer_result.node_balancer.id
     config_id: nodebalancer_result.configs[0].id
-    
+
     label: my-node
 
     # Use the private ip address of the instance

--- a/docs/modules/volume_info.md
+++ b/docs/modules/volume_info.md
@@ -13,7 +13,7 @@ Get info about a Linode Volume.
 - name: Get info about a volume by label
   linode.cloud.volume_info:
     label: example-volume
-    
+
 - name: Get info about a volume by id
   linode.cloud.volume_info:
     id: 12345

--- a/plugins/module_utils/doc_fragments/domain.py
+++ b/plugins/module_utils/doc_fragments/domain.py
@@ -1,0 +1,48 @@
+specdoc_examples = ['''
+- name: Create a domain 
+  linode.cloud.domain:
+    domain: my-domain.com
+    type: master
+    state: present''', '''
+- name: Delete a domain
+  linode.cloud.domain:
+    domain: my-domain.com
+    state: absent''']
+
+result_domain_samples = ['''{
+  "axfr_ips": [],
+  "description": null,
+  "domain": "example.org",
+  "expire_sec": 300,
+  "group": null,
+  "id": 1234,
+  "master_ips": [],
+  "refresh_sec": 300,
+  "retry_sec": 300,
+  "soa_email": "admin@example.org",
+  "status": "active",
+  "tags": [
+    "example tag",
+    "another example"
+  ],
+  "ttl_sec": 300,
+  "type": "master"
+}''']
+
+result_records_samples = ['''[
+  {
+    "created": "2018-01-01T00:01:01",
+    "id": 123456,
+    "name": "test",
+    "port": 80,
+    "priority": 50,
+    "protocol": null,
+    "service": null,
+    "tag": null,
+    "target": "192.0.2.0",
+    "ttl_sec": 604800,
+    "type": "A",
+    "updated": "2018-01-01T00:01:01",
+    "weight": 50
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/domain.py
+++ b/plugins/module_utils/doc_fragments/domain.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the domain module"""
+
 specdoc_examples = ['''
 - name: Create a domain 
   linode.cloud.domain:

--- a/plugins/module_utils/doc_fragments/domain_info.py
+++ b/plugins/module_utils/doc_fragments/domain_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the domain_info module"""
+
 specdoc_examples = ['''
 - name: Get info about a domain by domain
   linode.cloud.domain_info:

--- a/plugins/module_utils/doc_fragments/domain_info.py
+++ b/plugins/module_utils/doc_fragments/domain_info.py
@@ -1,0 +1,7 @@
+specdoc_examples = ['''
+- name: Get info about a domain by domain
+  linode.cloud.domain_info:
+    domain: my-domain.com''', '''
+- name: Get info about a domain by id
+  linode.cloud.domain_info:
+    id: 12345''']

--- a/plugins/module_utils/doc_fragments/domain_record.py
+++ b/plugins/module_utils/doc_fragments/domain_record.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the domain_record module"""
+
 specdoc_examples = ['''
 - name: Create an A record
   linode.cloud.domain_record:

--- a/plugins/module_utils/doc_fragments/domain_record.py
+++ b/plugins/module_utils/doc_fragments/domain_record.py
@@ -1,0 +1,29 @@
+specdoc_examples = ['''
+- name: Create an A record
+  linode.cloud.domain_record:
+    domain: my-domain.com
+    name: my-subdomain
+    type: 'A'
+    target: '127.0.0.1'
+    state: present''', '''
+- name: Delete a domain record
+  linode.cloud.domain:
+    domain: my-domain.com
+    name: my-subdomain
+    state: absent''']
+
+result_record_samples = ['''{
+  "created": "2018-01-01T00:01:01",
+  "id": 123456,
+  "name": "test",
+  "port": 80,
+  "priority": 50,
+  "protocol": null,
+  "service": null,
+  "tag": null,
+  "target": "192.0.2.0",
+  "ttl_sec": 604800,
+  "type": "A",
+  "updated": "2018-01-01T00:01:01",
+  "weight": 50
+}''']

--- a/plugins/module_utils/doc_fragments/domain_record_info.py
+++ b/plugins/module_utils/doc_fragments/domain_record_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the domain_record_info module"""
+
 specdoc_examples = ['''
 - name: Get info about domain records by name
   linode.cloud.domain_record_info:

--- a/plugins/module_utils/doc_fragments/domain_record_info.py
+++ b/plugins/module_utils/doc_fragments/domain_record_info.py
@@ -1,0 +1,11 @@
+specdoc_examples = ['''
+- name: Get info about domain records by name
+  linode.cloud.domain_record_info:
+    domain: my-domain.com
+    name: my-subdomain
+    type: A
+    target: 0.0.0.0''', '''
+- name: Get info about a domain record by id
+  linode.cloud.domain_info:
+    domain: my-domain.com
+    id: 12345''']

--- a/plugins/module_utils/doc_fragments/firewall.py
+++ b/plugins/module_utils/doc_fragments/firewall.py
@@ -1,0 +1,102 @@
+specdoc_examples = ['''
+- name: Create a Linode Firewall
+  linode.cloud.firewall:
+    label: 'my-firewall'
+    devices:
+      - id: 123
+        type: linode
+    rules:
+      inbound_policy: DROP
+      inbound:
+        - label: allow-http-in
+          addresses:
+            ipv4:
+              - 0.0.0.0/0
+            ipv6:
+              - 'ff00::/8'
+          description: Allow inbound HTTP and HTTPS connections.
+          ports: '80,443'
+          protocol: TCP
+          action: ACCEPT
+
+      outbound_policy: DROP
+      outbound:
+        - label: allow-http-out
+          addresses:
+            ipv4:
+              - 0.0.0.0/0
+            ipv6:
+              - 'ff00::/8'
+          description: Allow outbound HTTP and HTTPS connections.
+          ports: '80,443'
+          protocol: TCP
+          action: ACCEPT
+    state: present''', '''
+- name: Delete a Linode Firewall
+  linode.cloud.firewall:
+    label: 'my-firewall'
+    state: absent''']
+
+result_firewall_samples = ['''{
+  "created": "2018-01-01T00:01:01",
+  "id": 123,
+  "label": "firewall123",
+  "rules": {
+    "inbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24"
+          ],
+          "ipv6": [
+            "2001:DB8::/32"
+          ]
+        },
+        "description": "An example firewall rule description.",
+        "label": "firewallrule123",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "inbound_policy": "DROP",
+    "outbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24"
+          ],
+          "ipv6": [
+            "2001:DB8::/32"
+          ]
+        },
+        "description": "An example firewall rule description.",
+        "label": "firewallrule123",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "outbound_policy": "DROP"
+  },
+  "status": "enabled",
+  "tags": [
+    "example tag",
+    "another example"
+  ],
+  "updated": "2018-01-02T00:01:01"
+}''']
+
+result_devices_samples = ['''[
+  {
+    "created": "2018-01-01T00:01:01",
+    "entity": {
+      "id": 123,
+      "label": "my-linode",
+      "type": "linode",
+      "url": "/v4/linode/instances/123"
+    },
+    "id": 123,
+    "updated": "2018-01-02T00:01:01"
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/firewall.py
+++ b/plugins/module_utils/doc_fragments/firewall.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the firewall module"""
+
 specdoc_examples = ['''
 - name: Create a Linode Firewall
   linode.cloud.firewall:

--- a/plugins/module_utils/doc_fragments/firewall_device.py
+++ b/plugins/module_utils/doc_fragments/firewall_device.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the firewall_device module"""
+
 specdoc_examples = ['''
 - name: Create a Firewall
   linode.cloud.firewall:

--- a/plugins/module_utils/doc_fragments/firewall_device.py
+++ b/plugins/module_utils/doc_fragments/firewall_device.py
@@ -1,0 +1,36 @@
+specdoc_examples = ['''
+- name: Create a Firewall
+  linode.cloud.firewall:
+    label: my-firewall
+    rules:
+      inbound_policy: DROP
+    state: present
+  register: firewall_result
+
+- name: Create an Instance
+  linode.cloud.instance:
+    label: my-instance
+    region: us-east
+    private_ip: true
+    type: g6-standard-1
+    state: present
+  register: instance_result
+
+- name: Attach the instance to the Firewall
+  linode.cloud.firewall_device:
+    firewall_id: '{{ firewall_result.firewall.id }}'
+    entity_id: '{{ instance_result.instance.id }}'
+    entity_type: 'linode'
+    state: present''']
+
+result_device_samples = ['''{
+  "created": "2018-01-01T00:01:01",
+  "entity": {
+    "id": 123,
+    "label": "my-linode",
+    "type": "linode",
+    "url": "/v4/linode/instances/123"
+  },
+  "id": 123,
+  "updated": "2018-01-02T00:01:01"
+}''']

--- a/plugins/module_utils/doc_fragments/firewall_info.py
+++ b/plugins/module_utils/doc_fragments/firewall_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the firewall_info module"""
+
 specdoc_examples = ['''
 - name: Get info about a Firewall by label
   linode.cloud.firewall_info:

--- a/plugins/module_utils/doc_fragments/firewall_info.py
+++ b/plugins/module_utils/doc_fragments/firewall_info.py
@@ -1,0 +1,7 @@
+specdoc_examples = ['''
+- name: Get info about a Firewall by label
+  linode.cloud.firewall_info:
+    label: 'my-firewall' ''', '''
+- name: Get info about a Firewall by id
+  linode.cloud.firewall_info:
+    id: 12345''']

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the instance module"""
+
 specdoc_examples = ['''
 - name: Create a new Linode instance.
   linode.cloud.instance:

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -1,0 +1,139 @@
+specdoc_examples = ['''
+- name: Create a new Linode instance.
+  linode.cloud.instance:
+    label: my-linode
+    type: g6-nanode-1
+    region: us-east
+    image: linode/ubuntu20.04
+    root_pass: verysecurepassword!!!
+    private_ip: false
+    authorized_keys:
+      - "ssh-rsa ..."
+    stackscript_id: 1337
+    stackscript_data:
+      variable: value
+    group: app
+    tags:
+      - env=prod
+    state: present''', '''
+- name: Delete a Linode instance.
+  linode.cloud.instance:
+    label: my-linode
+    state: absent''']
+
+result_instance_samples = ['''{
+  "alerts": {
+    "cpu": 180,
+    "io": 10000,
+    "network_in": 10,
+    "network_out": 10,
+    "transfer_quota": 80
+  },
+  "backups": {
+    "enabled": true,
+    "last_successful": "2018-01-01T00:01:01",
+    "schedule": {
+      "day": "Saturday",
+      "window": "W22"
+    }
+  },
+  "created": "2018-01-01T00:01:01",
+  "group": "Linode-Group",
+  "hypervisor": "kvm",
+  "id": 123,
+  "image": "linode/debian10",
+  "ipv4": [
+    "203.0.113.1",
+    "192.0.2.1"
+  ],
+  "ipv6": "c001:d00d::1337/128",
+  "label": "linode123",
+  "region": "us-east",
+  "specs": {
+    "disk": 81920,
+    "memory": 4096,
+    "transfer": 4000,
+    "vcpus": 2
+  },
+  "status": "running",
+  "tags": [
+    "example tag",
+    "another example"
+  ],
+  "type": "g6-standard-1",
+  "updated": "2018-01-01T00:01:01",
+  "watchdog_enabled": true
+}''']
+
+result_configs_samples = ['''[
+  {
+    "comments": "This is my main Config",
+    "devices": {
+      "sda": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdb": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdc": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdd": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sde": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdf": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdg": {
+        "disk_id": 124458,
+        "volume_id": null
+      },
+      "sdh": {
+        "disk_id": 124458,
+        "volume_id": null
+      }
+    },
+    "helpers": {
+      "devtmpfs_automount": false,
+      "distro": true,
+      "modules_dep": true,
+      "network": true,
+      "updatedb_disabled": true
+    },
+    "id": 23456,
+    "interfaces": [
+      {
+        "ipam_address": "10.0.0.1/24",
+        "label": "example-interface",
+        "purpose": "vlan"
+      }
+    ],
+    "kernel": "linode/latest-64bit",
+    "label": "My Config",
+    "memory_limit": 2048,
+    "root_device": "/dev/sda",
+    "run_level": "default",
+    "virt_mode": "paravirt"
+  }
+]''']
+
+result_disks_samples = ['''[
+  {
+    "created": "2018-01-01T00:01:01",
+    "filesystem": "ext4",
+    "id": 25674,
+    "label": "Debian 9 Disk",
+    "size": 48640,
+    "status": "ready",
+    "updated": "2018-01-01T00:01:01"
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/instance_info.py
+++ b/plugins/module_utils/doc_fragments/instance_info.py
@@ -1,0 +1,7 @@
+specdoc_examples = ['''
+- name: Get info about an instance by label
+  linode.cloud.instance_info:
+    label: 'my-instance' ''', '''
+- name: Get info about an instance by id
+  linode.cloud.instance_info:
+    id: 12345''']

--- a/plugins/module_utils/doc_fragments/instance_info.py
+++ b/plugins/module_utils/doc_fragments/instance_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the instance_info module"""
+
 specdoc_examples = ['''
 - name: Get info about an instance by label
   linode.cloud.instance_info:

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -1,0 +1,82 @@
+
+specdoc_examples = ['''
+- name: Create a Linode NodeBalancer
+  linode.cloud.nodebalancer:
+    label: my-loadbalancer
+    region: us-east
+    tags: [ prod-env ]
+    state: present
+    configs:
+      - port: 80
+        protocol: http
+        algorithm: roundrobin
+        nodes:
+          - label: node1
+            address: 0.0.0.0:80''', '''
+- name: Delete the NodeBalancer
+  linode.cloud.nodebalancer:
+    label: my-loadbalancer
+    region: us-east
+    state: absent''']
+
+result_node_balancer_samples = ['''{
+  "client_conn_throttle": 0,
+  "created": "2018-01-01T00:01:01",
+  "hostname": "192.0.2.1.ip.linodeusercontent.com",
+  "id": 12345,
+  "ipv4": "12.34.56.78",
+  "ipv6": null,
+  "label": "balancer12345",
+  "region": "us-east",
+  "tags": [
+    "example tag",
+    "another example"
+  ],
+  "transfer": {
+    "in": 28.91200828552246,
+    "out": 3.5487728118896484,
+    "total": 32.46078109741211
+  },
+  "updated": "2018-03-01T00:01:01"
+}''']
+
+result_configs_samples = ['''[
+  {
+    "algorithm": "roundrobin",
+    "check": "http_body",
+    "check_attempts": 3,
+    "check_body": "it works",
+    "check_interval": 90,
+    "check_passive": true,
+    "check_path": "/test",
+    "check_timeout": 10,
+    "cipher_suite": "recommended",
+    "id": 4567,
+    "nodebalancer_id": 12345,
+    "nodes_status": {
+      "down": 0,
+      "up": 4
+    },
+    "port": 80,
+    "protocol": "http",
+    "proxy_protocol": "none",
+    "ssl_cert": null,
+    "ssl_commonname": null,
+    "ssl_fingerprint": null,
+    "ssl_key": null,
+    "stickiness": "http_cookie"
+  }
+]''']
+
+result_nodes_samples = ['''[
+  {
+    "address": "192.168.210.120:80",
+    "config_id": 4567,
+    "id": 54321,
+    "label": "node54321",
+    "mode": "accept",
+    "nodebalancer_id": 12345,
+    "status": "UP",
+    "weight": 50
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -1,3 +1,4 @@
+"""Documentation fragments for the nodebalanacer module"""
 
 specdoc_examples = ['''
 - name: Create a Linode NodeBalancer

--- a/plugins/module_utils/doc_fragments/nodebalancer_info.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the nodebalancer_info module"""
+
 specdoc_examples = ['''
 - name: Get a NodeBalancer by its id
   linode.cloud.nodebalancer_info:

--- a/plugins/module_utils/doc_fragments/nodebalancer_info.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_info.py
@@ -1,0 +1,7 @@
+specdoc_examples = ['''
+- name: Get a NodeBalancer by its id
+  linode.cloud.nodebalancer_info:
+    id: 12345''', '''
+- name: Get a NodeBalancer by its label
+  linode.cloud.nodebalancer_info:
+    label: cool_nodebalancer''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_node.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_node.py
@@ -1,0 +1,43 @@
+specdoc_examples = ['''
+- name: Create a NodeBalancer
+  linode.cloud.nodebalancer:
+    label: my-nodebalancer
+    region: us-east
+    state: present
+    configs:
+      - port: 80
+        protocol: http
+        algorithm: roundrobin
+  register: nodebalancer_result
+
+- name: Create an Instance
+  linode.cloud.instance:
+    label: my-instance
+    region: us-east
+    private_ip: true
+    type: g6-standard-1
+    state: present
+  register: instance_result
+
+- name: Attach the Instance to the NodeBalancer
+  linode.cloud.nodebalancer_node:
+    nodebalancer_id: nodebalancer_result.node_balancer.id
+    config_id: nodebalancer_result.configs[0].id
+
+    label: my-node
+
+    # Use the private ip address of the instance
+    address: '{{ instance_result.instance.ipv4[1] }}:80'
+
+    state: present''']
+
+result_node_samples = ['''{
+  "address": "123.123.123.123:80",
+  "config_id": 12345,
+  "id": 12345,
+  "label": "mynode",
+  "mode": "accept",
+  "nodebalancer_id": 12345,
+  "status": "Unknown",
+  "weight": 10
+}''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_node.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_node.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the nodebalancer_node module"""
+
 specdoc_examples = ['''
 - name: Create a NodeBalancer
   linode.cloud.nodebalancer:

--- a/plugins/module_utils/doc_fragments/object_cluster_info.py
+++ b/plugins/module_utils/doc_fragments/object_cluster_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the object_cluster_info module"""
+
 specdoc_examples = ['''
 - name: Get info about clusters in us-east
   linode.cloud.object_cluster_info:

--- a/plugins/module_utils/doc_fragments/object_cluster_info.py
+++ b/plugins/module_utils/doc_fragments/object_cluster_info.py
@@ -1,0 +1,17 @@
+specdoc_examples = ['''
+- name: Get info about clusters in us-east
+  linode.cloud.object_cluster_info:
+    region: us-east''', '''
+- name: Get info about the cluster with id us-east-1
+  linode.cloud.object_cluster_info:
+    id: us-east-1''']
+
+result_clusters_samples = ['''[
+  {
+    "domain": "us-east-1.linodeobjects.com",
+    "id": "us-east-1",
+    "region": "us-east",
+    "static_site_domain": "website-us-east-1.linodeobjects.com",
+    "status": "available"
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/object_keys.py
+++ b/plugins/module_utils/doc_fragments/object_keys.py
@@ -1,0 +1,32 @@
+specdoc_examples = ['''
+- name: Create an Object Storage key
+  linode.cloud.object_keys:
+    label: 'my-fullaccess-key'
+    state: present''', '''
+- name: Create a limited Object Storage key
+  linode.cloud.object_keys:
+    label: 'my-limited-key'
+    access:
+      - cluster: us-east-1
+        bucket_name: my-bucket
+        permissions: read_write
+    state: present''', '''
+- name: Remove an object storage key
+  linode.cloud.object_keys:
+    label: 'my-key'
+    state: absent''']
+
+result_key_samples = ['''{
+  "access_key": "KVAKUTGBA4WTR2NSJQ81",
+  "bucket_access": [
+    {
+      "bucket_name": "example-bucket",
+      "cluster": "ap-south-1",
+      "permissions": "read_only"
+    }
+  ],
+  "id": 123,
+  "label": "my-key",
+  "limited": true,
+  "secret_key": "OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"
+}''']

--- a/plugins/module_utils/doc_fragments/object_keys.py
+++ b/plugins/module_utils/doc_fragments/object_keys.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the object_keys module"""
+
 specdoc_examples = ['''
 - name: Create an Object Storage key
   linode.cloud.object_keys:

--- a/plugins/module_utils/doc_fragments/vlan_info.py
+++ b/plugins/module_utils/doc_fragments/vlan_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the vlan_info module"""
+
 specdoc_examples = ['''
 - name: Get info about a VLAN by label
   linode.cloud.vlan_info:

--- a/plugins/module_utils/doc_fragments/vlan_info.py
+++ b/plugins/module_utils/doc_fragments/vlan_info.py
@@ -1,0 +1,14 @@
+specdoc_examples = ['''
+- name: Get info about a VLAN by label
+  linode.cloud.vlan_info:
+    label: example-vlan''']
+
+result_vlan_samples = ['''{
+  "created": "2020-01-01T00:01:01",
+  "label": "vlan-example",
+  "linodes": [
+    111,
+    222
+  ],
+  "region": "ap-west"
+}''']

--- a/plugins/module_utils/doc_fragments/volume.py
+++ b/plugins/module_utils/doc_fragments/volume.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the volume module"""
+
 specdoc_examples = ['''
 - name: Create a volume attached to an instance
   linode.cloud.volume:

--- a/plugins/module_utils/doc_fragments/volume.py
+++ b/plugins/module_utils/doc_fragments/volume.py
@@ -1,0 +1,46 @@
+specdoc_examples = ['''
+- name: Create a volume attached to an instance
+  linode.cloud.volume:
+    label: example-volume
+    region: us-east
+    size: 30
+    linode_id: 12345
+    state: present''', '''
+- name: Create an unattached volume
+  linode.cloud.volume:
+    label: example-volume
+    region: us-east
+    size: 30
+    state: present''', '''
+- name: Resize a volume
+  linode.cloud.volume:
+    label: example-volume
+    size: 50
+    state: present''', '''
+- name: Detach a volume
+  linode.cloud.volume:
+    label: example-volume
+    attached: false
+    state: present''', '''
+- name: Delete a volume
+  linode.cloud.volume:
+    label: example-volume
+    state: absent''']
+
+result_volume_samples = ['''{
+  "created": "2018-01-01T00:01:01",
+  "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_my-volume",
+  "hardware_type": "nvme",
+  "id": 12345,
+  "label": "my-volume",
+  "linode_id": 12346,
+  "linode_label": "linode123",
+  "region": "us-east",
+  "size": 30,
+  "status": "active",
+  "tags": [
+    "example tag",
+    "another example"
+  ],
+  "updated": "2018-01-01T00:01:01"
+}''']

--- a/plugins/module_utils/doc_fragments/volume_info.py
+++ b/plugins/module_utils/doc_fragments/volume_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the volume_info module"""
+
 specdoc_examples = ['''
 - name: Get info about a volume by label
   linode.cloud.volume_info:

--- a/plugins/module_utils/doc_fragments/volume_info.py
+++ b/plugins/module_utils/doc_fragments/volume_info.py
@@ -1,0 +1,8 @@
+specdoc_examples = ['''
+- name: Get info about a volume by label
+  linode.cloud.volume_info:
+    label: example-volume
+
+- name: Get info about a volume by id
+  linode.cloud.volume_info:
+    id: 12345''']

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -129,6 +129,7 @@ class LinodeModuleBase:
                 api_token,
                 base_url='https://api.linode.com/{0}'.format(api_version),
                 user_agent=COLLECTION_USER_AGENT,
+                retry_rate_limit_interval=10,
             )
 
         return self._client

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -16,6 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain as docs
+
 linode_domain_spec = dict(
     # Unused for domain objects
     label=dict(type='str', required=False, doc_hide=True),
@@ -62,55 +64,6 @@ linode_domain_spec = dict(
     group=dict(type='str', doc_hide=True)
 )
 
-specdoc_examples = ['''
-- name: Create a domain 
-  linode.cloud.domain:
-    domain: my-domain.com
-    type: master
-    state: present''', '''
-- name: Delete a domain
-  linode.cloud.domain:
-    domain: my-domain.com
-    state: absent''']
-
-result_domain_samples = ['''{
-  "axfr_ips": [],
-  "description": null,
-  "domain": "example.org",
-  "expire_sec": 300,
-  "group": null,
-  "id": 1234,
-  "master_ips": [],
-  "refresh_sec": 300,
-  "retry_sec": 300,
-  "soa_email": "admin@example.org",
-  "status": "active",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "ttl_sec": 300,
-  "type": "master"
-}''']
-
-result_records_samples = ['''[
-  {
-    "created": "2018-01-01T00:01:01",
-    "id": 123456,
-    "name": "test",
-    "port": 80,
-    "priority": 50,
-    "protocol": null,
-    "service": null,
-    "tag": null,
-    "target": "192.0.2.0",
-    "ttl_sec": 604800,
-    "type": "A",
-    "updated": "2018-01-01T00:01:01",
-    "weight": 50
-  }
-]''']
-
 specdoc_meta = dict(
     description=[
         'Manage Linode Domains.'
@@ -118,19 +71,19 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_domain_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         domain=dict(
             description='The domain in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/domains/#domain-view',
             type='dict',
-            sample=result_domain_samples
+            sample=docs.result_domain_samples
         ),
         records=dict(
             description='The domain record in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/domains/#domain-record-view',
             type='list',
-            sample=result_records_samples
+            sample=docs.result_records_samples
         )
     )
 )

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -16,8 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-from ansible_collections.linode.cloud.plugins.modules.domain import specdoc_meta \
-    as domain_specdoc_meta
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_info as docs
 
 linode_domain_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
@@ -36,52 +36,6 @@ linode_domain_info_spec = dict(
                 ])
 )
 
-specdoc_examples = ['''
-- name: Get info about a domain by domain
-  linode.cloud.domain_info:
-    domain: my-domain.com''', '''
-- name: Get info about a domain by id
-  linode.cloud.domain_info:
-    id: 12345''']
-
-result_domain_samples = ['''{
-  "axfr_ips": [],
-  "description": null,
-  "domain": "example.org",
-  "expire_sec": 300,
-  "group": null,
-  "id": 1234,
-  "master_ips": [],
-  "refresh_sec": 300,
-  "retry_sec": 300,
-  "soa_email": "admin@example.org",
-  "status": "active",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "ttl_sec": 300,
-  "type": "master"
-}''']
-
-result_records_samples = ['''[
-  {
-    "created": "2018-01-01T00:01:01",
-    "id": 123456,
-    "name": "test",
-    "port": 80,
-    "priority": 50,
-    "protocol": null,
-    "service": null,
-    "tag": null,
-    "target": "192.0.2.0",
-    "ttl_sec": 604800,
-    "type": "A",
-    "updated": "2018-01-01T00:01:01",
-    "weight": 50
-  }
-]''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode Domain.'
@@ -89,8 +43,21 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_domain_info_spec,
-    examples=specdoc_examples,
-    return_values=domain_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        domain=dict(
+            description='The domain in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/domains/#domain-view',
+            type='dict',
+            sample=docs_parent.result_domain_samples
+        ),
+        records=dict(
+            description='The domain record in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/domains/#domain-record-view',
+            type='list',
+            sample=docs_parent.result_records_samples
+        )
+    )
 )
 
 linode_domain_valid_filters = [

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -16,6 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs
+
 linode_domain_record_spec = dict(
     # Unused for domain record objects
     label=dict(type='str', required=False, doc_hide=True),
@@ -80,36 +82,6 @@ linode_domain_record_spec = dict(
                             'used in the case of identical priority.')
 )
 
-specdoc_examples = ['''
-- name: Create an A record
-  linode.cloud.domain_record:
-    domain: my-domain.com
-    name: my-subdomain
-    type: 'A'
-    target: '127.0.0.1'
-    state: present''', '''
-- name: Delete a domain record
-  linode.cloud.domain:
-    domain: my-domain.com
-    name: my-subdomain
-    state: absent''']
-
-result_record_samples = ['''{
-  "created": "2018-01-01T00:01:01",
-  "id": 123456,
-  "name": "test",
-  "port": 80,
-  "priority": 50,
-  "protocol": null,
-  "service": null,
-  "tag": null,
-  "target": "192.0.2.0",
-  "ttl_sec": 604800,
-  "type": "A",
-  "updated": "2018-01-01T00:01:01",
-  "weight": 50
-}''']
-
 specdoc_meta = dict(
     description=[
         'Manage Linode Domain Records.',
@@ -118,13 +90,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_domain_record_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         record=dict(
             description='View a single Record on this Domain.',
             docs_url='https://www.linode.com/docs/api/domains/#domain-record-view',
             type='dict',
-            sample=result_record_samples
+            sample=docs.result_record_samples
         )
     )
 )

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -16,8 +16,10 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs_parent
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record_info as docs
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record \
+    as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record_info \
+    as docs
 
 linode_domain_record_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -52,7 +52,7 @@ linode_domain_record_info_spec = dict(
 
 specdoc_meta = dict(
     description=[
-        'Get info about a Linode Domain Records.'
+        'Get info about a Linode Domain Record.'
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -16,8 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-from ansible_collections.linode.cloud.plugins.modules.domain_record import specdoc_meta \
-    as domain_record_specdoc_meta
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record_info as docs
 
 linode_domain_record_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
@@ -48,34 +48,6 @@ linode_domain_record_info_spec = dict(
               ]),
 )
 
-specdoc_examples = ['''
-- name: Get info about domain records by name
-  linode.cloud.domain_record_info:
-    domain: my-domain.com
-    name: my-subdomain
-    type: A
-    target: 0.0.0.0''', '''
-- name: Get info about a domain record by id
-  linode.cloud.domain_info:
-    domain: my-domain.com
-    id: 12345''']
-
-result_record_samples = ['''{
-  "created": "2018-01-01T00:01:01",
-  "id": 123456,
-  "name": "test",
-  "port": 80,
-  "priority": 50,
-  "protocol": null,
-  "service": null,
-  "tag": null,
-  "target": "192.0.2.0",
-  "ttl_sec": 604800,
-  "type": "A",
-  "updated": "2018-01-01T00:01:01",
-  "weight": 50
-}''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode Domain Records.'
@@ -83,8 +55,15 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_domain_record_info_spec,
-    examples=specdoc_examples,
-    return_values=domain_record_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        record=dict(
+            description='View a single Record on this Domain.',
+            docs_url='https://www.linode.com/docs/api/domains/#domain-record-view',
+            type='dict',
+            sample=docs_parent.result_record_samples
+        )
+    )
 )
 
 

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -14,79 +14,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-EXAMPLES = '''
-'''
 
-RETURN = '''
-firewall:
-  description: The Firewall description in JSON serialized form.
-  linode_api_docs: "https://www.linode.com/docs/api/networking/#firewall-view"
-  returned: always
-  type: dict
-  sample: {
-   "created":"xxxxx",
-   "updated":"xxxxx",
-   "status":"enabled",
-   "id":xxxx,
-   "label":"my-firewall",
-   "rules":{
-      "inbound":[
-         {
-            "action":"ACCEPT",
-            "addresses":{
-               "ipv4":[
-                  "0.0.0.0/0"
-               ],
-               "ipv6":[
-                  "ff00::/8"
-               ]
-            },
-            "description":"Allow inbound HTTP and HTTPS connections.",
-            "label":"allow-http-in",
-            "ports":"80,443",
-            "protocol":"TCP"
-         }
-      ],
-      "inbound_policy":"DROP",
-      "outbound":[
-         {
-            "action":"ACCEPT",
-            "addresses":{
-               "ipv4":[
-                  "0.0.0.0/0"
-               ],
-               "ipv6":[
-                  "ff00::/8"
-               ]
-            },
-            "description":"Allow outbound HTTP and HTTPS connections.",
-            "label":"allow-http-out",
-            "ports":"80,443",
-            "protocol":"TCP"
-         }
-      ],
-      "outbound_policy":"DROP"
-   }
-}
-devices:
-  description: A list of Firewall devices JSON serialized form.
-  linode_api_docs: "https://www.linode.com/docs/api/networking/#firewall-device-view"
-  returned: always
-  type: list
-  sample: [
-   {
-      "created":"xxxxxx",
-      "entity":{
-         "id":xxxxxx,
-         "label":"my-device",
-         "type":"linode",
-         "url":"/v4/linode/instances/xxxxxx"
-      },
-      "id":xxxxxx,
-      "updated":"xxxxxx"
-   }
-]
-'''
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall as docs
 
 try:
     from linode_api4 import Firewall, FirewallDevice
@@ -187,108 +116,6 @@ linode_firewall_spec: dict = dict(
                choices=['present', 'absent'], required=True),
 )
 
-specdoc_examples = ['''
-- name: Create a Linode Firewall
-  linode.cloud.firewall:
-    label: 'my-firewall'
-    devices:
-      - id: 123
-        type: linode
-    rules:
-      inbound_policy: DROP
-      inbound:
-        - label: allow-http-in
-          addresses:
-            ipv4:
-              - 0.0.0.0/0
-            ipv6:
-              - 'ff00::/8'
-          description: Allow inbound HTTP and HTTPS connections.
-          ports: '80,443'
-          protocol: TCP
-          action: ACCEPT
-
-      outbound_policy: DROP
-      outbound:
-        - label: allow-http-out
-          addresses:
-            ipv4:
-              - 0.0.0.0/0
-            ipv6:
-              - 'ff00::/8'
-          description: Allow outbound HTTP and HTTPS connections.
-          ports: '80,443'
-          protocol: TCP
-          action: ACCEPT
-    state: present''', '''
-- name: Delete a Linode Firewall
-  linode.cloud.firewall:
-    label: 'my-firewall'
-    state: absent''']
-
-result_firewall_samples = ['''{
-  "created": "2018-01-01T00:01:01",
-  "id": 123,
-  "label": "firewall123",
-  "rules": {
-    "inbound": [
-      {
-        "action": "ACCEPT",
-        "addresses": {
-          "ipv4": [
-            "192.0.2.0/24"
-          ],
-          "ipv6": [
-            "2001:DB8::/32"
-          ]
-        },
-        "description": "An example firewall rule description.",
-        "label": "firewallrule123",
-        "ports": "22-24, 80, 443",
-        "protocol": "TCP"
-      }
-    ],
-    "inbound_policy": "DROP",
-    "outbound": [
-      {
-        "action": "ACCEPT",
-        "addresses": {
-          "ipv4": [
-            "192.0.2.0/24"
-          ],
-          "ipv6": [
-            "2001:DB8::/32"
-          ]
-        },
-        "description": "An example firewall rule description.",
-        "label": "firewallrule123",
-        "ports": "22-24, 80, 443",
-        "protocol": "TCP"
-      }
-    ],
-    "outbound_policy": "DROP"
-  },
-  "status": "enabled",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "updated": "2018-01-02T00:01:01"
-}''']
-
-result_devices_samples = ['''[
-  {
-    "created": "2018-01-01T00:01:01",
-    "entity": {
-      "id": 123,
-      "label": "my-linode",
-      "type": "linode",
-      "url": "/v4/linode/instances/123"
-    },
-    "id": 123,
-    "updated": "2018-01-02T00:01:01"
-  }
-]''']
 
 specdoc_meta = dict(
     description=[
@@ -297,19 +124,19 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_firewall_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         firewall=dict(
             description='The Firewall description in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/networking/#firewall-view',
             type='dict',
-            sample=result_firewall_samples
+            sample=docs.result_firewall_samples
         ),
         devices=dict(
             description='A list of Firewall devices JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/networking/#firewall-device-view',
             type='list',
-            sample=result_devices_samples
+            sample=docs.result_devices_samples
         )
     )
 )

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -14,6 +14,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_device as docs
+
 MODULE_SPEC = dict(
     firewall_id=dict(
         type='int', required=True,
@@ -42,42 +44,7 @@ MODULE_SPEC = dict(
                choices=['present', 'absent'], required=True),
 )
 
-specdoc_examples = ['''
-- name: Create a Firewall
-  linode.cloud.firewall:
-    label: my-firewall
-    rules:
-      inbound_policy: DROP
-    state: present
-  register: firewall_result
 
-- name: Create an Instance
-  linode.cloud.instance:
-    label: my-instance
-    region: us-east
-    private_ip: true
-    type: g6-standard-1
-    state: present
-  register: instance_result
-
-- name: Attach the instance to the Firewall
-  linode.cloud.firewall_device:
-    firewall_id: '{{ firewall_result.firewall.id }}'
-    entity_id: '{{ instance_result.instance.id }}'
-    entity_type: 'linode'
-    state: present''']
-
-result_device_samples = ['''{
-  "created": "2018-01-01T00:01:01",
-  "entity": {
-    "id": 123,
-    "label": "my-linode",
-    "type": "linode",
-    "url": "/v4/linode/instances/123"
-  },
-  "id": 123,
-  "updated": "2018-01-02T00:01:01"
-}''']
 
 specdoc_meta = dict(
     description=[
@@ -86,13 +53,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=MODULE_SPEC,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         device=dict(
             description='The Firewall Device in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/networking/#firewall-device-view__responses',
             type='dict',
-            sample=result_device_samples
+            sample=docs.result_device_samples
         )
     )
 )

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -16,8 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-from ansible_collections.linode.cloud.plugins.modules.firewall import specdoc_meta \
-    as firewall_specdoc_meta
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_info as docs
 
 linode_firewall_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
@@ -35,14 +35,6 @@ linode_firewall_info_spec = dict(
                ])
 )
 
-specdoc_examples = ['''
-- name: Get info about a Firewall by label
-  linode.cloud.firewall_info:
-    label: 'my-firewall' ''', '''
-- name: Get info about a Firewall by id
-  linode.cloud.firewall_info:
-    id: 12345''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode Firewall.'
@@ -50,8 +42,21 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_firewall_info_spec,
-    examples=specdoc_examples,
-    return_values=firewall_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        firewall=dict(
+            description='The Firewall description in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/networking/#firewall-view',
+            type='dict',
+            sample=docs_parent.result_firewall_samples
+        ),
+        devices=dict(
+            description='A list of Firewall devices JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/networking/#firewall-device-view',
+            type='list',
+            sample=docs_parent.result_devices_samples
+        )
+    )
 )
 
 linode_firewall_valid_filters = [

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -17,6 +17,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs
+
 try:
     from linode_api4 import Instance, Config, ConfigInterface, Disk, Volume
 except ImportError:
@@ -287,146 +289,6 @@ linode_instance_spec = dict(
         )
 )
 
-specdoc_examples = ['''
-- name: Create a new Linode instance.
-  linode.cloud.instance:
-    label: my-linode
-    type: g6-nanode-1
-    region: us-east
-    image: linode/ubuntu20.04
-    root_pass: verysecurepassword!!!
-    private_ip: false
-    authorized_keys:
-      - "ssh-rsa ..."
-    stackscript_id: 1337
-    stackscript_data:
-      variable: value
-    group: app
-    tags:
-      - env=prod
-    state: present''', '''
-- name: Delete a Linode instance.
-  linode.cloud.instance:
-    label: my-linode
-    state: absent''']
-
-result_instance_samples = ['''{
-  "alerts": {
-    "cpu": 180,
-    "io": 10000,
-    "network_in": 10,
-    "network_out": 10,
-    "transfer_quota": 80
-  },
-  "backups": {
-    "enabled": true,
-    "last_successful": "2018-01-01T00:01:01",
-    "schedule": {
-      "day": "Saturday",
-      "window": "W22"
-    }
-  },
-  "created": "2018-01-01T00:01:01",
-  "group": "Linode-Group",
-  "hypervisor": "kvm",
-  "id": 123,
-  "image": "linode/debian10",
-  "ipv4": [
-    "203.0.113.1",
-    "192.0.2.1"
-  ],
-  "ipv6": "c001:d00d::1337/128",
-  "label": "linode123",
-  "region": "us-east",
-  "specs": {
-    "disk": 81920,
-    "memory": 4096,
-    "transfer": 4000,
-    "vcpus": 2
-  },
-  "status": "running",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "type": "g6-standard-1",
-  "updated": "2018-01-01T00:01:01",
-  "watchdog_enabled": true
-}''']
-
-result_configs_samples = ['''[
-  {
-    "comments": "This is my main Config",
-    "devices": {
-      "sda": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdb": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdc": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdd": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sde": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdf": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdg": {
-        "disk_id": 124458,
-        "volume_id": null
-      },
-      "sdh": {
-        "disk_id": 124458,
-        "volume_id": null
-      }
-    },
-    "helpers": {
-      "devtmpfs_automount": false,
-      "distro": true,
-      "modules_dep": true,
-      "network": true,
-      "updatedb_disabled": true
-    },
-    "id": 23456,
-    "interfaces": [
-      {
-        "ipam_address": "10.0.0.1/24",
-        "label": "example-interface",
-        "purpose": "vlan"
-      }
-    ],
-    "kernel": "linode/latest-64bit",
-    "label": "My Config",
-    "memory_limit": 2048,
-    "root_device": "/dev/sda",
-    "run_level": "default",
-    "virt_mode": "paravirt"
-  }
-]''']
-
-result_disks_samples = ['''[
-  {
-    "created": "2018-01-01T00:01:01",
-    "filesystem": "ext4",
-    "id": 25674,
-    "label": "Debian 9 Disk",
-    "size": 48640,
-    "status": "ready",
-    "updated": "2018-01-01T00:01:01"
-  }
-]''']
-
 specdoc_meta = dict(
     description=[
         'Manage Linode Instances, Configs, and Disks.'
@@ -434,26 +296,26 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_instance_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         instance=dict(
             description=['The instance description in JSON serialized form.'],
             docs_url='https://www.linode.com/docs/api/linode-instances/#linode-view__responses',
             type='dict',
-            sample=result_instance_samples
+            sample=docs.result_instance_samples
         ),
         configs=dict(
             description=['A list of configs tied to this Linode Instance.'],
             docs_url='https://www.linode.com/docs/api/linode-instances/'
                      '#configuration-profile-view__responses',
             type='list',
-            sample=result_configs_samples
+            sample=docs.result_configs_samples
         ),
         disks=dict(
             description=['A list of disks tied to this Linode Instance.'],
             docs_url='https://www.linode.com/docs/api/linode-instances/#disk-view__responses',
             type='list',
-            sample=result_disks_samples
+            sample=docs.result_disks_samples
         )
     )
 )

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -16,8 +16,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-from ansible_collections.linode.cloud.plugins.modules.instance import specdoc_meta \
-    as instance_specdoc_meta
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_info as docs
 
 linode_instance_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
@@ -38,13 +38,6 @@ linode_instance_info_spec = dict(
         ])
 )
 
-specdoc_examples = ['''
-- name: Get info about an instance by label
-  linode.cloud.instance_info:
-    label: 'my-instance' ''', '''
-- name: Get info about an instance by id
-  linode.cloud.instance_info:
-    id: 12345''']
 
 specdoc_meta = dict(
     description=[
@@ -53,8 +46,28 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_instance_info_spec,
-    examples=specdoc_examples,
-    return_values=instance_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        instance=dict(
+            description=['The instance description in JSON serialized form.'],
+            docs_url='https://www.linode.com/docs/api/linode-instances/#linode-view__responses',
+            type='dict',
+            sample=docs_parent.result_instance_samples
+        ),
+        configs=dict(
+            description=['A list of configs tied to this Linode Instance.'],
+            docs_url='https://www.linode.com/docs/api/linode-instances/'
+                     '#configuration-profile-view__responses',
+            type='list',
+            sample=docs_parent.result_configs_samples
+        ),
+        disks=dict(
+            description=['A list of disks tied to this Linode Instance.'],
+            docs_url='https://www.linode.com/docs/api/linode-instances/#disk-view__responses',
+            type='list',
+            sample=docs_parent.result_disks_samples
+        )
+    )
 )
 
 linode_instance_valid_filters = [

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -18,6 +18,9 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer as docs
+
 # pylint: disable=unused-import
 from linode_api4 import NodeBalancer, NodeBalancerConfig, NodeBalancerNode, PaginatedList
 
@@ -158,87 +161,6 @@ linode_nodebalancer_spec = dict(
         description='A list of configs to apply to the NodeBalancer.')
 )
 
-specdoc_examples = ['''
-- name: Create a Linode NodeBalancer
-  linode.cloud.nodebalancer:
-    label: my-loadbalancer
-    region: us-east
-    tags: [ prod-env ]
-    state: present
-    configs:
-      - port: 80
-        protocol: http
-        algorithm: roundrobin
-        nodes:
-          - label: node1
-            address: 0.0.0.0:80''', '''
-- name: Delete the NodeBalancer
-  linode.cloud.nodebalancer:
-    label: my-loadbalancer
-    region: us-east
-    state: absent''']
-
-result_node_balancer_samples = ['''{
-  "client_conn_throttle": 0,
-  "created": "2018-01-01T00:01:01",
-  "hostname": "192.0.2.1.ip.linodeusercontent.com",
-  "id": 12345,
-  "ipv4": "12.34.56.78",
-  "ipv6": null,
-  "label": "balancer12345",
-  "region": "us-east",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "transfer": {
-    "in": 28.91200828552246,
-    "out": 3.5487728118896484,
-    "total": 32.46078109741211
-  },
-  "updated": "2018-03-01T00:01:01"
-}''']
-
-result_configs_samples = ['''[
-  {
-    "algorithm": "roundrobin",
-    "check": "http_body",
-    "check_attempts": 3,
-    "check_body": "it works",
-    "check_interval": 90,
-    "check_passive": true,
-    "check_path": "/test",
-    "check_timeout": 10,
-    "cipher_suite": "recommended",
-    "id": 4567,
-    "nodebalancer_id": 12345,
-    "nodes_status": {
-      "down": 0,
-      "up": 4
-    },
-    "port": 80,
-    "protocol": "http",
-    "proxy_protocol": "none",
-    "ssl_cert": null,
-    "ssl_commonname": null,
-    "ssl_fingerprint": null,
-    "ssl_key": null,
-    "stickiness": "http_cookie"
-  }
-]''']
-
-result_nodes_samples = ['''[
-  {
-    "address": "192.168.210.120:80",
-    "config_id": 4567,
-    "id": 54321,
-    "label": "node54321",
-    "mode": "accept",
-    "nodebalancer_id": 12345,
-    "status": "UP",
-    "weight": 50
-  }
-]''']
 
 specdoc_meta = dict(
     description=[
@@ -247,25 +169,25 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_nodebalancer_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         node_balancer=dict(
             description='The NodeBalancer in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses',
             type='dict',
-            sample=result_node_balancer_samples
+            sample=docs.result_node_balancer_samples
         ),
         configs=dict(
             description='A list of configs applied to the NodeBalancer.',
             docs_url='https://www.linode.com/docs/api/nodebalancers/#config-view__responses',
             type='list',
-            sample=result_configs_samples
+            sample=docs.result_configs_samples
         ),
         nodes=dict(
             description='A list of configs applied to the NodeBalancer.',
             docs_url='https://www.linode.com/docs/api/nodebalancers/#node-view',
             type='list',
-            sample=result_nodes_samples
+            sample=docs.result_nodes_samples
         )
     )
 )

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -12,11 +12,11 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
-from ansible_collections.linode.cloud.plugins.modules.nodebalancer import specdoc_meta \
-    as nodebalancer_specdoc_meta
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer as docs_parent
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_info as docs
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer\
+    as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_info\
+    as docs
 
 # pylint: disable=unused-import
 from linode_api4 import NodeBalancer, NodeBalancerConfig, NodeBalancerNode, PaginatedList, and_

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -15,6 +15,9 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import gl
 from ansible_collections.linode.cloud.plugins.modules.nodebalancer import specdoc_meta \
     as nodebalancer_specdoc_meta
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_info as docs
+
 # pylint: disable=unused-import
 from linode_api4 import NodeBalancer, NodeBalancerConfig, NodeBalancerNode, PaginatedList, and_
 
@@ -37,14 +40,6 @@ linode_nodebalancer_info_spec = dict(
         ])
 )
 
-specdoc_examples = ['''
-- name: Get a NodeBalancer by its id
-  linode.cloud.nodebalancer_info:
-    id: 12345''', '''
-- name: Get a NodeBalancer by its label
-  linode.cloud.nodebalancer_info:
-    label: cool_nodebalancer''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode NodeBalancer.'
@@ -52,8 +47,27 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_nodebalancer_info_spec,
-    examples=specdoc_examples,
-    return_values=nodebalancer_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        node_balancer=dict(
+            description='The NodeBalancer in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses',
+            type='dict',
+            sample=docs_parent.result_node_balancer_samples
+        ),
+        configs=dict(
+            description='A list of configs applied to the NodeBalancer.',
+            docs_url='https://www.linode.com/docs/api/nodebalancers/#config-view__responses',
+            type='list',
+            sample=docs_parent.result_configs_samples
+        ),
+        nodes=dict(
+            description='A list of configs applied to the NodeBalancer.',
+            docs_url='https://www.linode.com/docs/api/nodebalancers/#node-view',
+            type='list',
+            sample=docs_parent.result_nodes_samples
+        )
+    )
 )
 
 linode_nodebalancer_valid_filters = [

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -18,6 +18,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_node as docs
+
 MODULE_SPEC = dict(
     nodebalancer_id=dict(
         type='int', required=True,
@@ -59,50 +61,6 @@ MODULE_SPEC = dict(
     ),
 )
 
-specdoc_examples = ['''
-- name: Create a NodeBalancer
-  linode.cloud.nodebalancer:
-    label: my-nodebalancer
-    region: us-east
-    state: present
-    configs:
-      - port: 80
-        protocol: http
-        algorithm: roundrobin
-  register: nodebalancer_result
-        
-- name: Create an Instance
-  linode.cloud.instance:
-    label: my-instance
-    region: us-east
-    private_ip: true
-    type: g6-standard-1
-    state: present
-  register: instance_result
-    
-- name: Attach the Instance to the NodeBalancer
-  linode.cloud.nodebalancer_node:
-    nodebalancer_id: nodebalancer_result.node_balancer.id
-    config_id: nodebalancer_result.configs[0].id
-    
-    label: my-node
-
-    # Use the private ip address of the instance
-    address: '{{ instance_result.instance.ipv4[1] }}:80'
-
-    state: present''']
-
-result_node_samples = ['''{
-  "address": "123.123.123.123:80",
-  "config_id": 12345,
-  "id": 12345,
-  "label": "mynode",
-  "mode": "accept",
-  "nodebalancer_id": 12345,
-  "status": "Unknown",
-  "weight": 10
-}''']
-
 specdoc_meta = dict(
     description=[
         'Manage Linode NodeBalancer Nodes.'
@@ -110,13 +68,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=MODULE_SPEC,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         node=dict(
             description='The NodeBalancer Node in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/nodebalancers/#node-view__responses',
             type='dict',
-            sample=result_node_samples
+            sample=docs.result_node_samples
         )
     )
 )

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -15,6 +15,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.object_cluster_info as docs
+
 linode_object_cluster_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
     state=dict(type='str', required=False, doc_hide=True),
@@ -37,24 +39,6 @@ linode_object_cluster_info_spec = dict(
         description='The static-site domain of the clusters.')
 )
 
-specdoc_examples = ['''
-- name: Get info about clusters in us-east
-  linode.cloud.object_cluster_info:
-    region: us-east''', '''
-- name: Get info about the cluster with id us-east-1
-  linode.cloud.object_cluster_info:
-    id: us-east-1''']
-
-result_clusters_samples = ['''[
-  {
-    "domain": "us-east-1.linodeobjects.com",
-    "id": "us-east-1",
-    "region": "us-east",
-    "static_site_domain": "website-us-east-1.linodeobjects.com",
-    "status": "available"
-  }
-]''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode Object Storage Cluster.'
@@ -62,13 +46,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_object_cluster_info_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         clusters=dict(
             description='The Object Storage clusters in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/object-storage/#cluster-view__responses',
             type='list',
-            sample=result_clusters_samples
+            sample=docs.result_clusters_samples
         )
     )
 )

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -15,7 +15,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.object_cluster_info as docs
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.object_cluster_info \
+    as docs
 
 linode_object_cluster_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -15,6 +15,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.object_keys as docs
+
 linode_access_spec = dict(
     cluster=dict(
         type='str', required=True,
@@ -44,39 +46,6 @@ linode_object_keys_spec = dict(
                choices=['present', 'absent'], required=True),
 )
 
-specdoc_examples = ['''
-- name: Create an Object Storage key
-  linode.cloud.object_keys:
-    label: 'my-fullaccess-key'
-    state: present''', '''
-- name: Create a limited Object Storage key
-  linode.cloud.object_keys:
-    label: 'my-limited-key'
-    access:
-      - cluster: us-east-1
-        bucket_name: my-bucket
-        permissions: read_write
-    state: present''', '''
-- name: Remove an object storage key
-  linode.cloud.object_keys:
-    label: 'my-key'
-    state: absent''']
-
-result_key_samples = ['''{
-  "access_key": "KVAKUTGBA4WTR2NSJQ81",
-  "bucket_access": [
-    {
-      "bucket_name": "example-bucket",
-      "cluster": "ap-south-1",
-      "permissions": "read_only"
-    }
-  ],
-  "id": 123,
-  "label": "my-key",
-  "limited": true,
-  "secret_key": "OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"
-}''']
-
 specdoc_meta = dict(
     description=[
         'Manage Linode Object Storage Keys.'
@@ -84,14 +53,14 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_object_keys_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         key=dict(
             description='The Object Storage key in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/object-storage/#object-storage'
                      '-key-view__responses',
             type='dict',
-            sample=result_key_samples
+            sample=docs.result_key_samples
         )
     )
 )

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -15,6 +15,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vlan_info as docs
+
 linode_vlan_info_spec = dict(
     # We need to overwrite attributes to exclude them as requirements
     state=dict(type='str', required=False, doc_hide=True),
@@ -24,21 +26,6 @@ linode_vlan_info_spec = dict(
         description='The VLAN’s label.')
 )
 
-specdoc_examples = ['''
-- name: Get info about a VLAN by label
-  linode.cloud.vlan_info:
-    label: example-vlan''']
-
-result_vlan_samples = ['''{
-  "created": "2020-01-01T00:01:01",
-  "label": "vlan-example",
-  "linodes": [
-    111,
-    222
-  ],
-  "region": "ap-west"
-}''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode VLAN.'
@@ -46,13 +33,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_vlan_info_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         vlan=dict(
             description='The VLAN in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/networking/#vlans-list__response-samples',
             type='dict',
-            sample=result_vlan_samples
+            sample=docs.result_vlan_samples
         )
     )
 )

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -16,26 +16,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
-RETURN = '''
-volume:
-  description: The volume in JSON serialized form.
-  linode_api_docs: "https://www.linode.com/docs/api/volumes/#volume-view__responses"
-  returned: always
-  type: dict
-  sample: {
-   "created":"",
-   "filesystem_path":"/dev/disk/by-id/xxxxxx",
-   "id":xxxxxx,
-   "label":"xxxxxx",
-   "linode_id":xxxxxx,
-   "linode_label":"xxxxxx",
-   "region":"us-east",
-   "size":30,
-   "status":"creating",
-   "tags":[],
-   "updated":"2021-03-05T19:05:33"
-}
-'''
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume as docs
 
 linode_volume_spec = dict(
     label=dict(
@@ -85,53 +66,6 @@ linode_volume_spec = dict(
                choices=['present', 'absent'], required=True),
 )
 
-specdoc_examples = ['''
-- name: Create a volume attached to an instance
-  linode.cloud.volume:
-    label: example-volume
-    region: us-east
-    size: 30
-    linode_id: 12345
-    state: present''', '''
-- name: Create an unattached volume
-  linode.cloud.volume:
-    label: example-volume
-    region: us-east
-    size: 30
-    state: present''', '''
-- name: Resize a volume
-  linode.cloud.volume:
-    label: example-volume
-    size: 50
-    state: present''', '''
-- name: Detach a volume
-  linode.cloud.volume:
-    label: example-volume
-    attached: false
-    state: present''', '''
-- name: Delete a volume
-  linode.cloud.volume:
-    label: example-volume
-    state: absent''']
-
-result_volume_samples = ['''{
-  "created": "2018-01-01T00:01:01",
-  "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_my-volume",
-  "hardware_type": "nvme",
-  "id": 12345,
-  "label": "my-volume",
-  "linode_id": 12346,
-  "linode_label": "linode123",
-  "region": "us-east",
-  "size": 30,
-  "status": "active",
-  "tags": [
-    "example tag",
-    "another example"
-  ],
-  "updated": "2018-01-01T00:01:01"
-}''']
-
 specdoc_meta = dict(
     description=[
         'Manage a Linode Volume.'
@@ -139,13 +73,13 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_volume_spec,
-    examples=specdoc_examples,
+    examples=docs.specdoc_examples,
     return_values=dict(
         volume=dict(
             description='The volume in JSON serialized form.',
             docs_url='https://www.linode.com/docs/api/volumes/#volume-view__responses',
             type='dict',
-            sample=result_volume_samples
+            sample=docs.result_volume_samples
         )
     )
 )

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -15,6 +15,9 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume_info as docs
+
 from ansible_collections.linode.cloud.plugins.modules.volume import specdoc_meta \
     as volume_specdoc_meta
 
@@ -37,15 +40,6 @@ linode_volume_info_spec = dict(
         ])
 )
 
-specdoc_examples = ['''
-- name: Get info about a volume by label
-  linode.cloud.volume_info:
-    label: example-volume
-    
-- name: Get info about a volume by id
-  linode.cloud.volume_info:
-    id: 12345''']
-
 specdoc_meta = dict(
     description=[
         'Get info about a Linode Volume.'
@@ -53,8 +47,15 @@ specdoc_meta = dict(
     requirements=global_requirements,
     author=global_authors,
     spec=linode_volume_info_spec,
-    examples=specdoc_examples,
-    return_values=volume_specdoc_meta['return_values']
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        volume=dict(
+            description='The volume in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/volumes/#volume-view__responses',
+            type='dict',
+            sample=docs_parent.result_volume_samples
+        )
+    )
 )
 
 linode_volume_valid_filters = [


### PR DESCRIPTION
This pull request resolves an issue that caused `info` modules to fail with an import error. Additionally, this change refactors example and sample strings into a new `doc_fragments` directory. 