### PR TITLE
new: Add support for custom User-Agent prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,5 @@ $(INTEGRATION_CONFIG):
 	  echo "LINODE_API_TOKEN must be set"; \
 	  exit 1; \
 	fi
-	echo "api_token: $(LINODE_API_TOKEN)" >> $(INTEGRATION_CONFIG)
+	echo "api_token: $(LINODE_API_TOKEN)" > $(INTEGRATION_CONFIG)
+	echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Once the Linode Ansible collection is installed, it can be referenced by its [Fu
 In order to use this collection, the `LINODE_API_TOKEN` environment variable must be set to a valid Linode API v4 token. 
 Alternatively, you can pass your Linode API v4 token into the `api_token` option for each Linode module you reference.
 
+The `LINODE_UA_PREFIX` or the `ua_prefix` module option can be used to specify a custom User-Agent prefix.
+
 #### Example Playbook
 ```yaml
 ---

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -42,6 +42,12 @@ LINODE_COMMON_ARGS = dict(
         required=True,
         choices=['present', 'absent'],
     ),
+    ua_prefix=dict(
+        type='str',
+        description='An HTTP User-Agent Prefix to prepend in API requests.',
+        doc_hide=True,
+        fallback=(env_fallback, ['LINODE_UA_PREFIX'])
+    )
 )
 
 LINODE_TAG_ARGS = dict(
@@ -132,10 +138,17 @@ class LinodeModuleBase:
             api_token = self.module.params['api_token']
             api_version = self.module.params['api_version']
 
+            user_agent = COLLECTION_USER_AGENT
+
+            # Allow for custom user-agent prefixes
+            ua_prefix = self.module.params['ua_prefix']
+            if ua_prefix is not None:
+                user_agent = f"{ua_prefix}  {user_agent}"
+
             self._client = LinodeClient(
                 api_token,
                 base_url='https://api.linode.com/{0}'.format(api_version),
-                user_agent=COLLECTION_USER_AGENT,
+                user_agent=user_agent,
                 retry_rate_limit_interval=10,
             )
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -75,6 +75,8 @@ Once the Linode Ansible collection is installed, it can be referenced by its [Fu
 In order to use this collection, the `LINODE_API_TOKEN` environment variable must be set to a valid Linode API v4 token. 
 Alternatively, you can pass your Linode API v4 token into the `api_token` option for each Linode module you reference.
 
+The `LINODE_UA_PREFIX` or the `ua_prefix` module option can be used to specify a custom User-Agent prefix.
+
 #### Example Playbook
 ```yaml
 ---

--- a/tests/integration/targets/account_info/tasks/main.yaml
+++ b/tests/integration/targets/account_info/tasks/main.yaml
@@ -5,6 +5,7 @@
 #    - name: Get info about the current account
 #      linode.cloud.account_info:
 #        api_token: '{{ api_token }}'
+#        ua_prefix: '{{ ua_prefix }}'
 #      register: account
 #
 #    - assert:

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a domain
       linode.cloud.domain:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         description: 'really cool domain'
         domain: 'ansible-test-domain-{{ r }}.com'
         expire_sec: 300
@@ -35,6 +36,7 @@
     - name: Update a domain
       linode.cloud.domain:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         description: 'really cool'
         domain: '{{ create.domain.domain }}'
         expire_sec: 14400
@@ -64,6 +66,7 @@
     - name: Get domain info
       linode.cloud.domain_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ create.domain.domain }}'
       register: info
 
@@ -85,6 +88,7 @@
         - name: Delete the domain
           linode.cloud.domain:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ create.domain.domain }}'
             state: absent
           register: delete

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a domain
       linode.cloud.domain:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: 'ansible-test-domain-{{ r }}.com'
         soa_email: 'realemail@example.com'
         type: 'master'
@@ -21,6 +22,7 @@
     - name: Create a domain record
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         name: 'sub'
         type: 'A'
@@ -41,6 +43,7 @@
     - name: Update the domain record
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         record_id: '{{ record_create.record.id }}'
         ttl_sec: 14400
@@ -60,6 +63,7 @@
     - name: Get info about the record
       linode.cloud.domain_record_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         name: '{{ record_create.record.name }}'
       register: record_info
@@ -75,6 +79,7 @@
     - name: Get info about the record by id
       linode.cloud.domain_record_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         id: '{{ record_create.record.id }}'
       register: record_info_id
@@ -90,6 +95,7 @@
     - name: Create a domain record by domain id
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain_id: '{{ domain_create.domain.id }}'
         name: 'cool'
         type: 'TXT'
@@ -110,6 +116,7 @@
     - name: Create a duplicate record with a different target
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         name: 'sub'
         type: 'A'
@@ -130,6 +137,7 @@
     - name: Update the record by id
       linode.cloud.domain_record:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
         record_id: '{{ record_dupe_create.record.id }}'
         ttl_sec: 300
@@ -149,6 +157,7 @@
     - name: Get all domain records
       linode.cloud.domain_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ domain_create.domain.domain }}'
       register: domain_info
 
@@ -162,6 +171,7 @@
         - name: Delete the record
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ domain_create.domain.domain }}'
             record_id: '{{ record_create.record.id }}'
             state: absent
@@ -175,6 +185,7 @@
         - name: Delete the second record
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ domain_create.domain.domain }}'
             name: '{{ record2_create.record.name }}'
             type: '{{ record2_create.record.type }}'
@@ -190,6 +201,7 @@
         - name: Delete the duplicated record
           linode.cloud.domain_record:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ domain_create.domain.domain }}'
             record_id: '{{ record_dupe_create.record.id }}'
             state: absent
@@ -203,6 +215,7 @@
         - name: Delete the domain
           linode.cloud.domain:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ domain_create.domain.domain }}'
             state: absent
           register: domain_delete

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create an arbitrary event
       linode.cloud.stackscript:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         images: ['any/all']
         script: |
@@ -17,6 +18,7 @@
     - name: List the events for the current Linode Account
       linode.cloud.event_list:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         count: 5
       register: no_filter
 
@@ -28,6 +30,7 @@
     - name: Resolve the StackScript event
       linode.cloud.event_list:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         count: 1
         order_by: created
         order: desc

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -5,6 +5,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
@@ -15,6 +16,7 @@
     - name: Create another Linode Instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}-2'
         region: us-southeast
         type: g6-standard-1
@@ -25,6 +27,7 @@
     - name: Create a Linode Firewall
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: 'ansible-test-{{ r }}'
         devices: []
@@ -44,6 +47,7 @@
     - name: Update a Linode Firewall
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices: []
@@ -65,6 +69,7 @@
     - name: Update Linode Firewall devices
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices:
@@ -90,6 +95,7 @@
     - name: Update Linode Firewall devices again
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices:
@@ -115,6 +121,7 @@
     - name: Update Linode Firewall devices unchanged
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices:
@@ -137,6 +144,7 @@
     - name: Update Linode Firewall rules
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices: []
@@ -188,6 +196,7 @@
     - name: Update a Linode Firewall rules unchanged
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
         devices: []
@@ -223,6 +232,7 @@
     - name: Get info about the firewall
       linode.cloud.firewall_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
       register: firewall_info
@@ -254,6 +264,7 @@
         - name: Delete a Linode Firewall
           linode.cloud.firewall:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             api_version: v4beta
             label: '{{ create.firewall.label }}'
             state: absent
@@ -268,6 +279,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_instance.instance.label }}'
             state: absent
           register: delete_instance
@@ -281,6 +293,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_instance_2.instance.label }}'
             state: absent
           register: delete_instance_2

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
@@ -16,6 +17,7 @@
     - name: Create a Linode Firewall
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: 'ansible-test-{{ r }}'
         devices: []
@@ -30,6 +32,7 @@
     - name: Add Device to Linode Firewall
       linode.cloud.firewall_device:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         firewall_id: '{{ fw.firewall.id }}'
         entity_id: '{{ inst.instance.id }}'
@@ -45,6 +48,7 @@
     - name: Add Existing Device to Linode Firewall
       linode.cloud.firewall_device:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         firewall_id: '{{ fw.firewall.id }}'
         entity_id: '{{ inst.instance.id }}'
@@ -62,6 +66,7 @@
       block:
         - linode.cloud.firewall_device:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             firewall_id: '{{ fw.firewall.id }}'
             entity_id: '{{ inst.instance.id }}'
             entity_type: 'linode'
@@ -69,10 +74,12 @@
 
         - linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ inst.instance.label }}'
             state: absent
 
         - linode.cloud.firewall:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ fw.firewall.label }}'
             state: absent

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -5,6 +5,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
@@ -15,6 +16,7 @@
     - name: Create a Linode Firewall
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: 'ansible-test-{{ r }}'
         devices: []
@@ -40,6 +42,7 @@
     - name: Unchanged check
       linode.cloud.firewall:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: 'ansible-test-{{ r }}'
         devices: []
@@ -67,6 +70,7 @@
         - name: Delete a Linode Firewall
           linode.cloud.firewall:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             api_version: v4beta
             label: '{{ create.firewall.label }}'
             state: absent
@@ -81,6 +85,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_instance.instance.label }}'
             state: absent
           register: delete_instance

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create an instance to image
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -17,6 +18,7 @@
     - name: Create an image from the instance
       linode.cloud.image:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'cool'
@@ -31,6 +33,7 @@
     - name: Get info about the image by ID
       linode.cloud.image_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         id: '{{ image_create.image.id }}'
       register: info_id
 
@@ -43,6 +46,7 @@
     - name: Get info about the image by label
       linode.cloud.image_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ image_create.image.label }}'
       register: info_label
 
@@ -55,6 +59,7 @@
     - name: Update the image
       linode.cloud.image:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'cool2'
@@ -69,6 +74,7 @@
     - name: Overwrite the image
       linode.cloud.image:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'yooo'
@@ -88,10 +94,12 @@
       block:
         - linode.cloud.image:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ image_create.image.label }}'
             state: absent
 
         - linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ instance_create.instance.label }}'
             state: absent

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -17,6 +17,7 @@
     - name: Create an image from the image file
       linode.cloud.image:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         source_file: '{{ source_file.path }}'
         description: 'cool'
@@ -33,5 +34,6 @@
       block:
         - linode.cloud.image:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ image_create.image.label }}'
             state: absent

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode instance without a root password
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-nopass-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -25,6 +26,7 @@
     - name: Update the instance region and type (recreate disallowed)
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-southeast
         group: funny
@@ -39,6 +41,7 @@
     - name: Update the instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-east
         group: funny
@@ -56,6 +59,7 @@
     - name: Get info about the instance by id
       linode.cloud.instance_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         id: '{{ create.instance.id }}'
       register: info_id
 
@@ -70,6 +74,7 @@
     - name: Get info about the instance by label
       linode.cloud.instance_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
       register: info_label
 
@@ -86,6 +91,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ update.instance.label }}'
             state: absent
           register: delete_nopass

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a booted Linode instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
@@ -26,6 +27,7 @@
     - name: Power off the instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{create.instance.label}}'
         region: us-southeast
         type: g6-standard-1
@@ -47,6 +49,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create.instance.label }}'
             state: absent
           register: delete

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode instance with explicit disks and config
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-dc-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -56,6 +57,7 @@
     - name: Update the config
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-dc-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -92,6 +94,7 @@
     - name: Delete the config and resize the disk
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-east
         type: g6-standard-1
@@ -112,6 +115,7 @@
     - name: Try to update the disk
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-east
         type: g6-standard-1
@@ -127,6 +131,7 @@
     - name: Try to use conflicting params
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-east
         type: g6-standard-1
@@ -142,6 +147,7 @@
     - name: Boot the instance with a new config and disk
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create.instance.label }}'
         region: us-east
         type: g6-standard-1
@@ -183,6 +189,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create.instance.label }}'
             state: absent
           register: delete

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode instance with interface
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}-i'
         region: us-southeast
         type: g6-standard-1
@@ -30,6 +31,7 @@
     - name: Update the instance interfaces
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_interface.instance.label }}'
         region: us-southeast
         group: funny
@@ -54,6 +56,7 @@
     - name: Update the instance interfaces
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_interface.instance.label }}'
         region: us-southeast
         group: funny
@@ -78,6 +81,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_interface.instance.label }}'
             state: absent
           register: delete_interface

--- a/tests/integration/targets/instance_inventory/playbooks/setup_instance.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/setup_instance.yml
@@ -9,6 +9,7 @@
       linode.cloud.instance:
         label: 'ansible-test-inventory'
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         type: g6-nanode-1
         region: us-east
         tags:

--- a/tests/integration/targets/instance_inventory/playbooks/teardown.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/teardown.yml
@@ -9,6 +9,7 @@
       linode.cloud.instance:
         label: 'ansible-test-inventory'
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         type: g6-nanode-1
         region: us-east
         tags:

--- a/tests/integration/targets/instance_inventory/templates/filter.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/filter.instance.yml
@@ -1,5 +1,6 @@
 plugin: linode.cloud.instance
 api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
 types:
   - g6-nanode-1
 tags:

--- a/tests/integration/targets/instance_inventory/templates/keyedgroups.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/keyedgroups.instance.yml
@@ -1,5 +1,6 @@
 plugin: linode.cloud.instance
 api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
 keyed_groups:
   - key: tags
     separator: ''

--- a/tests/integration/targets/instance_inventory/templates/nofilter.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/nofilter.instance.yml
@@ -1,2 +1,4 @@
 plugin: linode.cloud.instance
 api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+ua_prefix: '{{ ua_prefix }}

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         k8s_version: 1.23
@@ -35,6 +36,7 @@
     - name: Update the cluster's node pools
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_cluster.cluster.label }}'
         region: us-southeast
         k8s_version: 1.23
@@ -68,6 +70,7 @@
     - name: Upgrade the cluster
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_cluster.cluster.label }}'
         region: us-southeast
         k8s_version: 1.23
@@ -102,6 +105,7 @@
       linode.cloud.lke_cluster_info:
         id: '{{ upgrade.cluster.id }}'
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
       register: info_by_id
 
     - assert:
@@ -118,6 +122,7 @@
     - name: Get info about the cluster by label
       linode.cloud.lke_cluster_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ upgrade.cluster.label }}'
       register: info_by_label
 
@@ -138,5 +143,6 @@
         - name: Delete the LKE cluster
           linode.cloud.lke_cluster:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_cluster.cluster.label }}'
             state: absent

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a minimal LKE cluster
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         k8s_version: 1.23
@@ -26,6 +27,7 @@
     - name: Add a node pool to the cluster
       linode.cloud.lke_node_pool:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         cluster_id: '{{ create_cluster.cluster.id }}'
 
         tags: ['my-pool']
@@ -44,6 +46,7 @@
     - name: Attempt to update an invalid field on the node pool
       linode.cloud.lke_node_pool:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         cluster_id: '{{ create_cluster.cluster.id }}'
 
         tags: [ 'my-pool' ]
@@ -56,6 +59,7 @@
     - name: Update the node pool
       linode.cloud.lke_node_pool:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         cluster_id: '{{ create_cluster.cluster.id }}'
 
         tags: ['my-pool']
@@ -83,11 +87,13 @@
         - name: Delete the LKE cluster node pool
           linode.cloud.lke_node_pool:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             cluster_id: '{{ create_cluster.cluster.id }}'
             tags: ['my-pool']
             state: absent
         - name: Delete the LKE cluster
           linode.cloud.lke_cluster:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_cluster.cluster.label }}'
             state: absent

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a database
       linode.cloud.database_mysql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: mysql/8.0.26
@@ -27,6 +28,7 @@
     - name: Update the database
       linode.cloud.database_mysql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: mysql/8.0.26
@@ -44,6 +46,7 @@
     - name: Update the database
       linode.cloud.database_mysql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: mysql/8.0.26
@@ -60,5 +63,6 @@
       block:
         - linode.cloud.database_mysql:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ db_create.database.label }}'
             state: absent

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Validation check
       linode.cloud.database_mysql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: mysql/8.0.26
@@ -19,6 +20,7 @@
     - name: Create a database
       linode.cloud.database_mysql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: mysql/8.0.26
@@ -64,5 +66,6 @@
       block:
         - linode.cloud.database_mysql:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ db_create.database.label }}'
             state: absent

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: create empty nodebalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-empty-{{ r }}'
         region: us-east
         state: present
@@ -20,6 +21,7 @@
     - name: update empty nodebalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
         region: us-east
         client_conn_throttle: 6
@@ -41,6 +43,7 @@
     - name: Add NodeBalancer config
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
         region: us-east
         client_conn_throttle: 6
@@ -59,6 +62,7 @@
     - name: Update NodeBalancer config
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
         region: us-east
         client_conn_throttle: 6
@@ -80,6 +84,7 @@
     - name: Recreate NodeBalancer config
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
         region: us-east
         client_conn_throttle: 6
@@ -103,6 +108,7 @@
         - name: Delete the empty NodeBalancer
           linode.cloud.nodebalancer:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_empty_nodebalancer.node_balancer.label }}'
             state: absent
           register: delete_empty

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -5,6 +5,7 @@
 
     - linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-nb-{{ r }}'
         region: us-east
         state: present
@@ -25,6 +26,7 @@
 
     - linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-node-{{ r }}'
         region: '{{ nb.node_balancer.region }}'
         private_ip: true
@@ -34,6 +36,7 @@
 
     - linode.cloud.nodebalancer_node:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         nodebalancer_id: '{{ nb.node_balancer.id }}'
         config_id: '{{ nb.configs[0].id }}'
 
@@ -55,6 +58,7 @@
 
     - linode.cloud.nodebalancer_node:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         nodebalancer_id: '{{ nb.node_balancer.id }}'
         config_id: '{{ nb.configs[0].id }}'
 
@@ -77,6 +81,7 @@
     - name: Create a populated NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-nb-{{ r }}'
         region: us-east
         state: present
@@ -100,6 +105,7 @@
 
     - linode.cloud.nodebalancer_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-nb-{{ r }}'
       register: nb_info
 
@@ -114,6 +120,7 @@
       block:
         - linode.cloud.nodebalancer_node:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             nodebalancer_id: '{{ nb.node_balancer.id }}'
             config_id: '{{ nb.configs[0].id }}'
             label: '{{ nb_node.node.label }}'
@@ -122,10 +129,12 @@
 
         - linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ inst.instance.label }}'
             state: absent
 
         - linode.cloud.nodebalancer:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ nb.node_balancer.label }}'
             state: absent

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -7,6 +7,7 @@
     - name: Create node1
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-node1-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -26,6 +27,7 @@
     - name: Create node2
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-node2-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -45,6 +47,7 @@
     - name: Create node3
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-node3-{{ r }}'
         region: us-central
         type: g6-standard-1
@@ -65,6 +68,7 @@
     - name: Create a populated NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-nb-populated-{{ r }}'
         region: us-east
         state: present
@@ -117,6 +121,7 @@
     - name: Update the NodeBalancer config
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -140,6 +145,7 @@
     - name: Attempt to update with no differences
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -161,6 +167,7 @@
     - name: Add node to NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -185,6 +192,7 @@
     - name: Add node from different region to NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -207,6 +215,7 @@
     - name: Add additional config and node to NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -239,6 +248,7 @@
     - name: Remove a config from the NodeBalancer
       linode.cloud.nodebalancer:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         region: us-east
         state: present
@@ -261,6 +271,7 @@
     - name: Get info about the NodeBalancer
       linode.cloud.nodebalancer_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
         id: '{{ create_populated_nodebalancer.node_balancer.id }}'
       register: nb_info
@@ -276,6 +287,7 @@
     - name: Get info about a NodeBalancer that doesn't exist
       linode.cloud.nodebalancer_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'fake_nodebalancer-{{ r }}'
       register: fake_nb_info
       failed_when:
@@ -287,6 +299,7 @@
         - name: Delete the populated NodeBalancer
           linode.cloud.nodebalancer:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_populated_nodebalancer.node_balancer.label }}'
             state: absent
           register: delete_populated
@@ -300,6 +313,7 @@
         - name: Delete node1
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ node1_inst.instance.label }}'
             state: absent
           register: delete_node1
@@ -313,6 +327,7 @@
         - name: Delete node2
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ node2_inst.instance.label }}'
             state: absent
           register: delete_node2
@@ -326,6 +341,7 @@
         - name: Delete node3
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ node3_inst.instance.label }}'
             state: absent
           register: delete_node3

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Get info about clusters in us-east
       linode.cloud.object_cluster_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         region: us-east
       register: info_by_region
 
@@ -18,6 +19,7 @@
     - name: Get info about cluster id us-east-1
       linode.cloud.object_cluster_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         id: us-east-1
       register: info_by_id
 
@@ -30,6 +32,7 @@
     - name: Create a Linode key
       linode.cloud.object_keys:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'test-ansible-key-{{ r }}'
         state: present
       register: create_key
@@ -57,6 +60,7 @@
     - name: Create a Linode key with access restrictions
       linode.cloud.object_keys:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'test-ansible-key-access-{{ r }}'
         access:
           - cluster: us-east-1
@@ -100,6 +104,7 @@
       - name: Remove the key
         linode.cloud.object_keys:
           api_token: '{{ api_token }}'
+          ua_prefix: '{{ ua_prefix }}'
           label: '{{ create_key.key.label }}'
           state: absent
         register: delete
@@ -113,6 +118,7 @@
       - name: Remove the restricted key
         linode.cloud.object_keys:
           api_token: '{{ api_token }}'
+          ua_prefix: '{{ ua_prefix }}'
           label: '{{ create_access.key.label }}'
           state: absent
         register: delete_access

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a database
       linode.cloud.database_postgresql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: postgresql/13.2
@@ -27,6 +28,7 @@
     - name: Update the database
       linode.cloud.database_postgresql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: postgresql/13.2
@@ -44,6 +46,7 @@
     - name: Update the database
       linode.cloud.database_postgresql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: postgresql/13.2
@@ -60,5 +63,6 @@
       block:
         - linode.cloud.database_postgresql:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ db_create.database.label }}'
             state: absent

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Validation check
       linode.cloud.database_postgresql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: postgresql/13.2
@@ -19,6 +20,7 @@
     - name: Create a database
       linode.cloud.database_postgresql:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         engine: postgresql/13.2
@@ -66,5 +68,6 @@
       block:
         - linode.cloud.database_postgresql:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ db_create.database.label }}'
             state: absent

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -3,6 +3,7 @@
     - name: Get info about the current profile
       linode.cloud.profile_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
       register: profile
 
     - assert:

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a basic stackscript without required fields
       linode.cloud.stackscript:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         state: present
       register: failed_create
@@ -14,6 +15,7 @@
     - name: Create a basic stackscript
       linode.cloud.stackscript:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         images: ['linode/alpine3.15']
         script: |
@@ -33,6 +35,7 @@
     - name: Update a basic stackscript
       linode.cloud.stackscript:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         images: ['linode/alpine3.14']
         script: |
@@ -56,5 +59,6 @@
       block:
         - linode.cloud.stackscript:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_stackscript.stackscript.label }}'
             state: absent

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create Linode Token
       linode.cloud.token:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         expiry: '2222-07-09T16:59:26'
         scopes: '*'
@@ -20,6 +21,7 @@
     - name: Update the Linode Token
       linode.cloud.token:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_token.token.label }}'
         expiry: '2222-08-09T16:59:26'
         state: present
@@ -32,5 +34,6 @@
         - name: Delete a Linode Token
           linode.cloud.token:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_token.token.label }}'
             state: absent

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create Linode User
       linode.cloud.user:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         username: 'ansible-test-{{ r }}'
         email: 'ansible-test-{{ r }}@linode.com'
         state: present
@@ -20,6 +21,7 @@
     - name: Update the Linode User
       linode.cloud.user:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         username: '{{ create_user.user.username }}'
         email: 'ansible-test-{{ r }}-changed@linode.com'
         restricted: False
@@ -38,5 +40,6 @@
         - name: Delete a Linode User
           linode.cloud.user:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             username: '{{ create_user.user.username }}'
             state: absent

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Domain to grant user access to
       linode.cloud.domain:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         domain: '{{ r }}-example.com'
         soa_email: 'dx@linode.com'
         type: master
@@ -15,6 +16,7 @@
     - name: Create Linode User
       linode.cloud.user:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         username: 'ansible-test-{{ r }}'
         email: 'ansible-test-{{ r }}@linode.com'
         grants:
@@ -43,6 +45,7 @@
     - name: Update Linode User grants
       linode.cloud.user:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         username: '{{ create_user.user.username }}'
         email: '{{ create_user.user.email }}'
         grants:
@@ -63,6 +66,7 @@
     - name: No changes
       linode.cloud.user:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         username: '{{ create_user.user.username }}'
         email: '{{ create_user.user.email }}'
         grants:
@@ -82,10 +86,12 @@
       block:
         - linode.cloud.user:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             username: '{{ create_user.user.username }}'
             state: absent
 
         - linode.cloud.domain:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             domain: '{{ create_domain.domain.domain }}'
             state: absent

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create a Linode instance with interface
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}-i'
         region: us-southeast
         type: g6-standard-1
@@ -30,6 +31,7 @@
     - name: Get information about the VLAN
       linode.cloud.vlan_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         api_version: v4beta
         label: 'really-cool-vlan'
       register: vlan_info
@@ -47,6 +49,7 @@
         - name: Delete a Linode instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_instance.instance.label }}'
             state: absent
           register: delete_instance

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -6,6 +6,7 @@
     - name: Create Linode instance
       linode.cloud.instance:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-inst-{{ r }}'
         region: us-east
         type: g6-standard-1
@@ -22,6 +23,7 @@
     - name: Create a volume with an instance
       linode.cloud.volume:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-attached-{{ r }}'
         region: us-east
         size: 30
@@ -39,6 +41,7 @@
     - name: Create a volume without an instance
       linode.cloud.volume:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-east
         size: 42
@@ -54,6 +57,7 @@
     - name: Resize the volume
       linode.cloud.volume:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_volume_noinst.volume.label }}'
         size: 50
         state: present
@@ -68,6 +72,7 @@
     - name: Attach the volume to a Linode
       linode.cloud.volume:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_volume_noinst.volume.label }}'
         linode_id: '{{ create_inst.instance.id }}'
         state: present
@@ -82,6 +87,7 @@
     - name: Get info about the volume by label
       linode.cloud.volume_info:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_volume_noinst.volume.label }}'
       register: volume_info_label
 
@@ -94,6 +100,7 @@
     - name: Detach the volume
       linode.cloud.volume:
         api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_volume_noinst.volume.label }}'
         attached: false
         state: present
@@ -111,6 +118,7 @@
         - name: Delete the instance volume
           linode.cloud.volume:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_volume_inst.volume.label }}'
             state: absent
           register: delete_volume_inst
@@ -123,6 +131,7 @@
         - name: Delete the volume
           linode.cloud.volume:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_volume_noinst.volume.label }}'
             state: absent
           register: delete_volume_noinst
@@ -135,6 +144,7 @@
         - name: Delete the instance
           linode.cloud.instance:
             api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
             label: '{{ create_inst.instance.label }}'
             state: absent
           register: delete_inst


### PR DESCRIPTION
This change allows users to specify a custom User-Agent prefix for tracking purposes. Additionally, all E2E tests now have the `E2E` UA prefix.

At the moment, there isn't an efficient way to share environment variables within integration tests so the `ua_prefix` field has been added to each module call.

A custom UA prefix can be defined through the `ua_prefix` field on each module or through the `LINODE_UA_PREFIX` environment variable.