### PR TITLE
Replace `str.removesuffix` usage in domain_record module

### DIFF
--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -140,11 +140,14 @@ class LinodeDomainRecord(LinodeModuleBase):
 
     def _find_record(self, domain: Domain, name: str, rtype: str, target: str) \
             -> Optional[DomainRecord]:
+        # We should strip the FQDN from the user-defined record name if defined.
+        suffix = '.' + domain.domain
+        search_name = name
+        if search_name.endswith(suffix):
+            search_name = search_name[:-len(suffix)]
         try:
             for record in domain.records:
-                # We should strip the FQDN from the user-defined record name
-                # if defined.
-                if record.name == name.removesuffix('.' + domain.domain) \
+                if record.name == search_name \
                         and record.type == rtype \
                         and record.target == target:
                     return record


### PR DESCRIPTION
`str.removesuffix` is new in Python 3.9:
https://docs.python.org/3/library/stdtypes.html#str.removesuffix

Python 3.7 and 3.8 are still in support:
https://devguide.python.org/versions/

On Python 3.7 or 3.8, the `domain_record` module fails with `failed to get domain record example.com: 'str' object has no attribute 'removesuffix'`

Python 3.8 is the default version of Python on Ubuntu 20.04 which is how this issue was discovered.

This change replaces the only usage of `str.removesuffix` in this repository with a conditional slice to restore compatibility with Python 3.7 and 3.8. This replacement provides the same functionality.