### PR TITLE
fix: Use ansible_collections directory for  PR integration test workflow

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -33,10 +33,11 @@ jobs:
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
 
-      - run: make TEST_ARGS="-v ${{ github.event.client_payload.slash_command.tests }}" test
+      - run: mkdir -p $COLLECTION_PATH && cp -r . $COLLECTION_PATH && cd $COLLECTION_PATH && make deps && make TEST_ARGS="-v ${{ github.event.client_payload.slash_command.tests }}" test
         if: ${{ steps.validate-tests.outputs.match == '' }}
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+          COLLECTION_PATH: ~/.ansible/collections/ansible_collections/linode/cloud
 
       - uses: actions/github-script@v5
         id: update-check-run

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ build:
 install: clean build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
+deps:
+	pip install -r requirements.txt -r requirements-dev.txt
+
 lint:
 	pylint plugins
 
 	mypy plugins/modules
 	mypy plugins/inventory
-
-gendocsspec:
-
 
 gendocs:
 	mkdir -p $(DOCS_PATH)


### PR DESCRIPTION
This change is necessary as an ansible collection must be under `ansible_collections/{namespace}/{collection}` in order for build/integration tests to properly run.