### PR TITLE
new: Add support for LKE Node Pool Autoscalers

### DIFF
--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -47,9 +47,33 @@ Manage Linode LKE clusters.
 | `region` | `str` | Optional | This Kubernetes cluster’s location.   |
 | `tags` | `list` | Optional | An array of tags applied to the Kubernetes cluster.   |
 | `high_availability` | `bool` | Optional | Defines whether High Availability is enabled for the Control Plane Components of the cluster.    |
-| `node_pools` | `list` | Optional | A list of node pools to configure the cluster with   |
+| [`node_pools` (sub-options)](#node_pools) | `list` | Optional | A list of node pools to configure the cluster with   |
 | `skip_polling` | `bool` | Optional | If true, the module will not wait for all nodes in the cluster to be ready.   |
 | `wait_timeout` | `int` | Optional | The period to wait for the cluster to be ready in seconds.  ( Default: `600`) |
+
+
+
+
+
+### node_pools
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `count` | `int` | **Required** | The number of nodes in the Node Pool.   |
+| `type` | `str` | **Required** | The Linode Type for all of the nodes in the Node Pool.   |
+| [`autoscaler` (sub-options)](#autoscaler) | `dict` | Optional | When enabled, the number of nodes autoscales within the defined minimum and maximum values.   |
+
+
+
+
+
+### autoscaler
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `enabled` | `bool` | Optional | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.   |
+| `max` | `int` | Optional | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.   |
+| `min` | `int` | Optional | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.   |
 
 
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -24,6 +24,22 @@ Manage Linode LKE clusters.
 ```
 
 ```yaml
+- name: Create a Linode LKE cluster with autoscaler
+  linode.cloud.lke_cluster:
+    label: 'my-cluster'
+    region: us-southeast
+    k8s_version: 1.23
+    node_pools:
+      - type: g6-standard-1
+        count: 2
+        autoscaler:
+          enable: true
+          min: 2
+          max: 5
+    state: present
+```
+
+```yaml
 - name: Delete a Linode LKE cluster
   linode.cloud.lke_cluster:
     label: 'my-cluster'

--- a/plugins/module_utils/doc_fragments/lke_cluster.py
+++ b/plugins/module_utils/doc_fragments/lke_cluster.py
@@ -12,6 +12,19 @@ examples = ['''
       - type: g6-standard-2
         count: 2
     state: present''', '''
+- name: Create a Linode LKE cluster with autoscaler
+  linode.cloud.lke_cluster:
+    label: 'my-cluster'
+    region: us-southeast
+    k8s_version: 1.23
+    node_pools:
+      - type: g6-standard-1
+        count: 2
+        autoscaler:
+          enable: true
+          min: 2
+          max: 5
+    state: present''', '''
 - name: Delete a Linode LKE cluster
   linode.cloud.lke_cluster:
     label: 'my-cluster'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ botocore==1.20.23
 pylint==2.7.2
 ansible-doc-extractor==0.1.8
 mypy==0.942
-ansible-specdoc==0.0.8
+ansible-specdoc==0.0.9
 ansible==5.7.0

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -11,6 +11,10 @@
             count: 3
           - type: g6-standard-4
             count: 1
+            autoscaler:
+              enabled: true
+              min: 1
+              max: 2
         skip_polling: true
         state: present
       register: create_cluster
@@ -21,6 +25,9 @@
           - create_cluster.cluster.region == 'us-southeast'
           - create_cluster.node_pools[0].type == 'g6-standard-1'
           - create_cluster.node_pools[0].count == 3
+          - create_cluster.node_pools[1].autoscaler.enabled
+          - create_cluster.node_pools[1].autoscaler.min == 1
+          - create_cluster.node_pools[1].autoscaler.max == 2
 
     - name: Update the cluster's node pools
       linode.cloud.lke_cluster:
@@ -66,6 +73,10 @@
         node_pools:
           - type: g6-standard-1
             count: 1
+            autoscaler:
+              enabled: true
+              min: 1
+              max: 3
         state: present
       register: upgrade
 
@@ -80,6 +91,9 @@
           - upgrade.node_pools[0].type == 'g6-standard-1'
           - upgrade.node_pools[0].count == 1
           - upgrade.node_pools[0].id == create_cluster.node_pools[0].id
+          - upgrade.node_pools[0].autoscaler.enabled
+          - upgrade.node_pools[0].autoscaler.min == 1
+          - upgrade.node_pools[0].autoscaler.max == 3
 
     - name: Get info about the cluster by id
       linode.cloud.lke_cluster_info:


### PR DESCRIPTION
This pull request adds an optional `autoscaler` block to be configured in each `lke_cluster` node pool. This block corresponds to the API configuration seen here: https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#node-pool-update__request-body-schema