### PR TITLE
fix: Recreate `ansible-test` SSH keys on workflow run

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: copy scripts to installed collection
         run: cp -r scripts ~/.ansible/collections/ansible_collections/linode/cloud/scripts
 
-      - name: remove existing keys
+      - name: replace existing keys
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
       - name: run tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: copy scripts to installed collection
         run: cp -r scripts ~/.ansible/collections/ansible_collections/linode/cloud/scripts
 
+      - name: remove existing keys
+        run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
+
       - name: run tests
         run: cd ~/.ansible/collections/ansible_collections/linode/cloud && make testall
         env:


### PR DESCRIPTION
This pull request resolves an issue that would cause all parallel tests to fail immediately.