### PR TITLE
new: Add `event_list` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Name | Description |
 [linode.cloud.volume_info](./docs/modules/volume_info.md)|Get info about a Linode Volume.|
 
 
+### List Modules
+
+Modules for retrieving and filtering on multiple Linode resources.
+
+Name | Description |
+--- | ------------ |
+
+
 ### Inventory Plugins
 
 Dynamically add Linode infrastructure to an Ansible inventory.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 
 Name | Description |
 --- | ------------ |
+[linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Linode events.|
 
 
 ### Inventory Plugins

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -1,0 +1,104 @@
+# event_list
+
+List and filter on Linode events.
+
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the events for the current Linode Account
+  linode.cloud.event_list: {}
+```
+
+```yaml
+- name: List the latest 5 events for the current Linode Account
+  linode.cloud.event_list:
+    count: 5
+    order_by: desc
+    order: created
+```
+
+```yaml
+- name: List all Linode Instance creation events for the current Linode Account
+  linode.cloud.event_list:
+    filter:
+      - name: action
+        values: linode_create
+```
+
+
+
+
+
+
+
+
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | `str` | Optional | The order to list events in.  (Choices:  `desc`  `asc` Default: `asc`) |
+| `order_by` | `str` | Optional | The attribute to order events by.   |
+| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting events.   |
+| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+
+
+
+
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/account/#events-list__responses   |
+| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+
+
+
+
+
+## Return Values
+
+- `events` - The returned events.
+
+    - Sample Response:
+        ```json
+        [
+           {
+              "action":"ticket_create",
+              "created":"2018-01-01T00:01:01",
+              "duration":300.56,
+              "entity":{
+                 "id":11111,
+                 "label":"Problem booting my Linode",
+                 "type":"ticket",
+                 "url":"/v4/support/tickets/11111"
+              },
+              "id":123,
+              "message":"None",
+              "percent_complete":null,
+              "rate":null,
+              "read":true,
+              "secondary_entity":{
+                 "id":"linode/debian9",
+                 "label":"linode1234",
+                 "type":"linode",
+                 "url":"/v4/linode/instances/1234"
+              },
+              "seen":true,
+              "status":null,
+              "time_remaining":null,
+              "username":"exampleUser"
+           }
+        ]
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#events-list__responses) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/event_list.py
+++ b/plugins/module_utils/doc_fragments/event_list.py
@@ -1,0 +1,44 @@
+"""Documentation fragments for the image_info module"""
+
+specdoc_examples = ['''
+- name: List all of the events for the current Linode Account
+  linode.cloud.event_list: {}''', '''
+- name: List the latest 5 events for the current Linode Account
+  linode.cloud.event_list:
+    count: 5
+    order_by: desc
+    order: created''', '''
+- name: List all Linode Instance creation events for the current Linode Account
+  linode.cloud.event_list:
+    filter:
+      - name: action
+        values: linode_create''']
+
+result_events_samples = ['''[
+   {
+      "action":"ticket_create",
+      "created":"2018-01-01T00:01:01",
+      "duration":300.56,
+      "entity":{
+         "id":11111,
+         "label":"Problem booting my Linode",
+         "type":"ticket",
+         "url":"/v4/support/tickets/11111"
+      },
+      "id":123,
+      "message":"None",
+      "percent_complete":null,
+      "rate":null,
+      "read":true,
+      "secondary_entity":{
+         "id":"linode/debian9",
+         "label":"linode1234",
+         "type":"linode",
+         "url":"/v4/linode/instances/1234"
+      },
+      "seen":true,
+      "status":null,
+      "time_remaining":null,
+      "username":"exampleUser"
+   }
+]''']

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode events."""
+
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=unused-import
+from typing import List, Any, Optional, Dict
+
+from linode_api4 import Image
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import create_filter_and, \
+    filter_null_values, construct_api_filter, get_all_paginated
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
+    global_requirements
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.event_list as docs
+
+spec_filter = dict(
+    name=dict(type='str', required=True,
+              description=[
+                  'The name of the field to filter on.',
+                  'Valid filterable attributes can be found here: '
+                  'https://www.linode.com/docs/api/account/#events-list__responses',
+              ]),
+    values=dict(type='list', elements='str', required=True,
+                description=[
+                    'A list of values to allow for this field.',
+                    'Fields will pass this filter if at least one of these values matches.'
+                ])
+)
+
+spec = dict(
+    # Disable the default values
+    state=dict(type='str', required=False, doc_hide=True),
+    label=dict(type='str', required=False, doc_hide=True),
+
+    order=dict(type='str', description='The order to list events in.',
+               default='asc', choices=['desc', 'asc']),
+    order_by=dict(type='str', description='The attribute to order events by.'),
+    filters=dict(type='list', elements='dict', options=spec_filter,
+                 description='A list of filters to apply to the resulting events.'),
+    count=dict(type='int',
+               description=[
+                   'The number of results to return.',
+                   'If undefined, all results will be returned.'])
+)
+
+specdoc_meta = dict(
+    description=[
+        'List and filter on Linode events.'
+    ],
+    requirements=global_requirements,
+    author=global_authors,
+    spec=spec,
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        events=dict(
+            description='The returned events.',
+            docs_url='https://www.linode.com/docs/api/account/#events-list__responses',
+            type='list',
+            elements='dict',
+            sample=docs.result_events_samples
+        )
+    )
+)
+
+
+class Module(LinodeModuleBase):
+    """Module for getting info about a Linode events"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = spec
+        self.results: Dict[str, Any] = {
+            'events': []
+        }
+
+        super().__init__(module_arg_spec=self.module_arg_spec)
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for event list module"""
+
+        filter_dict = construct_api_filter(self.module.params)
+
+        self.results['events'] = get_all_paginated(self.client, '/account/events', filter_dict,
+                                                   num_results=self.module.params['count'])
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the module"""
+    Module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to retrieve information about a Linode imagE."""
+"""This module allows users to retrieve information about a Linode image."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/scripts/render_readme.py
+++ b/scripts/render_readme.py
@@ -106,7 +106,7 @@ def main() -> None:
         'is_release': len(sys.argv) > 1,
         'modules': list_modules(),
         'info_modules': list_info_modules(),
-        'list_modules': list_modules(),
+        'list_modules': list_list_modules(),
         'inventory': list_inventory()
     })
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -34,6 +34,15 @@ Name | Description |
 {% for mod in info_modules %}[linode.cloud.{{ mod.name }}]({% if is_release %}https://github.com/linode/ansible_linode/blob/{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
 {% endfor %}
 
+### List Modules
+
+Modules for retrieving and filtering on multiple Linode resources.
+
+Name | Description |
+--- | ------------ |
+{% for mod in list_modules %}[linode.cloud.{{ mod.name }}]({% if is_release %}https://github.com/linode/ansible_linode/blob/{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
+{% endfor %}
+
 ### Inventory Plugins
 
 Dynamically add Linode infrastructure to an Ansible inventory.

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -1,0 +1,42 @@
+- name: event_list
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create an arbitrary event
+      linode.cloud.stackscript:
+        api_token: '{{ api_token }}'
+        label: 'ansible-test-{{ r }}'
+        images: ['any/all']
+        script: |
+            #!/bin/bash
+            apt-get -q update && apt-get -q -y install $PACKAGE
+        state: present
+      register: create_stackscript
+
+    - name: List the events for the current Linode Account
+      linode.cloud.event_list:
+        api_token: '{{ api_token }}'
+        count: 5
+      register: no_filter
+
+    - assert:
+        that:
+          # We can't ensure that the testing account will have 5 events
+          - no_filter.events | length <= 5
+
+    - name: Resolve the StackScript event
+      linode.cloud.event_list:
+        api_token: '{{ api_token }}'
+        count: 1
+        order_by: created
+        order: desc
+        filters:
+          - name: action
+            values: stackscript_create
+      register: filter
+
+    - assert:
+        that:
+          - filter.events | length == 1
+          - filter.events[0].entity.id == create_stackscript.stackscript.id


### PR DESCRIPTION
This pull request adds an `event_list` module for listing and filtering Linode Account Events. Additionally, this PR introduces a framework for filtering list responses on `_list` modules.

This pull request also adds a `List Modules` section to the `README.md` template.

Depends on #197 