### PR TITLE
fix: Strip FQDN from `domain_record` name

### DIFF
--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -46,7 +46,7 @@ NOTE: Domain records are identified by their name, target, and type.
 | `domain_id` | `int` | Optional | The ID of the parent Domain.   |
 | `domain` | `str` | Optional | The name of the parent Domain.   |
 | `record_id` | `int` | Optional | The id of the record to modify.   |
-| `name` | `str` | Optional | The name of this Record.   |
+| `name` | `str` | Optional | The name of this Record. NOTE: If the name of the record ends with the domain, it will be dropped from the resulting record's name.   |
 | `port` | `int` | Optional | The port this Record points to. Only valid and required for SRV record requests.   |
 | `priority` | `int` | Optional | The priority of the target host for this Record. Lower values are preferred. Only valid for MX and SRV record requests. Required for SRV record requests.   |
 | `protocol` | `str` | Optional | The protocol this Record’s service communicates with. An underscore (_) is prepended automatically to the submitted value for this property.   |

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -165,6 +165,54 @@
         that:
           - domain_info.records|length == 3
 
+    - name: Create a record containing FQDN
+      linode.cloud.domain_record:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'fqdn.{{ domain_create.domain.domain }}'
+        type: 'A'
+        target: '127.0.0.2'
+        state: present
+      register: record_fqdn_create
+
+    - assert:
+        that:
+          - record_fqdn_create.record.name == 'fqdn'
+          - record_fqdn_create.changed
+
+    - name: Create a record containing FQDN
+      linode.cloud.domain_record:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'fqdn.{{ domain_create.domain.domain }}'
+        type: 'A'
+        target: '127.0.0.2'
+        state: present
+      register: record_fqdn_nochange
+
+    - assert:
+        that:
+          - record_fqdn_nochange.record.name == 'fqdn'
+          - record_fqdn_nochange.changed == False
+
+    - name: Delete a record containing FQDN
+      linode.cloud.domain_record:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'fqdn.{{ domain_create.domain.domain }}'
+        type: 'A'
+        target: '127.0.0.2'
+        state: absent
+      register: record_fqdn_delete
+
+    - assert:
+        that:
+          - record_fqdn_delete.record.name == 'fqdn'
+          - record_fqdn_delete.changed
+
   always:
     - ignore_errors: yes
       block:


### PR DESCRIPTION
This change strips the domain name from the end of the domain record `name` field if it is included. This mirrors the equivalent behavior on the Linode API.