### PR TITLE
ref: Call `self.fail(...)` for API errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,4 +13,5 @@ disable=protected-access,
         duplicate-code,
         too-many-lines,
         too-many-branches,
-        anomalous-backslash-in-string
+        anomalous-backslash-in-string,
+        too-many-locals

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -263,3 +263,9 @@ def get_all_paginated(client: LinodeClient, endpoint: str, filters: Dict[str, An
         result = result[:num_results]
 
     return result
+
+
+def format_api_error(err: ApiError) -> str:
+    """Formats an API error into a readable string"""
+
+    return ';'.join(err.errors)


### PR DESCRIPTION
This change causes all `ApiError` errors to be properly handled using `self.fail(...)`. This is to avoid printing stack traces for non-client related issues.