### PR TITLE
fix: Resolve issue when attempting to update existing NodeBalancer configs

### DIFF
--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -71,6 +71,7 @@ Manage a Linode NodeBalancer.
 | `port` | `int` | Optional | The port this Config is for.   |
 | `protocol` | `str` | Optional | The protocol this port is configured to serve.  (Choices:  `http` `https` `tcp`) |
 | `proxy_protocol` | `str` | Optional | ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.  (Choices:  `none` `v1` `v2`) |
+| `recreate` | `bool` | Optional | If true, the config will be forcibly recreated on every run. This is useful for updates to redacted fields (`ssl_cert`, `ssl_key`)   |
 | `ssl_cert` | `str` | Optional | The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.   |
 | `ssl_key` | `str` | Optional | The PEM-formatted private key for the SSL certificate set in the ssl_cert field.   |
 | `stickiness` | `str` | Optional | Controls how session stickiness is handled on this port.  (Choices:  `none` `table` `http_cookie`) |

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -35,6 +35,65 @@
           - create_empty_nodebalancer.changed
           - create_empty_nodebalancer.configs|length == 0
 
+    - name: Add NodeBalancer config
+      linode.cloud.nodebalancer:
+        api_token: '{{ api_token }}'
+        label: '{{ create_empty_nodebalancer.node_balancer.label }}'
+        region: us-east
+        client_conn_throttle: 6
+        state: present
+        configs:
+          - port: 80
+            protocol: http
+            algorithm: roundrobin
+      register: create_config
+
+    - assert:
+        that:
+          - create_config.configs|length == 1
+          - create_config.configs[0].port == 80
+
+    - name: Update NodeBalancer config
+      linode.cloud.nodebalancer:
+        api_token: '{{ api_token }}'
+        label: '{{ create_empty_nodebalancer.node_balancer.label }}'
+        region: us-east
+        client_conn_throttle: 6
+        state: present
+        configs:
+          - port: 80
+            protocol: http
+            algorithm: roundrobin
+            check_timeout: 1
+      register: update_config
+
+    - assert:
+        that:
+          - update_config.configs|length == 1
+          - update_config.configs[0].check_timeout == 1
+          
+          - update_config.changed
+
+    - name: Recreate NodeBalancer config
+      linode.cloud.nodebalancer:
+        api_token: '{{ api_token }}'
+        label: '{{ create_empty_nodebalancer.node_balancer.label }}'
+        region: us-east
+        client_conn_throttle: 6
+        state: present
+        configs:
+          - port: 80
+            protocol: http
+            algorithm: roundrobin
+            check_timeout: 1
+            recreate: true
+      register: recreate_config
+
+    - assert:
+        that:
+          - recreate_config.changed
+          - update_config.configs|length == 1
+
   always:
     - ignore_errors: yes
       block:


### PR DESCRIPTION
This pull request overhauls the config update logic in the `nodebalancer` module to delete configs before recreating them. Additionally, this pull request adds an optional `recreate` field which allows users to recreate their config on every run of the module.