### PR TITLE
new: Add `image` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Name |
 [linode.cloud.firewall](./docs/modules/firewall.md)|
 [linode.cloud.firewall_device](./docs/modules/firewall_device.md)|
 [linode.cloud.firewall_info](./docs/modules/firewall_info.md)|
+[linode.cloud.image](./docs/modules/image.md)|
 [linode.cloud.instance](./docs/modules/instance.md)|
 [linode.cloud.instance_info](./docs/modules/instance_info.md)|
 [linode.cloud.lke_cluster](./docs/modules/lke_cluster.md)|

--- a/docs/modules/image.md
+++ b/docs/modules/image.md
@@ -1,0 +1,90 @@
+# image
+
+Manage a Linode Image.
+
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Create a basic image from an existing disk
+  linode.cloud.image:
+    label: my-image
+    description: Created using Ansible!
+    disk_id: 12345
+    state: present
+```
+
+```yaml
+- name: Create a basic image from a file
+  linode.cloud.image:
+    label: my-image
+    description: Created using Ansible!
+    source_file: myimage.img.gz
+    state: present
+```
+
+```yaml
+- name: Delete an image
+  linode.cloud.image:
+    label: my-image
+    state: absent
+```
+
+
+
+
+
+
+
+
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `label` | `str` | **Required** | This Image's unique label.   |
+| `state` | `str` | **Required** | The state of this Image.  (Choices:  `present`  `absent` ) |
+| `description` | `str` | Optional | A description for the Image.   |
+| `disk_id` | `int` | Optional | The ID of the disk to clone this image from.   |
+| `recreate` | `bool` | Optional | If true, the image with the given label will be deleted and recreated  (Default: `False`) |
+| `region` | `str` | Optional | The Linode region to upload this image to.  (Default: `us-east`) |
+| `source_file` | `str` | Optional | An image file to create this image with.   |
+| `wait` | `bool` | Optional | Wait for the image to have status `available` before returning.  (Default: `True`) |
+| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for an image to have status `available`.  (Default: `600`) |
+
+
+
+
+
+
+## Return Values
+
+- `image` - The Image in JSON serialized form.
+
+    - Sample Response:
+        ```json
+        {
+          "created": "2021-08-14T22:44:02",
+          "created_by": "linode",
+          "deprecated": false,
+          "description": "Example Image description.",
+          "eol": "2026-07-01T04:00:00",
+          "expiry": null,
+          "id": "linode/debian11",
+          "is_public": true,
+          "label": "Debian 11",
+          "size": 2500,
+          "status": null,
+          "type": "manual",
+          "updated": "2021-08-14T22:44:02",
+          "vendor": "Debian"
+        }
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#image-view__response-samples) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/image.py
+++ b/plugins/module_utils/doc_fragments/image.py
@@ -1,0 +1,36 @@
+"""Documentation fragments for the image module"""
+
+specdoc_examples = ['''
+- name: Create a basic image from an existing disk
+  linode.cloud.image:
+    label: my-image
+    description: Created using Ansible!
+    disk_id: 12345
+    state: present''', '''
+- name: Create a basic image from a file
+  linode.cloud.image:
+    label: my-image
+    description: Created using Ansible!
+    source_file: myimage.img.gz
+    state: present''', '''
+- name: Delete an image
+  linode.cloud.image:
+    label: my-image
+    state: absent''']
+
+result_image_samples = ['''{
+  "created": "2021-08-14T22:44:02",
+  "created_by": "linode",
+  "deprecated": false,
+  "description": "Example Image description.",
+  "eol": "2026-07-01T04:00:00",
+  "expiry": null,
+  "id": "linode/debian11",
+  "is_public": true,
+  "label": "Debian 11",
+  "size": 2500,
+  "status": null,
+  "type": "manual",
+  "updated": "2021-08-14T22:44:02",
+  "vendor": "Debian"
+}''']

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Images."""
+
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=unused-import
+import copy
+from typing import Optional, cast, Any, Set
+
+import polling
+from linode_api4 import Image
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
+    global_requirements
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import \
+    handle_updates, filter_null_values
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript as docs
+
+SPEC = dict(
+    label=dict(
+        type='str',
+        required=True,
+        description='This Image\'s unique label.'),
+    state=dict(
+        type='str',
+        choices=['present', 'absent'],
+        required=True,
+        description='The state of this StackScript.',
+    ),
+
+    disk_id=dict(
+        type='int',
+        description='Images that can be deployed using this StackScript.',
+    ),
+    description=dict(
+        type='str',
+        description='A description for the Image.',
+    ),
+
+    wait=dict(
+        type='bool', default=True,
+        description='Wait for the image to have status `available` before returning.'),
+
+    wait_timeout=dict(
+        type='int', default=240,
+        description='The amount of time, in seconds, to wait for an image to '
+                    'have status `available`.'
+    )
+)
+
+specdoc_meta = dict(
+    description=[
+        'Manage a Linode Image.'
+    ],
+    requirements=global_requirements,
+    author=global_authors,
+    spec=SPEC,
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        stackscript=dict(
+            description='The Image in JSON serialized form.',
+            docs_url='https://www.linode.com/docs/api/images/'
+                     '#image-view__response-samples',
+            type='dict',
+            sample=docs.result_stackscript_samples
+        )
+    )
+)
+
+MUTABLE_FIELDS = {
+    'description'
+}
+
+
+class Module(LinodeModuleBase):
+    """Module for creating and destroying Linode Images"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPEC
+        self.required_one_of = ['state', 'label']
+        self.results = dict(
+            changed=False,
+            actions=[],
+            image=None,
+        )
+
+        super().__init__(module_arg_spec=self.module_arg_spec,
+                         required_one_of=self.required_one_of,
+                         required_if=[('state', 'present', ['disk_id'])])
+
+    def _get_image_by_label(self, label: str) -> Optional[Image]:
+        try:
+            return self.client.images(Image.label == label)[0]
+        except IndexError:
+            return None
+        except Exception as exception:
+            return self.fail(msg='failed to get image {0}: {1}'.format(label, exception))
+
+    def _wait_for_image_status(self, image: Image, status: Set[str]) -> None:
+        def poll_func() -> bool:
+            image._api_get()
+            return image.status in status
+
+        # Initial attempt
+        if poll_func():
+            return
+
+        try:
+            polling.poll(
+                poll_func,
+                step=10,
+                timeout=self.module.params.get('wait_timeout'),
+            )
+        except polling.TimeoutException:
+            self.fail('failed to wait for image status: timeout period expired')
+
+    def _create_image_from_disk(self) -> Optional[Image]:
+        disk_id = self.module.params.get('disk_id')
+        label = self.module.params.get('label')
+        description = self.module.params.get('description')
+
+        try:
+            return self.client.image_create(disk_id, label=label, description=description)
+        except Exception as exception:
+            return self.fail(msg='failed to create image: {0}'.format(exception))
+
+    def _create_image(self) -> Optional[Image]:
+        if self.module.params.get('disk_id') is not None:
+            image = self._create_image_from_disk()
+
+            if self.module.params.get('wait'):
+                self._wait_for_image_status(image, {'available'})
+
+            return image
+
+        self.fail(msg='no handler found for image')
+
+    # def _update_stackscript(self, stackscript: Image) -> None:
+    #     stackscript._api_get()
+    #
+    #     params = filter_null_values(self.module.params)
+    #
+    #     handle_updates(stackscript, params, MUTABLE_FIELDS, self.register_action)
+
+    def _handle_present(self) -> None:
+        params = self.module.params
+
+        label = params.get('label')
+
+        image = self._get_image_by_label(label)
+
+        # Create the image if it does not already exist
+        if image is None:
+            image = self._create_image()
+            self.register_action('Created image {0}'.format(label))
+
+        # self._update_stackscript(image)
+
+        # Force lazy-loading
+        image._api_get()
+
+        self.results['image'] = image._raw_json
+
+    def _handle_absent(self) -> None:
+        label: str = self.module.params.get('label')
+
+        image = self._get_image_by_label(label)
+
+        if image is not None:
+            self.results['image'] = image._raw_json
+            image.delete()
+            self.register_action('Deleted image {0}'.format(label))
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Image module"""
+        state = kwargs.get('state')
+
+        if state == 'absent':
+            self._handle_absent()
+            return self.results
+
+        self._handle_present()
+
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the Image module"""
+    Module()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 linode-api4==5.2.1
 polling==0.3.2
+types-requests==2.28.9

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -1,0 +1,42 @@
+- name: stackscript_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create an instance to image
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/alpine3.16
+        wait: no
+        state: present
+      register: instance_create
+
+    - name: Create an image from the instance
+      linode.cloud.image:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        disk_id: '{{ instance_create.disks.0.id }}'
+        description: 'cool'
+        state: present
+      register: image_create
+
+    - assert:
+        that:
+          - image_create.image.status == 'available'
+          - image_create.image.description == 'cool'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.image:
+            api_token: '{{ api_token }}'
+            label: '{{ image_create.image.label }}'
+            state: absent
+
+        - linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            label: '{{ instance_create.instance.label }}'
+            state: absent

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -28,6 +28,37 @@
           - image_create.image.status == 'available'
           - image_create.image.description == 'cool'
 
+    - name: Update the image
+      linode.cloud.image:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        disk_id: '{{ instance_create.disks.0.id }}'
+        description: 'cool2'
+        state: present
+      register: image_update
+
+    - assert:
+        that:
+          - image_update.image.status == 'available'
+          - image_update.image.description == 'cool2'
+
+    - name: Overwrite the image
+      linode.cloud.image:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        disk_id: '{{ instance_create.disks.0.id }}'
+        description: 'yooo'
+        recreate: yes
+        wait: no
+        state: present
+      register: image_recreate
+
+    - assert:
+        that:
+          - image_recreate.changed
+          - image_recreate.image.id != image_create.image.id
+          - image_recreate.image.description == 'yooo'
+
   always:
     - ignore_errors: yes
       block:

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -1,0 +1,37 @@
+- name: image_upload
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+        file_content: 'H4sIAAAAAAAAA6vML1UozsgvzUlRKC1OVShJLSpKTMsvyuUCAMhLS4gZAAAA='
+
+    - name: Create temporary image file
+      tempfile:
+        state: file
+        suffix: .img.gz
+      register: source_file
+
+    - copy:
+        dest: '{{ source_file.path }}'
+        content: '{{ file_content | b64decode }}'
+
+    - name: Create an image from the image file
+      linode.cloud.image:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        source_file: '{{ source_file.path }}'
+        description: 'cool'
+        state: present
+      register: image_create
+
+    - assert:
+        that:
+          - image_create.image.size == 1
+          - image_create.image.status == 'available'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.image:
+            api_token: '{{ api_token }}'
+            label: '{{ image_create.image.label }}'
+            state: absent


### PR DESCRIPTION
This change allows users to create Linode images from an existing Linode disk or source file. Additionally users can update, destroy, and recreate their existing images.