### PR TITLE
fix: Use Python 3.10 for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: install dependencies
         run: pip3 install -r requirements-dev.txt -r requirements.txt


### PR DESCRIPTION
This change is necessary as `ansible-test` does not currently support Python 3.11. This change should be reverted in the future.