### PR TITLE
Feature/issue 216

### DIFF
--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -65,7 +65,7 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
+| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent`  `update` ) |
 | `label` | `str` | Optional | The unique label to give this Firewall.   |
 | [`devices` (sub-options)](#devices) | `list` | Optional | The devices that are attached to this Firewall.   |
 | [`rules` (sub-options)](#rules) | `dict` | Optional | The inbound and outbound access rules to apply to this Firewall.   |
@@ -104,7 +104,7 @@ Manage Linode Firewalls.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | `str` | **Required** | The label of this rule.   |
-| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.   |
+| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.  (Choices:  `ACCEPT`  `DROP` ) |
 | [`addresses` (sub-options)](#addresses) | `dict` | Optional | Allowed IPv4 or IPv6 addresses.   |
 | `description` | `str` | Optional | A description for this rule.   |
 | `ports` | `str` | Optional | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |
@@ -130,7 +130,7 @@ Manage Linode Firewalls.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | `str` | **Required** | The label of this rule.   |
-| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.   |
+| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.  (Choices:  `ACCEPT`  `DROP` ) |
 | [`addresses` (sub-options)](#addresses) | `dict` | Optional | Allowed IPv4 or IPv6 addresses.   |
 | `description` | `str` | Optional | A description for this rule.   |
 | `ports` | `str` | Optional | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -242,7 +242,7 @@ class LinodeFirewall(LinodeModuleBase):
 
         return result
 
-    def _amend_rules(self, remote_rules: list, local_rules: list) -> None:
+    def _amend_rules(self, remote_rules: list, local_rules: list) -> list:
         # produce a result list in the same order as remote_rules
         # amended by the updates from the local_rules
 

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -260,7 +260,7 @@ class LinodeFirewall(LinodeModuleBase):
             # insert all missing fields in local_rule from remote_rule
             local_rule = local_labeled_rules[remote_rule['label']]
             for field in linode_firewall_rule_spec:
-                if field not in local_rule:
+                if field not in local_rule and field in remote_rule:
                     local_rule[field]=remote_rule[field]
             result.append(local_rule)
         return result

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -285,7 +285,8 @@ class LinodeFirewall(LinodeModuleBase):
         return local_rules
 
     def _change_rules(self) -> Optional[dict]:
-        """Updates remote firewall rules relative to user-supplied new rules, and returns whether anything changed."""
+        """Updates remote firewall rules relative to user-supplied new rules,
+           and returns whether anything changed."""
         local_rules = filter_null_values_recursive(self.module.params['rules'])
         remote_rules = filter_null_values_recursive(mapping_to_dict(self._firewall.rules))
 

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -1,0 +1,613 @@
+tasks:
+- name: "firewall update tests"
+  block:
+    - set_fact:
+	r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+	state: present
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: 'ansible-test-{{ r }}'
+	devices: []
+	rules:
+	  inbound: []
+	  inbound_policy: DROP
+	  outbound: []
+	  outbound_policy: DROP
+      register: create
+
+    - name: Assert firewall created
+      assert:
+	that:
+	  - create.changed
+
+    - name: "Try ... Rescue"
+      block:
+	- name: "Expect fatal: Try to Update Linode Firewall rule that does not exist"
+	  linode.cloud.firewall:
+	    state: update
+	    api_token: '{{ api_token }}'
+	    api_version: v4beta
+	    label: '{{ create.firewall.label }}'
+	    devices: []
+	    rules:
+	      inbound:
+		- label: NOTTHERE
+		  action: DROP
+		  addresses:
+		    ipv4: ['0.0.0.0/0']
+		    ipv6: ['ff00::/8']
+		  description: 'Really cool firewall rule.'
+		  ports: '80,443'
+		  protocol: TCP
+	  register: failedupdaterules
+
+      rescue:
+	- name: "Caught fatal update. Checking return values."
+	  assert:
+	    that:
+	      - not failedupdaterules.changed
+
+    - name: Set Linode Firewall disabled
+      linode.cloud.firewall:
+	state: present
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound: []
+	  inbound_policy: DROP
+	  outbound: []
+	  outbound_policy: DROP
+	status: disabled
+      register: updaterules
+
+    - name: Assert firewall updated to disabled
+      assert:
+	that:
+	  - updaterules.changed
+	  - updaterules.firewall.status == 'disabled'
+
+    - name: Update Linode Firewall to enabled
+      linode.cloud.firewall:
+	state: update
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	status: enabled
+      register: updaterules
+
+    - name: Assert firewall updated to enabled
+      assert:
+	that:
+	  - updaterules.changed
+	  - updaterules.firewall.status == 'enabled'
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info same as updatedrules
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+    - name: Update Linode Firewall inbound/outbound policy to ACCEPT
+      linode.cloud.firewall:
+	state: update
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound_policy: ACCEPT
+	  outbound_policy: ACCEPT
+	status: enabled
+      register: update
+
+    - name: Assert firewall updated
+      assert:
+	that:
+	  - update.changed
+	  - update.firewall.rules.inbound_policy == 'ACCEPT'
+	  - update.firewall.rules.outbound_policy == 'ACCEPT'
+
+    - name: Set Linode Firewall inbound/outbound rules + policy to DROP
+      linode.cloud.firewall:
+	state: present
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound_policy: DROP
+	  inbound:
+	    - label: cool-http-in
+	      action: DROP
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+		ipv6: ['ff00::/8']
+	      description: 'Really cool firewall rule.'
+	      ports: '80,443'
+	      protocol: TCP
+
+	  outbound_policy: DROP
+	  outbound:
+	    - label: cool-http-out
+	      action: DROP
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+		ipv6: ['ff00::/8']
+	      description: 'Really cool firewall rule.'
+	      ports: '80,443'
+	      protocol: TCP
+      register: updaterules
+
+    - name: Assert firewall rules set
+      assert:
+	that:
+	  - updaterules.changed
+
+	  - updaterules.devices|length == 0
+
+	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+	  - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.inbound[0].action == 'DROP'
+	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+	  - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+
+	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+	  - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.outbound[0].action == 'DROP'
+	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+	  - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info same as updatedrules
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+
+    - name: "Try ... Rescue (2)"
+      block:
+	- name: "Expect fatal: Try to Update Linode Firewall (2) rule that does not exist"
+	  linode.cloud.firewall:
+	    state: update
+	    api_token: '{{ api_token }}'
+	    api_version: v4beta
+	    label: '{{ create.firewall.label }}'
+	    devices: []
+	    rules:
+	      inbound:
+		- label: NOTTHERE
+		  action: DROP
+		  addresses:
+		    ipv4: ['0.0.0.0/0']
+		    ipv6: ['ff00::/8']
+		  description: 'Really cool firewall rule.'
+		  ports: '80,443'
+		  protocol: TCP
+	  register: failedupdaterules
+
+      rescue:
+	- name: "Caught fatal update. Checking return values."
+	  assert:
+	    that:
+	      - not failedupdaterules.changed
+
+    - name: Update labeled rules to action=ACCEPT
+      linode.cloud.firewall:
+	state: update
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+      register: updaterules
+
+
+    - name: Assert firewall rules updated
+      assert:
+	that:
+	  - updaterules.changed
+
+	  - updaterules.devices|length == 0
+
+	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+	  - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+
+	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+	  - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info same as updatedrules
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+
+    - name: Update labeled rules description to "Amazing rule."
+      linode.cloud.firewall:
+	state: update
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	      description: 'Amazing rule.'
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+	      description: 'Amazing rule.'
+      register: updaterules
+
+    - name: Assert firewall rules updated
+      assert:
+	that:
+	  - updaterules.changed
+
+	  - updaterules.devices|length == 0
+
+	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+	  - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
+	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+
+	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+	  - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
+	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info same as updatedrules
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+
+    - name: Update labeled rules ipv4 addresses
+      linode.cloud.firewall:
+	state: update
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
+      register: updaterules
+
+    - name: Assert firewall rules updated
+      assert:
+	that:
+	  - updaterules.changed
+
+	  - updaterules.devices|length == 0
+
+	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+	  - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
+	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+
+	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+	  - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
+	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
+	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+	  - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info same as updatedrules
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+    - name: Update Description of Linode Firewall rules
+      linode.cloud.firewall:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	      description: 'Amazing firewall rule.'
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+	      description: 'Amazing firewall rule.'
+	state: update
+      register: updaterules
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+    - name: Update IP addresses Linode Firewall rules
+      linode.cloud.firewall:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+	state: update
+      register: updaterules
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+    - name: Make update that should not cause any Linode Firewall changes
+      linode.cloud.firewall:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+	devices: []
+	rules:
+	  inbound:
+	    - label: cool-http-in
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+	  outbound:
+	    - label: cool-http-out
+	      action: ACCEPT
+	      addresses:
+		ipv4: ['0.0.0.0/0']
+	state: update
+      register: updaterules
+
+    - name: Assert firewall rules did not update
+      assert:
+	that:
+	  - not updaterules.changed
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+	api_token: '{{ api_token }}'
+	api_version: v4beta
+	label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall info
+      assert:
+	that:
+	  - firewall_info.devices|length == 0
+
+	  - firewall_info.firewall.id == create.firewall.id
+	  - firewall_info.firewall.status == updaterules.firewall.status
+
+	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+
+	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+
+  always:
+    - ignore_errors: yes
+      block:
+	- name: Delete a Linode Firewall
+	  linode.cloud.firewall:
+	    api_token: '{{ api_token }}'
+	    api_version: v4beta
+	    label: '{{ create.firewall.label }}'
+	    state: absent
+	  register: delete
+
+	- name: Assert Firewall delete succeeded
+	  assert:
+	    that:
+	      - delete.changed
+	      - delete.firewall.id == create.firewall.id
+

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -1,613 +1,609 @@
-tasks:
 - name: "firewall update tests"
   block:
     - set_fact:
-	r: "{{ 1000000000 | random }}"
+        r: "{{ 1000000000 | random }}"
 
     - name: Create a Linode Firewall
       linode.cloud.firewall:
-	state: present
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: 'ansible-test-{{ r }}'
-	devices: []
-	rules:
-	  inbound: []
-	  inbound_policy: DROP
-	  outbound: []
-	  outbound_policy: DROP
+        state: present
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: 'ansible-test-{{ r }}'
+        devices: []
+        rules:
+          inbound: []
+          inbound_policy: DROP
+          outbound: []
+          outbound_policy: DROP
       register: create
 
     - name: Assert firewall created
       assert:
-	that:
-	  - create.changed
+        that:
+          - create.changed
 
     - name: "Try ... Rescue"
       block:
-	- name: "Expect fatal: Try to Update Linode Firewall rule that does not exist"
-	  linode.cloud.firewall:
-	    state: update
-	    api_token: '{{ api_token }}'
-	    api_version: v4beta
-	    label: '{{ create.firewall.label }}'
-	    devices: []
-	    rules:
-	      inbound:
-		- label: NOTTHERE
-		  action: DROP
-		  addresses:
-		    ipv4: ['0.0.0.0/0']
-		    ipv6: ['ff00::/8']
-		  description: 'Really cool firewall rule.'
-		  ports: '80,443'
-		  protocol: TCP
-	  register: failedupdaterules
+        - name: "Expect fatal: Try to Update Linode Firewall rule that does not exist"
+          linode.cloud.firewall:
+            state: update
+            api_token: '{{ api_token }}'
+            api_version: v4beta
+            label: '{{ create.firewall.label }}'
+            devices: []
+            rules:
+              inbound:
+                - label: NOTTHERE
+                  action: DROP
+                  addresses:
+                    ipv4: ['0.0.0.0/0']
+                    ipv6: ['ff00::/8']
+                  description: 'Really cool firewall rule.'
+                  ports: '80,443'
+                  protocol: TCP
+          register: failedupdaterules
 
       rescue:
-	- name: "Caught fatal update. Checking return values."
-	  assert:
-	    that:
-	      - not failedupdaterules.changed
+        - name: "Caught fatal update. Checking return values."
+          assert:
+            that:
+              - not failedupdaterules.changed
 
     - name: Set Linode Firewall disabled
       linode.cloud.firewall:
-	state: present
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound: []
-	  inbound_policy: DROP
-	  outbound: []
-	  outbound_policy: DROP
-	status: disabled
+        state: present
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound: []
+          inbound_policy: DROP
+          outbound: []
+          outbound_policy: DROP
+        status: disabled
       register: updaterules
 
     - name: Assert firewall updated to disabled
       assert:
-	that:
-	  - updaterules.changed
-	  - updaterules.firewall.status == 'disabled'
+        that:
+          - updaterules.changed
+          - updaterules.firewall.status == 'disabled'
 
     - name: Update Linode Firewall to enabled
       linode.cloud.firewall:
-	state: update
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	status: enabled
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        status: enabled
       register: updaterules
 
     - name: Assert firewall updated to enabled
       assert:
-	that:
-	  - updaterules.changed
-	  - updaterules.firewall.status == 'enabled'
+        that:
+          - updaterules.changed
+          - updaterules.firewall.status == 'enabled'
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info same as updatedrules
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
     - name: Update Linode Firewall inbound/outbound policy to ACCEPT
       linode.cloud.firewall:
-	state: update
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound_policy: ACCEPT
-	  outbound_policy: ACCEPT
-	status: enabled
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound_policy: ACCEPT
+          outbound_policy: ACCEPT
+        status: enabled
       register: update
 
     - name: Assert firewall updated
       assert:
-	that:
-	  - update.changed
-	  - update.firewall.rules.inbound_policy == 'ACCEPT'
-	  - update.firewall.rules.outbound_policy == 'ACCEPT'
+        that:
+          - update.changed
+          - update.firewall.rules.inbound_policy == 'ACCEPT'
+          - update.firewall.rules.outbound_policy == 'ACCEPT'
 
     - name: Set Linode Firewall inbound/outbound rules + policy to DROP
       linode.cloud.firewall:
-	state: present
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound_policy: DROP
-	  inbound:
-	    - label: cool-http-in
-	      action: DROP
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-		ipv6: ['ff00::/8']
-	      description: 'Really cool firewall rule.'
-	      ports: '80,443'
-	      protocol: TCP
+        state: present
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound_policy: DROP
+          inbound:
+            - label: cool-http-in
+              action: DROP
+              addresses:
+                ipv4: ['0.0.0.0/0']
+                ipv6: ['ff00::/8']
+              description: 'Really cool firewall rule.'
+              ports: '80,443'
+              protocol: TCP
 
-	  outbound_policy: DROP
-	  outbound:
-	    - label: cool-http-out
-	      action: DROP
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-		ipv6: ['ff00::/8']
-	      description: 'Really cool firewall rule.'
-	      ports: '80,443'
-	      protocol: TCP
+          outbound_policy: DROP
+          outbound:
+            - label: cool-http-out
+              action: DROP
+              addresses:
+                ipv4: ['0.0.0.0/0']
+                ipv6: ['ff00::/8']
+              description: 'Really cool firewall rule.'
+              ports: '80,443'
+              protocol: TCP
       register: updaterules
 
     - name: Assert firewall rules set
       assert:
-	that:
-	  - updaterules.changed
+        that:
+          - updaterules.changed
 
-	  - updaterules.devices|length == 0
+          - updaterules.devices|length == 0
 
-	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-	  - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
-	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.inbound[0].action == 'DROP'
-	  - updaterules.firewall.rules.inbound_policy == 'DROP'
-	  - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+          - updaterules.firewall.rules.inbound[0].ports == '80,443'
+          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.inbound[0].action == 'DROP'
+          - updaterules.firewall.rules.inbound_policy == 'DROP'
+          - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0']
 
-	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-	  - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
-	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.outbound[0].action == 'DROP'
-	  - updaterules.firewall.rules.outbound_policy == 'DROP'
-	  - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+          - updaterules.firewall.rules.outbound[0].ports == '80,443'
+          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.outbound[0].action == 'DROP'
+          - updaterules.firewall.rules.outbound_policy == 'DROP'
+          - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0']
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info same as updatedrules
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
 
     - name: "Try ... Rescue (2)"
       block:
-	- name: "Expect fatal: Try to Update Linode Firewall (2) rule that does not exist"
-	  linode.cloud.firewall:
-	    state: update
-	    api_token: '{{ api_token }}'
-	    api_version: v4beta
-	    label: '{{ create.firewall.label }}'
-	    devices: []
-	    rules:
-	      inbound:
-		- label: NOTTHERE
-		  action: DROP
-		  addresses:
-		    ipv4: ['0.0.0.0/0']
-		    ipv6: ['ff00::/8']
-		  description: 'Really cool firewall rule.'
-		  ports: '80,443'
-		  protocol: TCP
-	  register: failedupdaterules
+        - name: "Expect fatal: Try to Update Linode Firewall (2) rule that does not exist"
+          linode.cloud.firewall:
+            state: update
+            api_token: '{{ api_token }}'
+            api_version: v4beta
+            label: '{{ create.firewall.label }}'
+            devices: []
+            rules:
+              inbound:
+              - label: NOTTHERE
+                action: DROP
+                addresses:
+                  ipv4: ['0.0.0.0/0']
+                  ipv6: ['ff00::/8']
+                description: 'Really cool firewall rule.'
+                ports: '80,443'
+                protocol: TCP
+          register: failedupdaterules
 
       rescue:
-	- name: "Caught fatal update. Checking return values."
-	  assert:
-	    that:
-	      - not failedupdaterules.changed
+        - name: "Caught fatal update. Checking return values."
+          assert:
+            that:
+              - not failedupdaterules.changed
 
     - name: Update labeled rules to action=ACCEPT
       linode.cloud.firewall:
-	state: update
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
       register: updaterules
 
 
     - name: Assert firewall rules updated
       assert:
-	that:
-	  - updaterules.changed
+        that:
+          - updaterules.changed
 
-	  - updaterules.devices|length == 0
+          - updaterules.devices|length == 0
 
-	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-	  - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
-	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+          - updaterules.firewall.rules.inbound[0].ports == '80,443'
+          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.inbound_policy == 'DROP'
 
-	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-	  - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
-	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.outbound_policy == 'DROP'
-
+          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+          - updaterules.firewall.rules.outbound[0].ports == '80,443'
+          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.outbound_policy == 'DROP'
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info same as updatedrules
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
 
     - name: Update labeled rules description to "Amazing rule."
       linode.cloud.firewall:
-	state: update
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	      description: 'Amazing rule.'
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
-	      description: 'Amazing rule.'
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+              description: 'Amazing rule.'
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
+              description: 'Amazing rule.'
       register: updaterules
 
     - name: Assert firewall rules updated
       assert:
-	that:
-	  - updaterules.changed
+        that:
+          - updaterules.changed
 
-	  - updaterules.devices|length == 0
+          - updaterules.devices|length == 0
 
-	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-	  - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
-	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
+          - updaterules.firewall.rules.inbound[0].ports == '80,443'
+          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.inbound_policy == 'DROP'
 
-	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-	  - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
-	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
+          - updaterules.firewall.rules.outbound[0].ports == '80,443'
+          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.outbound_policy == 'DROP'
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info same as updatedrules
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
-
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
     - name: Update labeled rules ipv4 addresses
       linode.cloud.firewall:
-	state: update
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
       register: updaterules
 
     - name: Assert firewall rules updated
       assert:
-	that:
-	  - updaterules.changed
+        that:
+          - updaterules.changed
 
-	  - updaterules.devices|length == 0
+          - updaterules.devices|length == 0
 
-	  - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-	  - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
-	  - updaterules.firewall.rules.inbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
-	  - updaterules.firewall.rules.inbound_policy == 'DROP'
+          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
+          - updaterules.firewall.rules.inbound[0].ports == '80,443'
+          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+          - updaterules.firewall.rules.inbound_policy == 'DROP'
 
-	  - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-	  - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
-	  - updaterules.firewall.rules.outbound[0].ports == '80,443'
-	  - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-	  - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-	  - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
-	  - updaterules.firewall.rules.outbound_policy == 'DROP'
+          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
+          - updaterules.firewall.rules.outbound[0].ports == '80,443'
+          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
+          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
+          - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+          - updaterules.firewall.rules.outbound_policy == 'DROP'
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info same as updatedrules
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
     - name: Update Description of Linode Firewall rules
       linode.cloud.firewall:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	      description: 'Amazing firewall rule.'
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
-	      description: 'Amazing firewall rule.'
-	state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+              description: 'Amazing firewall rule.'
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
+              description: 'Amazing firewall rule.'
+        state: update
       register: updaterules
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
     - name: Update IP addresses Linode Firewall rules
       linode.cloud.firewall:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-	state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0']
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0']
+        state: update
       register: updaterules
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
     - name: Make update that should not cause any Linode Firewall changes
       linode.cloud.firewall:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
-	devices: []
-	rules:
-	  inbound:
-	    - label: cool-http-in
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-	  outbound:
-	    - label: cool-http-out
-	      action: ACCEPT
-	      addresses:
-		ipv4: ['0.0.0.0/0']
-	state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound:
+            - label: cool-http-in
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0']
+          outbound:
+            - label: cool-http-out
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0']
+        state: update
       register: updaterules
 
     - name: Assert firewall rules did not update
       assert:
-	that:
-	  - not updaterules.changed
+        that:
+          - not updaterules.changed
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
-	api_token: '{{ api_token }}'
-	api_version: v4beta
-	label: '{{ create.firewall.label }}'
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
       register: firewall_info
 
     - name: Assert firewall info
       assert:
-	that:
-	  - firewall_info.devices|length == 0
+        that:
+          - firewall_info.devices|length == 0
 
-	  - firewall_info.firewall.id == create.firewall.id
-	  - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.firewall.status == updaterules.firewall.status
 
-	  - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-	  - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-	  - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-	  - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-	  - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-	  - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
+          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
+          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
+          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
+          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
+          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
+          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
 
-	  - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-	  - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-	  - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-	  - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-	  - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-	  - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
+          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
+          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
+          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
+          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
+          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
 
   always:
     - ignore_errors: yes
       block:
-	- name: Delete a Linode Firewall
-	  linode.cloud.firewall:
-	    api_token: '{{ api_token }}'
-	    api_version: v4beta
-	    label: '{{ create.firewall.label }}'
-	    state: absent
-	  register: delete
+        - name: Delete a Linode Firewall
+          linode.cloud.firewall:
+            api_token: '{{ api_token }}'
+            api_version: v4beta
+            label: '{{ create.firewall.label }}'
+            state: absent
+          register: delete
 
-	- name: Assert Firewall delete succeeded
-	  assert:
-	    that:
-	      - delete.changed
-	      - delete.firewall.id == create.firewall.id
-
+        - name: Assert Firewall delete succeeded
+          assert:
+            that:
+              - delete.changed
+              - delete.firewall.id == create.firewall.id


### PR DESCRIPTION
Draft PR for linode.cloud.firewall `state=update` feature. The focus of the `update` feature was for rules. The intent is for a workflow such that one can update specifically labeled rules without needing to know their position within the rules list. For example, a user may add arbitrary rules to a firewall (manually or using some other tool) and then one wants to use ansible to update specifically labeled rules.