### PR TITLE
new: Display whether a field is updatable in generated documentation

### DIFF
--- a/docs/modules/api_request.md
+++ b/docs/modules/api_request.md
@@ -42,11 +42,11 @@ The Linode API documentation can be found here: https://www.linode.com/docs/api
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `path` | `str` | **Required** | The relative path to the endpoint to make a request to. e.g. "linode/instances"   |
-| `method` | `str` | **Required** | The HTTP method of the request or response.  (Choices:  `POST`  `PUT`  `GET`  `DELETE` ) |
-| `body` | `dict` | Optional | The body of the request. This is a YAML structure that will be marshalled to JSON.   |
-| `body_json` | `str` | Optional | The body of the request in JSON format.   |
-| `filters` | `dict` | Optional | A YAML structure corresponding to the X-Filter request header. See: https://www.linode.com/docs/api/#filtering-and-sorting   |
+| `path` | <center>`str`</center> | <center>**Required**</center> | The relative path to the endpoint to make a request to. e.g. "linode/instances"   |
+| `method` | <center>`str`</center> | <center>**Required**</center> | The HTTP method of the request or response.  **(Choices: `POST`, `PUT`, `GET`, `DELETE`)** |
+| `body` | <center>`dict`</center> | <center>Optional</center> | The body of the request. This is a YAML structure that will be marshalled to JSON.   |
+| `body_json` | <center>`str`</center> | <center>Optional</center> | The body of the request in JSON format.   |
+| `filters` | <center>`dict`</center> | <center>Optional</center> | A YAML structure corresponding to the X-Filter request header. See: https://www.linode.com/docs/api/#filtering-and-sorting   |
 
 
 

--- a/docs/modules/database_mysql.md
+++ b/docs/modules/database_mysql.md
@@ -60,11 +60,11 @@ Manage a Linode MySQL database.
 | `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
-| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`;Default: `1`)** |
+| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`; Default: `1`)** |
 | `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The Region ID for the Managed Database.   |
-| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`;Default: `none`)** |
+| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`; Default: `none`)** |
 | `ssl_connection` | <center>`bool`</center> | <center>Optional</center> | Whether to require SSL credentials to establish a connection to the Managed Database.  **(Default: `True`)** |
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.   |
 | [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
@@ -82,7 +82,7 @@ Manage a Linode MySQL database.
 | `day_of_week` | <center>`int`</center> | <center>**Required**</center> | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  **(Choices: `1`, `2`, `3`, `4`, `5`, `6`, `7`)** |
 | `duration` | <center>`int`</center> | <center>**Required**</center> | The maximum maintenance window time in hours.  **(Choices: `1`, `3`)** |
 | `hour_of_day` | <center>`int`</center> | <center>**Required**</center> | The hour to begin maintenance based in UTC time.   |
-| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`;Default: `weekly`)** |
+| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`; Default: `weekly`)** |
 | `week_of_month` | <center>`int`</center> | <center>Optional</center> | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
 
 

--- a/docs/modules/database_mysql.md
+++ b/docs/modules/database_mysql.md
@@ -57,19 +57,19 @@ Manage a Linode MySQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This database's unique label.   |
-| `state` | `str` | **Required** | The state of this database.  (Choices:  `present`  `absent` ) |
-| `allow_list` | `list` | Optional | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.   |
-| `cluster_size` | `int` | Optional | The number of Linode Instance nodes deployed to the Managed Database.  (Choices:  `1`  `3` Default: `1`) |
-| `encrypted` | `bool` | Optional | Whether the Managed Databases is encrypted.   |
-| `engine` | `str` | Optional | The Managed Database engine in engine/version format.   |
-| `region` | `str` | Optional | The Region ID for the Managed Database.   |
-| `replication_type` | `str` | Optional | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  (Choices:  `none`  `asynch`  `semi_synch` Default: `none`) |
-| `ssl_connection` | `bool` | Optional | Whether to require SSL credentials to establish a connection to the Managed Database.  (Default: `True`) |
-| `type` | `str` | Optional | The Linode Instance type used by the Managed Database for its nodes.   |
-| [`updates` (sub-options)](#updates) | `dict` | Optional | Configuration settings for automated patch update maintenance for the Managed Database.   |
-| `wait` | `bool` | Optional | Wait for the database to have status `available` before returning.  (Default: `True`) |
-| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for an image to have status `available`.  (Default: `3600`) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
+| `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
+| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`;Default: `1`)** |
+| `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |
+| `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The Region ID for the Managed Database.   |
+| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`;Default: `none`)** |
+| `ssl_connection` | <center>`bool`</center> | <center>Optional</center> | Whether to require SSL credentials to establish a connection to the Managed Database.  **(Default: `True`)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.   |
+| [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
+| `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the database to have status `available` before returning.  **(Default: `True`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an image to have status `available`.  **(Default: `3600`)** |
 
 
 
@@ -79,11 +79,11 @@ Manage a Linode MySQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `day_of_week` | `int` | **Required** | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  (Choices:  `1`  `2`  `3`  `4`  `5`  `6`  `7` ) |
-| `duration` | `int` | **Required** | The maximum maintenance window time in hours.  (Choices:  `1`  `3` ) |
-| `hour_of_day` | `int` | **Required** | The hour to begin maintenance based in UTC time.   |
-| `frequency` | `str` | Optional | Whether maintenance occurs on a weekly or monthly basis.  (Choices:  `weekly`  `monthly` Default: `weekly`) |
-| `week_of_month` | `int` | Optional | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
+| `day_of_week` | <center>`int`</center> | <center>**Required**</center> | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  **(Choices: `1`, `2`, `3`, `4`, `5`, `6`, `7`)** |
+| `duration` | <center>`int`</center> | <center>**Required**</center> | The maximum maintenance window time in hours.  **(Choices: `1`, `3`)** |
+| `hour_of_day` | <center>`int`</center> | <center>**Required**</center> | The hour to begin maintenance based in UTC time.   |
+| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`;Default: `weekly`)** |
+| `week_of_month` | <center>`int`</center> | <center>Optional</center> | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
 
 
 

--- a/docs/modules/database_mysql_info.md
+++ b/docs/modules/database_mysql_info.md
@@ -34,8 +34,8 @@ Get info about a Linode MySQL Managed Database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `str` | Optional | The ID of the MySQL Database.   |
-| `label` | `str` | Optional | The label of the MySQL Database.   |
+| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the MySQL Database.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the MySQL Database.   |
 
 
 

--- a/docs/modules/database_postgresql.md
+++ b/docs/modules/database_postgresql.md
@@ -58,20 +58,20 @@ Manage a Linode PostgreSQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This database's unique label.   |
-| `state` | `str` | **Required** | The state of this database.  (Choices:  `present`  `absent` ) |
-| `allow_list` | `list` | Optional | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.   |
-| `cluster_size` | `int` | Optional | The number of Linode Instance nodes deployed to the Managed Database.  (Choices:  `1`  `3` Default: `1`) |
-| `encrypted` | `bool` | Optional | Whether the Managed Databases is encrypted.   |
-| `engine` | `str` | Optional | The Managed Database engine in engine/version format.   |
-| `region` | `str` | Optional | The Region ID for the Managed Database.   |
-| `replication_type` | `str` | Optional | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  (Choices:  `none`  `asynch`  `semi_synch` Default: `none`) |
-| `replication_commit_type` | `str` | Optional | The synchronization level of the replicating server. Must be local or off for the asynch replication type. Must be on, remote_write, or remote_apply for the semi_synch replication type.  (Choices:  `off`  `on`  `local`  `remote_write`  `remote_apply` Default: `local`) |
-| `ssl_connection` | `bool` | Optional | Whether to require SSL credentials to establish a connection to the Managed Database.  (Default: `True`) |
-| `type` | `str` | Optional | The Linode Instance type used by the Managed Database for its nodes.   |
-| [`updates` (sub-options)](#updates) | `dict` | Optional | Configuration settings for automated patch update maintenance for the Managed Database.   |
-| `wait` | `bool` | Optional | Wait for the database to have status `available` before returning.  (Default: `True`) |
-| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for an image to have status `available`.  (Default: `3600`) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
+| `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
+| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`;Default: `1`)** |
+| `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |
+| `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The Region ID for the Managed Database.   |
+| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`;Default: `none`)** |
+| `replication_commit_type` | <center>`str`</center> | <center>Optional</center> | The synchronization level of the replicating server. Must be local or off for the asynch replication type. Must be on, remote_write, or remote_apply for the semi_synch replication type.  **(Choices: `off`, `on`, `local`, `remote_write`, `remote_apply`;Default: `local`)** |
+| `ssl_connection` | <center>`bool`</center> | <center>Optional</center> | Whether to require SSL credentials to establish a connection to the Managed Database.  **(Default: `True`)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.   |
+| [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
+| `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the database to have status `available` before returning.  **(Default: `True`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an image to have status `available`.  **(Default: `3600`)** |
 
 
 
@@ -81,11 +81,11 @@ Manage a Linode PostgreSQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `day_of_week` | `int` | **Required** | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  (Choices:  `1`  `2`  `3`  `4`  `5`  `6`  `7` ) |
-| `duration` | `int` | **Required** | The maximum maintenance window time in hours.  (Choices:  `1`  `3` ) |
-| `hour_of_day` | `int` | **Required** | The hour to begin maintenance based in UTC time.   |
-| `frequency` | `str` | Optional | Whether maintenance occurs on a weekly or monthly basis.  (Choices:  `weekly`  `monthly` Default: `weekly`) |
-| `week_of_month` | `int` | Optional | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
+| `day_of_week` | <center>`int`</center> | <center>**Required**</center> | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  **(Choices: `1`, `2`, `3`, `4`, `5`, `6`, `7`)** |
+| `duration` | <center>`int`</center> | <center>**Required**</center> | The maximum maintenance window time in hours.  **(Choices: `1`, `3`)** |
+| `hour_of_day` | <center>`int`</center> | <center>**Required**</center> | The hour to begin maintenance based in UTC time.   |
+| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`;Default: `weekly`)** |
+| `week_of_month` | <center>`int`</center> | <center>Optional</center> | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
 
 
 

--- a/docs/modules/database_postgresql.md
+++ b/docs/modules/database_postgresql.md
@@ -61,12 +61,12 @@ Manage a Linode PostgreSQL database.
 | `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
-| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`;Default: `1`)** |
+| `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`; Default: `1`)** |
 | `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The Region ID for the Managed Database.   |
-| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`;Default: `none`)** |
-| `replication_commit_type` | <center>`str`</center> | <center>Optional</center> | The synchronization level of the replicating server. Must be local or off for the asynch replication type. Must be on, remote_write, or remote_apply for the semi_synch replication type.  **(Choices: `off`, `on`, `local`, `remote_write`, `remote_apply`;Default: `local`)** |
+| `replication_type` | <center>`str`</center> | <center>Optional</center> | The replication method used for the Managed Database. Defaults to none for a single cluster and semi_synch for a high availability cluster. Must be none for a single node cluster. Must be asynch or semi_synch for a high availability cluster.  **(Choices: `none`, `asynch`, `semi_synch`; Default: `none`)** |
+| `replication_commit_type` | <center>`str`</center> | <center>Optional</center> | The synchronization level of the replicating server. Must be local or off for the asynch replication type. Must be on, remote_write, or remote_apply for the semi_synch replication type.  **(Choices: `off`, `on`, `local`, `remote_write`, `remote_apply`; Default: `local`)** |
 | `ssl_connection` | <center>`bool`</center> | <center>Optional</center> | Whether to require SSL credentials to establish a connection to the Managed Database.  **(Default: `True`)** |
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.   |
 | [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
@@ -84,7 +84,7 @@ Manage a Linode PostgreSQL database.
 | `day_of_week` | <center>`int`</center> | <center>**Required**</center> | The day to perform maintenance. 1=Monday, 2=Tuesday, etc.  **(Choices: `1`, `2`, `3`, `4`, `5`, `6`, `7`)** |
 | `duration` | <center>`int`</center> | <center>**Required**</center> | The maximum maintenance window time in hours.  **(Choices: `1`, `3`)** |
 | `hour_of_day` | <center>`int`</center> | <center>**Required**</center> | The hour to begin maintenance based in UTC time.   |
-| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`;Default: `weekly`)** |
+| `frequency` | <center>`str`</center> | <center>Optional</center> | Whether maintenance occurs on a weekly or monthly basis.  **(Choices: `weekly`, `monthly`; Default: `weekly`)** |
 | `week_of_month` | <center>`int`</center> | <center>Optional</center> | The week of the month to perform monthly frequency updates. Defaults to None. Required for monthly frequency updates. Must be null for weekly frequency updates.   |
 
 

--- a/docs/modules/database_postgresql_info.md
+++ b/docs/modules/database_postgresql_info.md
@@ -34,8 +34,8 @@ Get info about a Linode PostgreSQL Managed Database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `str` | Optional | The ID of the PostgreSQL Database.   |
-| `label` | `str` | Optional | The label of the PostgreSQL Database.   |
+| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the PostgreSQL Database.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the PostgreSQL Database.   |
 
 
 

--- a/docs/modules/domain.md
+++ b/docs/modules/domain.md
@@ -37,19 +37,19 @@ Manage Linode Domains.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `domain` | `str` | **Required** | The domain this Domain represents.   |
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `axfr_ips` | `list` | Optional | The list of IPs that may perform a zone transfer for this Domain.   |
-| `description` | `str` | Optional | The list of IPs that may perform a zone transfer for this Domain.   |
-| `expire_sec` | `int` | Optional | The amount of time in seconds that may pass before this Domain is no longer authoritative.   |
-| `master_ips` | `list` | Optional | The IP addresses representing the master DNS for this Domain.   |
-| `refresh_sec` | `int` | Optional | The amount of time in seconds before this Domain should be refreshed.   |
-| `retry_sec` | `int` | Optional | The interval, in seconds, at which a failed refresh should be retried.   |
-| `soa_email` | `str` | Optional | The Start of Authority email address.   |
-| `status` | `str` | Optional | Used to control whether this Domain is currently being rendered.   |
-| `tags` | `list` | Optional | An array of tags applied to this object.   |
-| `ttl_sec` | `int` | Optional | the amount of time in seconds that this Domain’s records may be cached by resolvers or other domain servers.   |
-| `type` | `str` | Optional | Whether this Domain represents the authoritative source of information for the domain it describes (master), or whether it is a read-only copy of a master (slave).   |
+| `domain` | <center>`str`</center> | <center>**Required**</center> | The domain this Domain represents.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `axfr_ips` | <center>`list`</center> | <center>Optional</center> | The list of IPs that may perform a zone transfer for this Domain.  **(Updatable)** |
+| `description` | <center>`str`</center> | <center>Optional</center> | The list of IPs that may perform a zone transfer for this Domain.  **(Updatable)** |
+| `expire_sec` | <center>`int`</center> | <center>Optional</center> | The amount of time in seconds that may pass before this Domain is no longer authoritative.  **(Updatable)** |
+| `master_ips` | <center>`list`</center> | <center>Optional</center> | The IP addresses representing the master DNS for this Domain.  **(Updatable)** |
+| `refresh_sec` | <center>`int`</center> | <center>Optional</center> | The amount of time in seconds before this Domain should be refreshed.  **(Updatable)** |
+| `retry_sec` | <center>`int`</center> | <center>Optional</center> | The interval, in seconds, at which a failed refresh should be retried.  **(Updatable)** |
+| `soa_email` | <center>`str`</center> | <center>Optional</center> | The Start of Authority email address.  **(Updatable)** |
+| `status` | <center>`str`</center> | <center>Optional</center> | Used to control whether this Domain is currently being rendered.  **(Updatable)** |
+| `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to this object.  **(Updatable)** |
+| `ttl_sec` | <center>`int`</center> | <center>Optional</center> | the amount of time in seconds that this Domain’s records may be cached by resolvers or other domain servers.  **(Updatable)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | Whether this Domain represents the authoritative source of information for the domain it describes (master), or whether it is a read-only copy of a master (slave).  **(Updatable)** |
 
 
 

--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -34,8 +34,8 @@ Get info about a Linode Domain.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The unique domain name of the Domain. Optional if `domain` is defined.   |
-| `domain` | `str` | Optional | The unique id of the Domain. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The unique domain name of the Domain. Optional if `domain` is defined.   |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The unique id of the Domain. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -42,20 +42,20 @@ NOTE: Domain records are identified by their name, target, and type.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `domain_id` | `int` | Optional | The ID of the parent Domain.   |
-| `domain` | `str` | Optional | The name of the parent Domain.   |
-| `record_id` | `int` | Optional | The id of the record to modify.   |
-| `name` | `str` | Optional | The name of this Record. NOTE: If the name of the record ends with the domain, it will be dropped from the resulting record's name.   |
-| `port` | `int` | Optional | The port this Record points to. Only valid and required for SRV record requests.   |
-| `priority` | `int` | Optional | The priority of the target host for this Record. Lower values are preferred. Only valid for MX and SRV record requests. Required for SRV record requests.   |
-| `protocol` | `str` | Optional | The protocol this Record’s service communicates with. An underscore (_) is prepended automatically to the submitted value for this property.   |
-| `service` | `str` | Optional | An underscore (_) is prepended and a period (.) is appended automatically to the submitted value for this property. Only valid and required for SRV record requests. The name of the service.   |
-| `tag` | `str` | Optional | The tag portion of a CAA record. Only valid and required for CAA record requests.   |
-| `target` | `str` | Optional | The target for this Record.   |
-| `ttl_sec` | `int` | Optional | The amount of time in seconds that this Domain’s records may be cached by resolvers or other domain servers.   |
-| `type` | `str` | Optional | The type of Record this is in the DNS system.   |
-| `weight` | `int` | Optional | The relative weight of this Record used in the case of identical priority.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain.   |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain.   |
+| `record_id` | <center>`int`</center> | <center>Optional</center> | The id of the record to modify.   |
+| `name` | <center>`str`</center> | <center>Optional</center> | The name of this Record. NOTE: If the name of the record ends with the domain, it will be dropped from the resulting record's name.   |
+| `port` | <center>`int`</center> | <center>Optional</center> | The port this Record points to. Only valid and required for SRV record requests.  **(Updatable)** |
+| `priority` | <center>`int`</center> | <center>Optional</center> | The priority of the target host for this Record. Lower values are preferred. Only valid for MX and SRV record requests. Required for SRV record requests.  **(Updatable)** |
+| `protocol` | <center>`str`</center> | <center>Optional</center> | The protocol this Record’s service communicates with. An underscore (_) is prepended automatically to the submitted value for this property.  **(Updatable)** |
+| `service` | <center>`str`</center> | <center>Optional</center> | An underscore (_) is prepended and a period (.) is appended automatically to the submitted value for this property. Only valid and required for SRV record requests. The name of the service.  **(Updatable)** |
+| `tag` | <center>`str`</center> | <center>Optional</center> | The tag portion of a CAA record. Only valid and required for CAA record requests.  **(Updatable)** |
+| `target` | <center>`str`</center> | <center>Optional</center> | The target for this Record.   |
+| `ttl_sec` | <center>`int`</center> | <center>Optional</center> | The amount of time in seconds that this Domain’s records may be cached by resolvers or other domain servers.  **(Updatable)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | The type of Record this is in the DNS system.   |
+| `weight` | <center>`int`</center> | <center>Optional</center> | The relative weight of this Record used in the case of identical priority.  **(Updatable)** |
 
 
 

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -38,10 +38,10 @@ Get info about a Linode Domain Record.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `domain_id` | `int` | Optional | The ID of the parent Domain. Optional if `domain` is defined.   |
-| `domain` | `str` | Optional | The name of the parent Domain. Optional if `domain_id` is defined.   |
-| `id` | `int` | Optional | The unique id of the subdomain. Optional if `name` is defined.   |
-| `name` | `str` | Optional | The name of the domain record. Optional if `id` is defined.   |
+| `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain. Optional if `domain` is defined.   |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain. Optional if `domain_id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The unique id of the subdomain. Optional if `name` is defined.   |
+| `name` | <center>`str`</center> | <center>Optional</center> | The name of the domain record. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -43,7 +43,7 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`;Default: `asc`)** |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -43,10 +43,10 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | `str` | Optional | The order to list events in.  (Choices:  `desc`  `asc` Default: `asc`) |
-| `order_by` | `str` | Optional | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting events.   |
-| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`;Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 
 
 
@@ -56,8 +56,8 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/account/#events-list__responses   |
-| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/account/#events-list__responses   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 
 

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -65,11 +65,11 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `label` | `str` | Optional | The unique label to give this Firewall.   |
-| [`devices` (sub-options)](#devices) | `list` | Optional | The devices that are attached to this Firewall.   |
-| [`rules` (sub-options)](#rules) | `dict` | Optional | The inbound and outbound access rules to apply to this Firewall.   |
-| `status` | `str` | Optional | The status of this Firewall.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this Firewall.   |
+| [`devices` (sub-options)](#devices) | <center>`list`</center> | <center>Optional</center> | The devices that are attached to this Firewall.  **(Updatable)** |
+| [`rules` (sub-options)](#rules) | <center>`dict`</center> | <center>Optional</center> | The inbound and outbound access rules to apply to this Firewall.  **(Updatable)** |
+| `status` | <center>`str`</center> | <center>Optional</center> | The status of this Firewall.  **(Updatable)** |
 
 
 
@@ -79,8 +79,8 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | **Required** | The unique ID of the device to attach to this Firewall.   |
-| `type` | `str` | Optional | The type of device to be attached to this Firewall.  (Default: `linode`) |
+| `id` | <center>`int`</center> | <center>**Required**</center> | The unique ID of the device to attach to this Firewall.   |
+| `type` | <center>`str`</center> | <center>Optional</center> | The type of device to be attached to this Firewall.  **(Default: `linode`)** |
 
 
 
@@ -90,10 +90,10 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| [`inbound` (sub-options)](#inbound) | `list` | Optional | A list of rules for inbound traffic.   |
-| `inbound_policy` | `str` | Optional | The default behavior for inbound traffic.   |
-| [`outbound` (sub-options)](#outbound) | `list` | Optional | A list of rules for outbound traffic.   |
-| `outbound_policy` | `str` | Optional | The default behavior for outbound traffic.   |
+| [`inbound` (sub-options)](#inbound) | <center>`list`</center> | <center>Optional</center> | A list of rules for inbound traffic.   |
+| `inbound_policy` | <center>`str`</center> | <center>Optional</center> | The default behavior for inbound traffic.   |
+| [`outbound` (sub-options)](#outbound) | <center>`list`</center> | <center>Optional</center> | A list of rules for outbound traffic.   |
+| `outbound_policy` | <center>`str`</center> | <center>Optional</center> | The default behavior for outbound traffic.   |
 
 
 
@@ -103,12 +103,12 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The label of this rule.   |
-| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.   |
-| [`addresses` (sub-options)](#addresses) | `dict` | Optional | Allowed IPv4 or IPv6 addresses.   |
-| `description` | `str` | Optional | A description for this rule.   |
-| `ports` | `str` | Optional | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |
-| `protocol` | `str` | Optional | The type of network traffic to allow.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label of this rule.   |
+| `action` | <center>`str`</center> | <center>**Required**</center> | Controls whether traffic is accepted or dropped by this rule.   |
+| [`addresses` (sub-options)](#addresses) | <center>`dict`</center> | <center>Optional</center> | Allowed IPv4 or IPv6 addresses.   |
+| `description` | <center>`str`</center> | <center>Optional</center> | A description for this rule.   |
+| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |
+| `protocol` | <center>`str`</center> | <center>Optional</center> | The type of network traffic to allow.   |
 
 
 
@@ -118,8 +118,8 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `ipv4` | `list` | Optional | A list of IPv4 addresses or networks. Must be in IP/mask format.   |
-| `ipv6` | `list` | Optional | A list of IPv4 addresses or networks. Must be in IP/mask format.   |
+| `ipv4` | <center>`list`</center> | <center>Optional</center> | A list of IPv4 addresses or networks. Must be in IP/mask format.   |
+| `ipv6` | <center>`list`</center> | <center>Optional</center> | A list of IPv4 addresses or networks. Must be in IP/mask format.   |
 
 
 
@@ -129,12 +129,12 @@ Manage Linode Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The label of this rule.   |
-| `action` | `str` | **Required** | Controls whether traffic is accepted or dropped by this rule.   |
-| [`addresses` (sub-options)](#addresses) | `dict` | Optional | Allowed IPv4 or IPv6 addresses.   |
-| `description` | `str` | Optional | A description for this rule.   |
-| `ports` | `str` | Optional | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |
-| `protocol` | `str` | Optional | The type of network traffic to allow.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label of this rule.   |
+| `action` | <center>`str`</center> | <center>**Required**</center> | Controls whether traffic is accepted or dropped by this rule.   |
+| [`addresses` (sub-options)](#addresses) | <center>`dict`</center> | <center>Optional</center> | Allowed IPv4 or IPv6 addresses.   |
+| `description` | <center>`str`</center> | <center>Optional</center> | A description for this rule.   |
+| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See U(https://www.linode.com/docs/api/networking/#firewall-create)   |
+| `protocol` | <center>`str`</center> | <center>Optional</center> | The type of network traffic to allow.   |
 
 
 

--- a/docs/modules/firewall_device.md
+++ b/docs/modules/firewall_device.md
@@ -48,10 +48,10 @@ Manage Linode Firewall Devices.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `firewall_id` | `int` | **Required** | The ID of the Firewall that contains this device.   |
-| `entity_id` | `int` | **Required** | The ID for this Firewall Device. This will be the ID of the Linode Entity.   |
-| `entity_type` | `str` | **Required** | The type of Linode Entity. Currently only supports linode.  (Choices:  `linode` ) |
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
+| `firewall_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Firewall that contains this device.   |
+| `entity_id` | <center>`int`</center> | <center>**Required**</center> | The ID for this Firewall Device. This will be the ID of the Linode Entity.   |
+| `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode.  **(Choices: `linode`)** |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 
 
 

--- a/docs/modules/firewall_info.md
+++ b/docs/modules/firewall_info.md
@@ -34,8 +34,8 @@ Get info about a Linode Firewall.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The unique id of the Firewall. Optional if `label` is defined.   |
-| `label` | `str` | Optional | The Firewall’s label. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The unique id of the Firewall. Optional if `label` is defined.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The Firewall’s label. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/image.md
+++ b/docs/modules/image.md
@@ -47,15 +47,15 @@ Manage a Linode Image.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This Image's unique label.   |
-| `state` | `str` | **Required** | The state of this Image.  (Choices:  `present`  `absent` ) |
-| `description` | `str` | Optional | A description for the Image.   |
-| `disk_id` | `int` | Optional | The ID of the disk to clone this image from.   |
-| `recreate` | `bool` | Optional | If true, the image with the given label will be deleted and recreated  (Default: `False`) |
-| `region` | `str` | Optional | The Linode region to upload this image to.  (Default: `us-east`) |
-| `source_file` | `str` | Optional | An image file to create this image with.   |
-| `wait` | `bool` | Optional | Wait for the image to have status `available` before returning.  (Default: `True`) |
-| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for an image to have status `available`.  (Default: `600`) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This Image's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this Image.  **(Choices: `present`, `absent`)** |
+| `description` | <center>`str`</center> | <center>Optional</center> | A description for the Image.  **(Updatable)** |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to clone this image from.   |
+| `recreate` | <center>`bool`</center> | <center>Optional</center> | If true, the image with the given label will be deleted and recreated  **(Default: `False`)** |
+| `region` | <center>`str`</center> | <center>Optional</center> | The Linode region to upload this image to.  **(Default: `us-east`)** |
+| `source_file` | <center>`str`</center> | <center>Optional</center> | An image file to create this image with.   |
+| `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the image to have status `available` before returning.  **(Default: `True`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an image to have status `available`.  **(Default: `600`)** |
 
 
 

--- a/docs/modules/image_info.md
+++ b/docs/modules/image_info.md
@@ -34,8 +34,8 @@ Get info about a Linode Image.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `str` | Optional | The ID of the image.   |
-| `label` | `str` | Optional | The label of the image.   |
+| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the image.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the image.   |
 
 
 

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -43,10 +43,10 @@ List and filter on Linode images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | `str` | Optional | The order to list events in.  (Choices:  `desc`  `asc` Default: `asc`) |
-| `order_by` | `str` | Optional | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting events.   |
-| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`;Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 
 
 
@@ -56,8 +56,8 @@ List and filter on Linode images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/images/#images-list__responses   |
-| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/images/#images-list__responses   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 
 

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -43,7 +43,7 @@ List and filter on Linode images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`;Default: `asc`)** |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -111,7 +111,7 @@ Manage Linode Instances, Configs, and Disks.
 | `memory_limit` | <center>`int`</center> | <center>Optional</center> | Defaults to the total RAM of the Linode.  **(Updatable)** |
 | `root_device` | <center>`str`</center> | <center>Optional</center> | The root device to boot.  **(Updatable)** |
 | `run_level` | <center>`str`</center> | <center>Optional</center> | Defines the state of your Linode after booting.  **(Updatable)** |
-| `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`;Updatable)** |
+| `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`; Updatable)** |
 
 
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -76,24 +76,24 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `type` | `str` | Optional | The unique label to give this instance.   |
-| `region` | `str` | Optional | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |
-| `image` | `str` | Optional | The image ID to deploy the instance disk from.   |
-| `authorized_keys` | `list` | Optional | A list of SSH public key parts to deploy for the root user.   |
-| `root_pass` | `str` | Optional | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
-| `stackscript_id` | `int` | Optional | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-| `stackscript_data` | `dict` | Optional | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-| `private_ip` | `bool` | Optional | If true, the created Linode will have private networking enabled.   |
-| `group` | `str` | Optional | The group that the instance should be marked under. Please note, that group labelling is deprecated but still supported. The encouraged method for marking instances is to use tags.   |
-| `boot_config_label` | `str` | Optional | The label of the config to boot from.   |
-| [`configs` (sub-options)](#configs) | `list` | Optional | A list of Instance configs to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create).   |
-| [`disks` (sub-options)](#disks) | `list` | Optional | A list of Disks to create on the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#disk-create).   |
-| [`interfaces` (sub-options)](#interfaces) | `list` | Optional | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema).   |
-| `booted` | `bool` | Optional | Whether the new Instance should be booted. This will default to True if the Instance is deployed from an Image or Backup.   |
-| `backup_id` | `int` | Optional | The id of the Backup to restore to the new Instance. May not be provided if “image” is given.   |
-| `wait` | `bool` | Optional | Wait for the instance to have status `running` before returning.  (Default: `True`) |
-| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for an instance to have status `running`.  (Default: `240`) |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | The unique label to give this instance.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |
+| `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.   |
+| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |
+| `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
+| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `private_ip` | <center>`bool`</center> | <center>Optional</center> | If true, the created Linode will have private networking enabled.   |
+| `group` | <center>`str`</center> | <center>Optional</center> | The group that the instance should be marked under. Please note, that group labelling is deprecated but still supported. The encouraged method for marking instances is to use tags.  **(Updatable)** |
+| `boot_config_label` | <center>`str`</center> | <center>Optional</center> | The label of the config to boot from.   |
+| [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of Instance configs to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create).  **(Updatable)** |
+| [`disks` (sub-options)](#disks) | <center>`list`</center> | <center>Optional</center> | A list of Disks to create on the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#disk-create).  **(Updatable)** |
+| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema).   |
+| `booted` | <center>`bool`</center> | <center>Optional</center> | Whether the new Instance should be booted. This will default to True if the Instance is deployed from an Image or Backup.   |
+| `backup_id` | <center>`int`</center> | <center>Optional</center> | The id of the Backup to restore to the new Instance. May not be provided if “image” is given.   |
+| `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the instance to have status `running` before returning.  **(Default: `True`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an instance to have status `running`.  **(Default: `240`)** |
 
 
 
@@ -103,15 +103,15 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The label to assign to this config.   |
-| `comments` | `str` | Optional | Arbitrary User comments on this Config.   |
-| [`devices` (sub-options)](#devices) | `dict` | Optional | The devices to map to this configuration.   |
-| [`helpers` (sub-options)](#helpers) | `dict` | Optional | Helpers enabled when booting to this Linode Config.   |
-| `kernel` | `str` | Optional | A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.   |
-| `memory_limit` | `int` | Optional | Defaults to the total RAM of the Linode.   |
-| `root_device` | `str` | Optional | The root device to boot.   |
-| `run_level` | `str` | Optional | Defines the state of your Linode after booting.   |
-| `virt_mode` | `str` | Optional | Controls the virtualization mode.  (Choices:  `paravirt`  `fullvirt` ) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label to assign to this config.   |
+| `comments` | <center>`str`</center> | <center>Optional</center> | Arbitrary User comments on this Config.  **(Updatable)** |
+| [`devices` (sub-options)](#devices) | <center>`dict`</center> | <center>Optional</center> | The devices to map to this configuration.   |
+| [`helpers` (sub-options)](#helpers) | <center>`dict`</center> | <center>Optional</center> | Helpers enabled when booting to this Linode Config.   |
+| `kernel` | <center>`str`</center> | <center>Optional</center> | A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.  **(Updatable)** |
+| `memory_limit` | <center>`int`</center> | <center>Optional</center> | Defaults to the total RAM of the Linode.  **(Updatable)** |
+| `root_device` | <center>`str`</center> | <center>Optional</center> | The root device to boot.  **(Updatable)** |
+| `run_level` | <center>`str`</center> | <center>Optional</center> | Defines the state of your Linode after booting.  **(Updatable)** |
+| `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`;Updatable)** |
 
 
 
@@ -121,14 +121,14 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| [`sda` (sub-options)](#sda) | `dict` | Optional |   |
-| [`sdb` (sub-options)](#sdb) | `dict` | Optional |   |
-| [`sdc` (sub-options)](#sdc) | `dict` | Optional |   |
-| [`sdd` (sub-options)](#sdd) | `dict` | Optional |   |
-| [`sde` (sub-options)](#sde) | `dict` | Optional |   |
-| [`sdf` (sub-options)](#sdf) | `dict` | Optional |   |
-| [`sdg` (sub-options)](#sdg) | `dict` | Optional |   |
-| [`sdh` (sub-options)](#sdh) | `dict` | Optional |   |
+| [`sda` (sub-options)](#sda) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdb` (sub-options)](#sdb) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdc` (sub-options)](#sdc) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdd` (sub-options)](#sdd) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sde` (sub-options)](#sde) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdf` (sub-options)](#sdf) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdg` (sub-options)](#sdg) | <center>`dict`</center> | <center>Optional</center> |   |
+| [`sdh` (sub-options)](#sdh) | <center>`dict`</center> | <center>Optional</center> |   |
 
 
 
@@ -138,9 +138,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -150,9 +150,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -162,9 +162,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -174,9 +174,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -186,9 +186,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -198,9 +198,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -210,9 +210,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -222,9 +222,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `disk_label` | `str` | Optional | The label of the disk to attach to this Linode.   |
-| `disk_id` | `int` | Optional | The ID of the disk to attach to this Linode.   |
-| `volume_id` | `int` | Optional | The ID of the volume to attach to this Linode.   |
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 
 
@@ -234,11 +234,11 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `devtmpfs_automount` | `bool` | Optional | Populates the /dev directory early during boot without udev.   |
-| `distro` | `bool` | Optional | Helps maintain correct inittab/upstart console device.   |
-| `modules_dep` | `bool` | Optional | Creates a modules dependency file for the Kernel you run.   |
-| `network` | `bool` | Optional | Automatically configures static networking.   |
-| `updatedb_disabled` | `bool` | Optional | Disables updatedb cron job to avoid disk thrashing.   |
+| `devtmpfs_automount` | <center>`bool`</center> | <center>Optional</center> | Populates the /dev directory early during boot without udev.   |
+| `distro` | <center>`bool`</center> | <center>Optional</center> | Helps maintain correct inittab/upstart console device.   |
+| `modules_dep` | <center>`bool`</center> | <center>Optional</center> | Creates a modules dependency file for the Kernel you run.   |
+| `network` | <center>`bool`</center> | <center>Optional</center> | Automatically configures static networking.   |
+| `updatedb_disabled` | <center>`bool`</center> | <center>Optional</center> | Disables updatedb cron job to avoid disk thrashing.   |
 
 
 
@@ -248,15 +248,15 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The label to give this Disk.   |
-| `size` | `int` | **Required** | The size of the Disk in MB.   |
-| `authorized_keys` | `list` | Optional | A list of SSH public key parts to deploy for the root user.   |
-| `authorized_users` | `list` | Optional | A list of usernames.   |
-| `filesystem` | `str` | Optional | The filesystem to create this disk with.   |
-| `image` | `str` | Optional | An Image ID to deploy the Disk from.   |
-| `root_pass` | `str` | Optional | The root user’s password on the newly-created Linode.   |
-| `stackscript_id` | `int` | Optional | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-| `stackscript_data` | `dict` | Optional | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label to give this Disk.   |
+| `size` | <center>`int`</center> | <center>**Required**</center> | The size of the Disk in MB.  **(Updatable)** |
+| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |
+| `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames.   |
+| `filesystem` | <center>`str`</center> | <center>Optional</center> | The filesystem to create this disk with.   |
+| `image` | <center>`str`</center> | <center>Optional</center> | An Image ID to deploy the Disk from.   |
+| `root_pass` | <center>`str`</center> | <center>Optional</center> | The root user’s password on the newly-created Linode.   |
+| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
 
 
 
@@ -266,9 +266,9 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `purpose` | `str` | **Required** | The type of interface.  (Choices:  `public`  `vlan` ) |
-| `label` | `str` | Optional | The name of this interface. Required for vlan purpose interfaces. Must be an empty string or null for public purpose interfaces.   |
-| `ipam_address` | `str` | Optional | This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.   |
+| `purpose` | <center>`str`</center> | <center>**Required**</center> | The type of interface.  **(Choices: `public`, `vlan`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The name of this interface. Required for vlan purpose interfaces. Must be an empty string or null for public purpose interfaces.   |
+| `ipam_address` | <center>`str`</center> | <center>Optional</center> | This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.   |
 
 
 

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -34,8 +34,8 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The instance’s label. Optional if `label` is defined.   |
-| `label` | `str` | Optional | The unique ID of the Instance. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The instance’s label. Optional if `label` is defined.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The unique ID of the Instance. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/ip_info.md
+++ b/docs/modules/ip_info.md
@@ -28,7 +28,7 @@ Get info about a Linode IP.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `address` | `str` | **Required** | The IP address to operate on.   |
+| `address` | <center>`str`</center> | <center>**Required**</center> | The IP address to operate on.   |
 
 
 

--- a/docs/modules/ipv6_range_info.md
+++ b/docs/modules/ipv6_range_info.md
@@ -28,7 +28,7 @@ Get info about a Linode IPv6 range.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `range` | `str` | Optional | The IPv6 range to access.   |
+| `range` | <center>`str`</center> | <center>Optional</center> | The IPv6 range to access.   |
 
 
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -63,7 +63,7 @@ Manage Linode LKE clusters.
 | `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |
-| `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`;Updatable)** |
+| `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`; Updatable)** |
 | [`node_pools` (sub-options)](#node_pools) | <center>`list`</center> | <center>Optional</center> | A list of node pools to configure the cluster with  **(Updatable)** |
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -59,14 +59,14 @@ Manage Linode LKE clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This Kubernetes cluster’s unique label.   |
-| `k8s_version` | `str` | Optional | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.   |
-| `region` | `str` | Optional | This Kubernetes cluster’s location.   |
-| `tags` | `list` | Optional | An array of tags applied to the Kubernetes cluster.   |
-| `high_availability` | `bool` | Optional | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   (Default: `False`) |
-| [`node_pools` (sub-options)](#node_pools) | `list` | Optional | A list of node pools to configure the cluster with   |
-| `skip_polling` | `bool` | Optional | If true, the module will not wait for all nodes in the cluster to be ready.  (Default: `False`) |
-| `wait_timeout` | `int` | Optional | The period to wait for the cluster to be ready in seconds.  (Default: `600`) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This Kubernetes cluster’s unique label.   |
+| `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.  **(Updatable)** |
+| `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
+| `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |
+| `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`;Updatable)** |
+| [`node_pools` (sub-options)](#node_pools) | <center>`list`</center> | <center>Optional</center> | A list of node pools to configure the cluster with  **(Updatable)** |
+| `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |
 
 
 
@@ -76,9 +76,9 @@ Manage Linode LKE clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `count` | `int` | **Required** | The number of nodes in the Node Pool.   |
-| `type` | `str` | **Required** | The Linode Type for all of the nodes in the Node Pool.   |
-| [`autoscaler` (sub-options)](#autoscaler) | `dict` | Optional | When enabled, the number of nodes autoscales within the defined minimum and maximum values.   |
+| `count` | <center>`int`</center> | <center>**Required**</center> | The number of nodes in the Node Pool.  **(Updatable)** |
+| `type` | <center>`str`</center> | <center>**Required**</center> | The Linode Type for all of the nodes in the Node Pool.   |
+| [`autoscaler` (sub-options)](#autoscaler) | <center>`dict`</center> | <center>Optional</center> | When enabled, the number of nodes autoscales within the defined minimum and maximum values.  **(Updatable)** |
 
 
 
@@ -88,9 +88,9 @@ Manage Linode LKE clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `enabled` | `bool` | Optional | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.   |
-| `max` | `int` | Optional | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.   |
-| `min` | `int` | Optional | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.   |
+| `enabled` | <center>`bool`</center> | <center>Optional</center> | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.  **(Updatable)** |
+| `max` | <center>`int`</center> | <center>Optional</center> | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.  **(Updatable)** |
+| `min` | <center>`int`</center> | <center>Optional</center> | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.  **(Updatable)** |
 
 
 

--- a/docs/modules/lke_cluster_info.md
+++ b/docs/modules/lke_cluster_info.md
@@ -34,8 +34,8 @@ Get info about a Linode LKE cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The ID of the LKE cluster. Optional if `label` is defined.   |
-| `label` | `str` | Optional | The label of the LKE cluster. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the LKE cluster. Optional if `label` is defined.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the LKE cluster. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/lke_node_pool.md
+++ b/docs/modules/lke_node_pool.md
@@ -55,15 +55,15 @@ Manage Linode LKE cluster node pools.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `cluster_id` | `int` | **Required** | The ID of the LKE cluster that contains this node pool.   |
-| `tags` | `list` | **Required** | An array of tags applied to this object. Tags must be unique as they are used by the `lke_node_pool` module to uniquely identify node pools.   |
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| [`autoscaler` (sub-options)](#autoscaler) | `dict` | Optional | When enabled, the number of nodes autoscales within the defined minimum and maximum values.   |
-| `count` | `int` | Optional | The number of nodes in the Node Pool.   |
-| [`disks` (sub-options)](#disks) | `list` | Optional | This Node Pool’s custom disk layout. Each item in this array will create a new disk partition for each node in this Node Pool.   |
-| `type` | `str` | Optional | The Linode Type for all of the nodes in the Node Pool. Required if `state` == `present`.   |
-| `skip_polling` | `bool` | Optional | If true, the module will not wait for all nodes in the node pool to be ready.  (Default: `False`) |
-| `wait_timeout` | `int` | Optional | The period to wait for the node pool to be ready in seconds.  (Default: `600`) |
+| `cluster_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the LKE cluster that contains this node pool.   |
+| `tags` | <center>`list`</center> | <center>**Required**</center> | An array of tags applied to this object. Tags must be unique as they are used by the `lke_node_pool` module to uniquely identify node pools.  **(Updatable)** |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| [`autoscaler` (sub-options)](#autoscaler) | <center>`dict`</center> | <center>Optional</center> | When enabled, the number of nodes autoscales within the defined minimum and maximum values.  **(Updatable)** |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of nodes in the Node Pool.  **(Updatable)** |
+| [`disks` (sub-options)](#disks) | <center>`list`</center> | <center>Optional</center> | This Node Pool’s custom disk layout. Each item in this array will create a new disk partition for each node in this Node Pool.   |
+| `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type for all of the nodes in the Node Pool. Required if `state` == `present`.   |
+| `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the node pool to be ready.  **(Default: `False`)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the node pool to be ready in seconds.  **(Default: `600`)** |
 
 
 
@@ -73,9 +73,9 @@ Manage Linode LKE cluster node pools.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `enabled` | `bool` | Optional | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.   |
-| `max` | `int` | Optional | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.   |
-| `min` | `int` | Optional | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.   |
+| `enabled` | <center>`bool`</center> | <center>Optional</center> | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.  **(Updatable)** |
+| `max` | <center>`int`</center> | <center>Optional</center> | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.  **(Updatable)** |
+| `min` | <center>`int`</center> | <center>Optional</center> | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.  **(Updatable)** |
 
 
 
@@ -85,8 +85,8 @@ Manage Linode LKE cluster node pools.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `type` | `str` | **Required** | This custom disk partition’s filesystem type.  (Choices:  `raw`  `ext4` ) |
-| `size` | `int` | **Required** | The size of this custom disk partition in MB.   |
+| `type` | <center>`str`</center> | <center>**Required**</center> | This custom disk partition’s filesystem type.  **(Choices: `raw`, `ext4`)** |
+| `size` | <center>`int`</center> | <center>**Required**</center> | The size of this custom disk partition in MB.   |
 
 
 

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -46,11 +46,11 @@ Manage a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The unique label to give this NodeBalancer.   |
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `client_conn_throttle` | `int` | Optional | Throttle connections per second. Set to 0 (zero) to disable throttling.   |
-| `region` | `str` | Optional | The ID of the Region to create this NodeBalancer in.   |
-| [`configs` (sub-options)](#configs) | `list` | Optional | A list of configs to apply to the NodeBalancer.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The unique label to give this NodeBalancer.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `client_conn_throttle` | <center>`int`</center> | <center>Optional</center> | Throttle connections per second. Set to 0 (zero) to disable throttling.  **(Updatable)** |
+| `region` | <center>`str`</center> | <center>Optional</center> | The ID of the Region to create this NodeBalancer in.   |
+| [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 
 
 
@@ -60,23 +60,23 @@ Manage a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `algorithm` | `str` | Optional | What algorithm this NodeBalancer should use for routing traffic to backends.  (Choices:  `roundrobin`  `leastconn`  `source` ) |
-| `check` | `str` | Optional | The type of check to perform against backends to ensure they are serving requests.  (Choices:  `none`  `connection`  `http`  `http_body` ) |
-| `check_attempts` | `int` | Optional | How many times to attempt a check before considering a backend to be down.   |
-| `check_body` | `str` | Optional | This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.   |
-| `check_interval` | `int` | Optional | How often, in seconds, to check that backends are up and serving requests.   |
-| `check_passive` | `bool` | Optional | If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.   |
-| `check_path` | `str` | Optional | The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.   |
-| `check_timeout` | `int` | Optional | How long, in seconds, to wait for a check attempt before considering it failed.   |
-| `cipher_suite` | `str` | Optional | What ciphers to use for SSL connections served by this NodeBalancer.  (Choices:  `recommended`  `legacy` Default: `recommended`) |
-| `port` | `int` | Optional | The port this Config is for.   |
-| `protocol` | `str` | Optional | The protocol this port is configured to serve.  (Choices:  `http`  `https`  `tcp` ) |
-| `proxy_protocol` | `str` | Optional | ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.  (Choices:  `none`  `v1`  `v2` ) |
-| `recreate` | `bool` | Optional | If true, the config will be forcibly recreated on every run. This is useful for updates to redacted fields (`ssl_cert`, `ssl_key`)  (Default: `False`) |
-| `ssl_cert` | `str` | Optional | The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.   |
-| `ssl_key` | `str` | Optional | The PEM-formatted private key for the SSL certificate set in the ssl_cert field.   |
-| `stickiness` | `str` | Optional | Controls how session stickiness is handled on this port.  (Choices:  `none`  `table`  `http_cookie` ) |
-| [`nodes` (sub-options)](#nodes) | `list` | Optional | A list of nodes to apply to this config. These can alternatively be configured through the nodebalancer_node module.   |
+| `algorithm` | <center>`str`</center> | <center>Optional</center> | What algorithm this NodeBalancer should use for routing traffic to backends.  **(Choices: `roundrobin`, `leastconn`, `source`;Updatable)** |
+| `check` | <center>`str`</center> | <center>Optional</center> | The type of check to perform against backends to ensure they are serving requests.  **(Choices: `none`, `connection`, `http`, `http_body`;Updatable)** |
+| `check_attempts` | <center>`int`</center> | <center>Optional</center> | How many times to attempt a check before considering a backend to be down.  **(Updatable)** |
+| `check_body` | <center>`str`</center> | <center>Optional</center> | This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.  **(Updatable)** |
+| `check_interval` | <center>`int`</center> | <center>Optional</center> | How often, in seconds, to check that backends are up and serving requests.  **(Updatable)** |
+| `check_passive` | <center>`bool`</center> | <center>Optional</center> | If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.  **(Updatable)** |
+| `check_path` | <center>`str`</center> | <center>Optional</center> | The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.  **(Updatable)** |
+| `check_timeout` | <center>`int`</center> | <center>Optional</center> | How long, in seconds, to wait for a check attempt before considering it failed.  **(Updatable)** |
+| `cipher_suite` | <center>`str`</center> | <center>Optional</center> | What ciphers to use for SSL connections served by this NodeBalancer.  **(Choices: `recommended`, `legacy`;Default: `recommended`;Updatable)** |
+| `port` | <center>`int`</center> | <center>Optional</center> | The port this Config is for.  **(Updatable)** |
+| `protocol` | <center>`str`</center> | <center>Optional</center> | The protocol this port is configured to serve.  **(Choices: `http`, `https`, `tcp`;Updatable)** |
+| `proxy_protocol` | <center>`str`</center> | <center>Optional</center> | ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.  **(Choices: `none`, `v1`, `v2`;Updatable)** |
+| `recreate` | <center>`bool`</center> | <center>Optional</center> | If true, the config will be forcibly recreated on every run. This is useful for updates to redacted fields (`ssl_cert`, `ssl_key`)  **(Default: `False`)** |
+| `ssl_cert` | <center>`str`</center> | <center>Optional</center> | The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.  **(Updatable)** |
+| `ssl_key` | <center>`str`</center> | <center>Optional</center> | The PEM-formatted private key for the SSL certificate set in the ssl_cert field.  **(Updatable)** |
+| `stickiness` | <center>`str`</center> | <center>Optional</center> | Controls how session stickiness is handled on this port.  **(Choices: `none`, `table`, `http_cookie`;Updatable)** |
+| [`nodes` (sub-options)](#nodes) | <center>`list`</center> | <center>Optional</center> | A list of nodes to apply to this config. These can alternatively be configured through the nodebalancer_node module.  **(Updatable)** |
 
 
 
@@ -86,10 +86,10 @@ Manage a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The label for this node.   |
-| `address` | `str` | **Required** | The private IP Address where this backend can be reached. This must be a private IP address.   |
-| `weight` | `int` | Optional | Nodes with a higher weight will receive more traffic.   |
-| `mode` | `str` | Optional | The mode this NodeBalancer should use when sending traffic to this backend.  (Choices:  `accept`  `reject`  `drain`  `backup` ) |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label for this node.   |
+| `address` | <center>`str`</center> | <center>**Required**</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
+| `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |
+| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`;Updatable)** |
 
 
 

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -60,22 +60,22 @@ Manage a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `algorithm` | <center>`str`</center> | <center>Optional</center> | What algorithm this NodeBalancer should use for routing traffic to backends.  **(Choices: `roundrobin`, `leastconn`, `source`;Updatable)** |
-| `check` | <center>`str`</center> | <center>Optional</center> | The type of check to perform against backends to ensure they are serving requests.  **(Choices: `none`, `connection`, `http`, `http_body`;Updatable)** |
+| `algorithm` | <center>`str`</center> | <center>Optional</center> | What algorithm this NodeBalancer should use for routing traffic to backends.  **(Choices: `roundrobin`, `leastconn`, `source`; Updatable)** |
+| `check` | <center>`str`</center> | <center>Optional</center> | The type of check to perform against backends to ensure they are serving requests.  **(Choices: `none`, `connection`, `http`, `http_body`; Updatable)** |
 | `check_attempts` | <center>`int`</center> | <center>Optional</center> | How many times to attempt a check before considering a backend to be down.  **(Updatable)** |
 | `check_body` | <center>`str`</center> | <center>Optional</center> | This value must be present in the response body of the check in order for it to pass. If this value is not present in the response body of a check request, the backend is considered to be down.  **(Updatable)** |
 | `check_interval` | <center>`int`</center> | <center>Optional</center> | How often, in seconds, to check that backends are up and serving requests.  **(Updatable)** |
 | `check_passive` | <center>`bool`</center> | <center>Optional</center> | If true, any response from this backend with a 5xx status code will be enough for it to be considered unhealthy and taken out of rotation.  **(Updatable)** |
 | `check_path` | <center>`str`</center> | <center>Optional</center> | The URL path to check on each backend. If the backend does not respond to this request it is considered to be down.  **(Updatable)** |
 | `check_timeout` | <center>`int`</center> | <center>Optional</center> | How long, in seconds, to wait for a check attempt before considering it failed.  **(Updatable)** |
-| `cipher_suite` | <center>`str`</center> | <center>Optional</center> | What ciphers to use for SSL connections served by this NodeBalancer.  **(Choices: `recommended`, `legacy`;Default: `recommended`;Updatable)** |
+| `cipher_suite` | <center>`str`</center> | <center>Optional</center> | What ciphers to use for SSL connections served by this NodeBalancer.  **(Choices: `recommended`, `legacy`; Default: `recommended`; Updatable)** |
 | `port` | <center>`int`</center> | <center>Optional</center> | The port this Config is for.  **(Updatable)** |
-| `protocol` | <center>`str`</center> | <center>Optional</center> | The protocol this port is configured to serve.  **(Choices: `http`, `https`, `tcp`;Updatable)** |
-| `proxy_protocol` | <center>`str`</center> | <center>Optional</center> | ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.  **(Choices: `none`, `v1`, `v2`;Updatable)** |
+| `protocol` | <center>`str`</center> | <center>Optional</center> | The protocol this port is configured to serve.  **(Choices: `http`, `https`, `tcp`; Updatable)** |
+| `proxy_protocol` | <center>`str`</center> | <center>Optional</center> | ProxyProtocol is a TCP extension that sends initial TCP connection information such as source/destination IPs and ports to backend devices.  **(Choices: `none`, `v1`, `v2`; Updatable)** |
 | `recreate` | <center>`bool`</center> | <center>Optional</center> | If true, the config will be forcibly recreated on every run. This is useful for updates to redacted fields (`ssl_cert`, `ssl_key`)  **(Default: `False`)** |
 | `ssl_cert` | <center>`str`</center> | <center>Optional</center> | The PEM-formatted public SSL certificate (or the combined PEM-formatted SSL certificate and Certificate Authority chain) that should be served on this NodeBalancerConfig’s port.  **(Updatable)** |
 | `ssl_key` | <center>`str`</center> | <center>Optional</center> | The PEM-formatted private key for the SSL certificate set in the ssl_cert field.  **(Updatable)** |
-| `stickiness` | <center>`str`</center> | <center>Optional</center> | Controls how session stickiness is handled on this port.  **(Choices: `none`, `table`, `http_cookie`;Updatable)** |
+| `stickiness` | <center>`str`</center> | <center>Optional</center> | Controls how session stickiness is handled on this port.  **(Choices: `none`, `table`, `http_cookie`; Updatable)** |
 | [`nodes` (sub-options)](#nodes) | <center>`list`</center> | <center>Optional</center> | A list of nodes to apply to this config. These can alternatively be configured through the nodebalancer_node module.  **(Updatable)** |
 
 
@@ -89,7 +89,7 @@ Manage a Linode NodeBalancer.
 | `label` | <center>`str`</center> | <center>**Required**</center> | The label for this node.   |
 | `address` | <center>`str`</center> | <center>**Required**</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
 | `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |
-| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`;Updatable)** |
+| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`; Updatable)** |
 
 
 

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -34,8 +34,8 @@ Get info about a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The ID of this NodeBalancer. Optional if `label` is defined.   |
-| `label` | `str` | Optional | The label of this NodeBalancer. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of this NodeBalancer. Optional if `label` is defined.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of this NodeBalancer. Optional if `id` is defined.   |
 
 
 

--- a/docs/modules/nodebalancer_node.md
+++ b/docs/modules/nodebalancer_node.md
@@ -56,13 +56,13 @@ Manage Linode NodeBalancer Nodes.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `nodebalancer_id` | `int` | **Required** | The ID of the NodeBalancer that contains this node.   |
-| `config_id` | `int` | **Required** | The ID of the NodeBalancer Config that contains this node.   |
-| `label` | `str` | **Required** | The label for this node. This is used to identify nodes within a config.   |
-| `state` | `str` | **Required** | Whether the NodeBalancer node should be present or absent.  (Choices:  `present`  `absent` ) |
-| `address` | `str` | Optional | The private IP Address where this backend can be reached. This must be a private IP address.   |
-| `mode` | `str` | Optional | The mode this NodeBalancer should use when sending traffic to this backend.  (Choices:  `accept`  `reject`  `drain`  `backup` ) |
-| `weight` | `int` | Optional | Nodes with a higher weight will receive more traffic.   |
+| `nodebalancer_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the NodeBalancer that contains this node.   |
+| `config_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the NodeBalancer Config that contains this node.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label for this node. This is used to identify nodes within a config.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | Whether the NodeBalancer node should be present or absent.  **(Choices: `present`, `absent`)** |
+| `address` | <center>`str`</center> | <center>Optional</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
+| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`;Updatable)** |
+| `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |
 
 
 

--- a/docs/modules/nodebalancer_node.md
+++ b/docs/modules/nodebalancer_node.md
@@ -61,7 +61,7 @@ Manage Linode NodeBalancer Nodes.
 | `label` | <center>`str`</center> | <center>**Required**</center> | The label for this node. This is used to identify nodes within a config.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | Whether the NodeBalancer node should be present or absent.  **(Choices: `present`, `absent`)** |
 | `address` | <center>`str`</center> | <center>Optional</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
-| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`;Updatable)** |
+| `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`; Updatable)** |
 | `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |
 
 

--- a/docs/modules/object_cluster_info.md
+++ b/docs/modules/object_cluster_info.md
@@ -34,10 +34,10 @@ Get info about a Linode Object Storage Cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `str` | Optional | The unique id given to the clusters.   |
-| `region` | `str` | Optional | The region the clusters are in.   |
-| `domain` | `str` | Optional | The domain of the clusters.   |
-| `static_site_domain` | `str` | Optional | The static-site domain of the clusters.   |
+| `id` | <center>`str`</center> | <center>Optional</center> | The unique id given to the clusters.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The region the clusters are in.   |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The domain of the clusters.   |
+| `static_site_domain` | <center>`str`</center> | <center>Optional</center> | The static-site domain of the clusters.   |
 
 
 

--- a/docs/modules/object_keys.md
+++ b/docs/modules/object_keys.md
@@ -47,9 +47,9 @@ Manage Linode Object Storage Keys.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `label` | `str` | Optional | The unique label to give this key.   |
-| [`access` (sub-options)](#access) | `list` | Optional | A list of access permissions to give the key.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this key.   |
+| [`access` (sub-options)](#access) | <center>`list`</center> | <center>Optional</center> | A list of access permissions to give the key.   |
 
 
 
@@ -59,9 +59,9 @@ Manage Linode Object Storage Keys.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `cluster` | `str` | **Required** | The id of the cluster that the provided bucket exists under.   |
-| `bucket_name` | `str` | **Required** | The name of the bucket to set the key's permissions for.   |
-| `permissions` | `str` | **Required** | The permissions to give the key.  (Choices:  `read_only`  `write_only`  `read_write` ) |
+| `cluster` | <center>`str`</center> | <center>**Required**</center> | The id of the cluster that the provided bucket exists under.   |
+| `bucket_name` | <center>`str`</center> | <center>**Required**</center> | The name of the bucket to set the key's permissions for.   |
+| `permissions` | <center>`str`</center> | <center>**Required**</center> | The permissions to give the key.  **(Choices: `read_only`, `write_only`, `read_write`)** |
 
 
 

--- a/docs/modules/stackscript.md
+++ b/docs/modules/stackscript.md
@@ -42,13 +42,13 @@ Manage a Linode StackScript.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This StackScript's unique label.   |
-| `state` | `str` | **Required** | The state of this StackScript.  (Choices:  `present`  `absent` ) |
-| `description` | `str` | Optional | A description for the StackScript.   |
-| `images` | `list` | Optional | Images that can be deployed using this StackScript.   |
-| `is_public` | `bool` | Optional | This determines whether other users can use your StackScript.   |
-| `rev_note` | `str` | Optional | This field allows you to add notes for the set of revisions made to this StackScript.   |
-| `script` | `str` | Optional | The script to execute when provisioning a new Linode with this StackScript.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This StackScript's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this StackScript.  **(Choices: `present`, `absent`)** |
+| `description` | <center>`str`</center> | <center>Optional</center> | A description for the StackScript.  **(Updatable)** |
+| `images` | <center>`list`</center> | <center>Optional</center> | Images that can be deployed using this StackScript.  **(Updatable)** |
+| `is_public` | <center>`bool`</center> | <center>Optional</center> | This determines whether other users can use your StackScript.  **(Updatable)** |
+| `rev_note` | <center>`str`</center> | <center>Optional</center> | This field allows you to add notes for the set of revisions made to this StackScript.  **(Updatable)** |
+| `script` | <center>`str`</center> | <center>Optional</center> | The script to execute when provisioning a new Linode with this StackScript.  **(Updatable)** |
 
 
 

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -34,8 +34,8 @@ Get info about a Linode StackScript.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The ID of the StackScript.   |
-| `label` | `str` | Optional | The label of the StackScript.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript.   |
 
 
 

--- a/docs/modules/stackscript_list.md
+++ b/docs/modules/stackscript_list.md
@@ -43,10 +43,10 @@ List and filter on Linode stackscripts.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | `str` | Optional | The order to list events in.  (Choices:  `desc`  `asc` Default: `asc`) |
-| `order_by` | `str` | Optional | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting events.   |
-| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 
 
 
@@ -56,8 +56,8 @@ List and filter on Linode stackscripts.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples   |
-| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 
 

--- a/docs/modules/token.md
+++ b/docs/modules/token.md
@@ -45,10 +45,10 @@ Manage a Linode Token.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | This token's unique label.   |
-| `state` | `str` | **Required** | The state of this token.  (Choices:  `present`  `absent` ) |
-| `expiry` | `str` | Optional | When this token should be valid until.   |
-| `scopes` | `str` | Optional | The OAuth scopes to create the token with.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This token's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
+| `expiry` | <center>`str`</center> | <center>Optional</center> | When this token should be valid until.   |
+| `scopes` | <center>`str`</center> | <center>Optional</center> | The OAuth scopes to create the token with.   |
 
 
 

--- a/docs/modules/token_info.md
+++ b/docs/modules/token_info.md
@@ -34,8 +34,8 @@ Get info about a Linode Personal Access Token.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The ID of the token.   |
-| `label` | `str` | Optional | The label of the token.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the token.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the token.   |
 
 
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -55,7 +55,7 @@ Manage a Linode User.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `username` | <center>`str`</center> | <center>**Required**</center> | The username of this user.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this user.  **(Choices: `present`, `absent`)** |
-| `restricted` | <center>`bool`</center> | <center>Optional</center> | If true, the User must be granted access to perform actions or access entities on this Account.  **(Default: `True`;Updatable)** |
+| `restricted` | <center>`bool`</center> | <center>Optional</center> | If true, the User must be granted access to perform actions or access entities on this Account.  **(Default: `True`; Updatable)** |
 | `email` | <center>`str`</center> | <center>Optional</center> | The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.   |
 | [`grants` (sub-options)](#grants) | <center>`dict`</center> | <center>Optional</center> | Update the grants a User has.  **(Updatable)** |
 
@@ -78,18 +78,18 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `account_access` | <center></center> | <center>Optional</center> | The level of access this User has to Account-level actions, like billing information. A restricted User will never be able to manage users.  **(Choices: `read_only`, `read_write`;Updatable)** |
-| `add_databases` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Managed Databases.  **(Default: `False`;Updatable)** |
-| `add_domains` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Domains.  **(Default: `False`;Updatable)** |
-| `add_firewalls` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add firewalls.  **(Default: `False`;Updatable)** |
-| `add_images` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add images.  **(Default: `False`;Updatable)** |
-| `add_linodes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Linodes.  **(Default: `False`;Updatable)** |
-| `add_longview` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add LongView.  **(Default: `False`;Updatable)** |
-| `add_nodebalancers` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add NodeBalancers.  **(Default: `False`;Updatable)** |
-| `add_stackscripts` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add StackScripts.  **(Default: `False`;Updatable)** |
-| `add_volumes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add volumes.  **(Default: `False`;Updatable)** |
-| `cancel_account` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add cancel the entire account.  **(Default: `False`;Updatable)** |
-| `longview_subscription` | <center>`bool`</center> | <center>Optional</center> | If true, this User may manage the Account’s Longview subscription.  **(Default: `False`;Updatable)** |
+| `account_access` | <center></center> | <center>Optional</center> | The level of access this User has to Account-level actions, like billing information. A restricted User will never be able to manage users.  **(Choices: `read_only`, `read_write`; Updatable)** |
+| `add_databases` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Managed Databases.  **(Default: `False`; Updatable)** |
+| `add_domains` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Domains.  **(Default: `False`; Updatable)** |
+| `add_firewalls` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add firewalls.  **(Default: `False`; Updatable)** |
+| `add_images` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add images.  **(Default: `False`; Updatable)** |
+| `add_linodes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Linodes.  **(Default: `False`; Updatable)** |
+| `add_longview` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add LongView.  **(Default: `False`; Updatable)** |
+| `add_nodebalancers` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add NodeBalancers.  **(Default: `False`; Updatable)** |
+| `add_stackscripts` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add StackScripts.  **(Default: `False`; Updatable)** |
+| `add_volumes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add volumes.  **(Default: `False`; Updatable)** |
+| `cancel_account` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add cancel the entire account.  **(Default: `False`; Updatable)** |
+| `longview_subscription` | <center>`bool`</center> | <center>Optional</center> | If true, this User may manage the Account’s Longview subscription.  **(Default: `False`; Updatable)** |
 
 
 
@@ -99,9 +99,9 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `type` | <center></center> | <center>**Required**</center> | The type of resource to grant access to.  **(Choices: `domain`, `image`, `linode`, `longview`, `nodebalancer`, `stackscript`, `volume`;Updatable)** |
+| `type` | <center></center> | <center>**Required**</center> | The type of resource to grant access to.  **(Choices: `domain`, `image`, `linode`, `longview`, `nodebalancer`, `stackscript`, `volume`; Updatable)** |
 | `id` | <center>`int`</center> | <center>**Required**</center> | The ID of the resource to grant access to.  **(Updatable)** |
-| `permissions` | <center>`str`</center> | <center>**Required**</center> | The level of access this User has to this entity. If null, this User has no access.  **(Choices: `read_only`, `read_write`;Updatable)** |
+| `permissions` | <center>`str`</center> | <center>**Required**</center> | The level of access this User has to this entity. If null, this User has no access.  **(Choices: `read_only`, `read_write`; Updatable)** |
 
 
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -53,11 +53,11 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `username` | `str` | **Required** | The username of this user.   |
-| `state` | `str` | **Required** | The state of this user.  (Choices:  `present`  `absent` ) |
-| `restricted` | `bool` | Optional | If true, the User must be granted access to perform actions or access entities on this Account.  (Default: `True`) |
-| `email` | `str` | Optional | The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.   |
-| [`grants` (sub-options)](#grants) | `dict` | Optional | Update the grants a User has.   |
+| `username` | <center>`str`</center> | <center>**Required**</center> | The username of this user.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this user.  **(Choices: `present`, `absent`)** |
+| `restricted` | <center>`bool`</center> | <center>Optional</center> | If true, the User must be granted access to perform actions or access entities on this Account.  **(Default: `True`;Updatable)** |
+| `email` | <center>`str`</center> | <center>Optional</center> | The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.   |
+| [`grants` (sub-options)](#grants) | <center>`dict`</center> | <center>Optional</center> | Update the grants a User has.  **(Updatable)** |
 
 
 
@@ -67,8 +67,8 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| [`global` (sub-options)](#global) | `dict` | Optional | A structure containing the Account-level grants a User has.   |
-| [`resources` (sub-options)](#resources) | `list` | Optional | A list of resource grants to give to the user.   |
+| [`global` (sub-options)](#global) | <center>`dict`</center> | <center>Optional</center> | A structure containing the Account-level grants a User has.  **(Updatable)** |
+| [`resources` (sub-options)](#resources) | <center>`list`</center> | <center>Optional</center> | A list of resource grants to give to the user.  **(Updatable)** |
 
 
 
@@ -78,18 +78,18 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `account_access` |  | Optional | The level of access this User has to Account-level actions, like billing information. A restricted User will never be able to manage users.  (Choices:  `read_only`  `read_write` ) |
-| `add_databases` | `bool` | Optional | If true, this User may add Managed Databases.  (Default: `False`) |
-| `add_domains` | `bool` | Optional | If true, this User may add Domains.  (Default: `False`) |
-| `add_firewalls` | `bool` | Optional | If true, this User may add firewalls.  (Default: `False`) |
-| `add_images` | `bool` | Optional | If true, this User may add images.  (Default: `False`) |
-| `add_linodes` | `bool` | Optional | If true, this User may add Linodes.  (Default: `False`) |
-| `add_longview` | `bool` | Optional | If true, this User may add LongView.  (Default: `False`) |
-| `add_nodebalancers` | `bool` | Optional | If true, this User may add NodeBalancers.  (Default: `False`) |
-| `add_stackscripts` | `bool` | Optional | If true, this User may add StackScripts.  (Default: `False`) |
-| `add_volumes` | `bool` | Optional | If true, this User may add volumes.  (Default: `False`) |
-| `cancel_account` | `bool` | Optional | If true, this User may add cancel the entire account.  (Default: `False`) |
-| `longview_subscription` | `bool` | Optional | If true, this User may manage the Account’s Longview subscription.  (Default: `False`) |
+| `account_access` | <center></center> | <center>Optional</center> | The level of access this User has to Account-level actions, like billing information. A restricted User will never be able to manage users.  **(Choices: `read_only`, `read_write`;Updatable)** |
+| `add_databases` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Managed Databases.  **(Default: `False`;Updatable)** |
+| `add_domains` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Domains.  **(Default: `False`;Updatable)** |
+| `add_firewalls` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add firewalls.  **(Default: `False`;Updatable)** |
+| `add_images` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add images.  **(Default: `False`;Updatable)** |
+| `add_linodes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add Linodes.  **(Default: `False`;Updatable)** |
+| `add_longview` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add LongView.  **(Default: `False`;Updatable)** |
+| `add_nodebalancers` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add NodeBalancers.  **(Default: `False`;Updatable)** |
+| `add_stackscripts` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add StackScripts.  **(Default: `False`;Updatable)** |
+| `add_volumes` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add volumes.  **(Default: `False`;Updatable)** |
+| `cancel_account` | <center>`bool`</center> | <center>Optional</center> | If true, this User may add cancel the entire account.  **(Default: `False`;Updatable)** |
+| `longview_subscription` | <center>`bool`</center> | <center>Optional</center> | If true, this User may manage the Account’s Longview subscription.  **(Default: `False`;Updatable)** |
 
 
 
@@ -99,9 +99,9 @@ Manage a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `type` |  | **Required** | The type of resource to grant access to.  (Choices:  `domain`  `image`  `linode`  `longview`  `nodebalancer`  `stackscript`  `volume` ) |
-| `id` | `int` | **Required** | The ID of the resource to grant access to.   |
-| `permissions` | `str` | **Required** | The level of access this User has to this entity. If null, this User has no access.  (Choices:  `read_only`  `read_write` ) |
+| `type` | <center></center> | <center>**Required**</center> | The type of resource to grant access to.  **(Choices: `domain`, `image`, `linode`, `longview`, `nodebalancer`, `stackscript`, `volume`;Updatable)** |
+| `id` | <center>`int`</center> | <center>**Required**</center> | The ID of the resource to grant access to.  **(Updatable)** |
+| `permissions` | <center>`str`</center> | <center>**Required**</center> | The level of access this User has to this entity. If null, this User has no access.  **(Choices: `read_only`, `read_write`;Updatable)** |
 
 
 

--- a/docs/modules/user_info.md
+++ b/docs/modules/user_info.md
@@ -28,7 +28,7 @@ Get info about a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `username` | `str` | **Required** | The username of the user.   |
+| `username` | <center>`str`</center> | <center>**Required**</center> | The username of the user.   |
 
 
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -28,7 +28,7 @@ Get info about a Linode VLAN.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | `str` | **Required** | The VLAN’s label.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | The VLAN’s label.   |
 
 
 

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -36,10 +36,10 @@ List and filter on Linode VLANs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | `str` | Optional | The order to list VLANs in.  (Choices:  `desc`  `asc` Default: `asc`) |
-| `order_by` | `str` | Optional | The attribute to order VLANs by.   |
-| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting VLANs.   |
-| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list VLANs in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VLANs by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VLANs.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 
 
 
@@ -49,8 +49,8 @@ List and filter on Linode VLANs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/networking/#vlans-list__response-samples   |
-| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/networking/#vlans-list__response-samples   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 
 

--- a/docs/modules/volume.md
+++ b/docs/modules/volume.md
@@ -64,14 +64,14 @@ Manage a Linode Volume.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | `str` | **Required** | The desired state of the target.  (Choices:  `present`  `absent` ) |
-| `label` | `str` | Optional | The Volume’s label, which is also used in the filesystem_path of the resulting volume.   |
-| `config_id` | `int` | Optional | When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.   |
-| `linode_id` | `int` | Optional | The Linode this volume should be attached to upon creation. If not given, the volume will be created without an attachment.   |
-| `region` | `str` | Optional | The location to deploy the volume in. See U(https://api.linode.com/v4/regions)   |
-| `size` | `int` | Optional | The size of this volume, in GB. Be aware that volumes may only be resized up after creation.   |
-| `attached` | `bool` | Optional | If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.  (Default: `True`) |
-| `wait_timeout` | `int` | Optional | The amount of time, in seconds, to wait for a volume to have the active status.  (Default: `240`) |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The Volume’s label, which is also used in the filesystem_path of the resulting volume.   |
+| `config_id` | <center>`int`</center> | <center>Optional</center> | When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.   |
+| `linode_id` | <center>`int`</center> | <center>Optional</center> | The Linode this volume should be attached to upon creation. If not given, the volume will be created without an attachment.  **(Updatable)** |
+| `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the volume in. See U(https://api.linode.com/v4/regions)   |
+| `size` | <center>`int`</center> | <center>Optional</center> | The size of this volume, in GB. Be aware that volumes may only be resized up after creation.  **(Updatable)** |
+| `attached` | <center>`bool`</center> | <center>Optional</center> | If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.  **(Default: `True`;Updatable)** |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for a volume to have the active status.  **(Default: `240`)** |
 
 
 

--- a/docs/modules/volume.md
+++ b/docs/modules/volume.md
@@ -70,7 +70,7 @@ Manage a Linode Volume.
 | `linode_id` | <center>`int`</center> | <center>Optional</center> | The Linode this volume should be attached to upon creation. If not given, the volume will be created without an attachment.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the volume in. See U(https://api.linode.com/v4/regions)   |
 | `size` | <center>`int`</center> | <center>Optional</center> | The size of this volume, in GB. Be aware that volumes may only be resized up after creation.  **(Updatable)** |
-| `attached` | <center>`bool`</center> | <center>Optional</center> | If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.  **(Default: `True`;Updatable)** |
+| `attached` | <center>`bool`</center> | <center>Optional</center> | If true, the volume will be attached to a Linode. Otherwise, the volume will be detached.  **(Default: `True`; Updatable)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for a volume to have the active status.  **(Default: `240`)** |
 
 

--- a/docs/modules/volume_info.md
+++ b/docs/modules/volume_info.md
@@ -32,8 +32,8 @@ Get info about a Linode Volume.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | `int` | Optional | The ID of the Volume. Optional if `label` is defined.   |
-| `label` | `str` | Optional | The label of the Volume. Optional if `id` is defined.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Volume. Optional if `label` is defined.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Volume. Optional if `id` is defined.   |
 
 
 

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -46,7 +46,8 @@ SPEC = dict(
             'A list of IP addresses that can access the Managed Database.',
             'Each item must be a range in CIDR format.'
         ],
-        default=[]
+        default=[],
+        editable=True,
     ),
     cluster_size=dict(
         type='int',
@@ -93,7 +94,8 @@ SPEC = dict(
         type='dict',
         options=SPEC_UPDATE_WINDOW,
         description='Configuration settings for automated patch '
-                    'update maintenance for the Managed Database.'
+                    'update maintenance for the Managed Database.',
+        editable=True
     ),
     wait=dict(
         type='bool', default=True,

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -44,7 +44,8 @@ SPEC = dict(
             'A list of IP addresses that can access the Managed Database.',
             'Each item must be a range in CIDR format.'
         ],
-        default=[]
+        default=[],
+        editable=True,
     ),
     cluster_size=dict(
         type='int',
@@ -101,7 +102,8 @@ SPEC = dict(
         type='dict',
         options=SPEC_UPDATE_WINDOW,
         description='Configuration settings for automated patch '
-                    'update maintenance for the Managed Database.'
+                    'update maintenance for the Managed Database.',
+        editable=True
     ),
     wait=dict(
         type='bool', default=True,

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -22,39 +22,43 @@ linode_domain_spec = dict(
     # Unused for domain objects
     label=dict(type='str', required=False, doc_hide=True),
 
-    axfr_ips=dict(type='list', elements='str',
+    axfr_ips=dict(type='list', elements='str', editable=True,
                   description='The list of IPs that may perform a zone transfer for this Domain.'),
-    description=dict(type='str',
+    description=dict(type='str', editable=True,
                      description='The list of IPs that may perform a '
                                  'zone transfer for this Domain.'),
     domain=dict(type='str', required=True,
                 description='The domain this Domain represents.'),
-    expire_sec=dict(type='int',
+    expire_sec=dict(type='int', editable=True,
                     description='The amount of time in seconds that may pass'
                                 ' before this Domain is no longer authoritative.'),
-    master_ips=dict(type='list', elements='str',
+    master_ips=dict(type='list', elements='str', editable=True,
                     description='The IP addresses representing the '
                                 'master DNS for this Domain.'),
-    refresh_sec=dict(type='int',
+    refresh_sec=dict(type='int', editable=True,
                      description='The amount of time in seconds before '
                                  'this Domain should be refreshed.'),
-    retry_sec=dict(type='int',
+    retry_sec=dict(type='int', editable=True,
                    description='The interval, in seconds, at which a '
                                'failed refresh should be retried.'),
     soa_email=dict(type='str',
-                   description='The Start of Authority email address.'),
+                   description='The Start of Authority email address.',
+                   editable=True),
     status=dict(type='str',
-                description='Used to control whether this Domain is currently being rendered.'),
+                description='Used to control whether this Domain is currently being rendered.',
+                editable=True),
     state=dict(type='str',
                description='The desired state of the target.',
                choices=['present', 'absent'], required=True),
-    tags=dict(type='list', elements='str',
+    tags=dict(type='list', elements='str', editable=True,
               description='An array of tags applied to this object.'),
-    ttl_sec=dict(type='int',
+    ttl_sec=dict(type='int', editable=True,
                  description='the amount of time in seconds that this '
                              'Domain’s records may be cached by resolvers '
-                             'or other domain servers.'),
+                             'or other domain servers.'
+                 ),
     type=dict(type='str',
+              editable=True,
               description='Whether this Domain represents the authoritative '
                           'source of information for the domain'
                           ' it describes (master), or whether it is a '

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -36,25 +36,25 @@ linode_domain_record_spec = dict(
                   'NOTE: If the name of the record ends with the domain, '
                   'it will be dropped from the resulting record\'s name.'
               ]),
-    port=dict(type='int',
+    port=dict(type='int', editable=True,
               description=[
                   'The port this Record points to.',
                   'Only valid and required for SRV record requests.'
               ]),
-    priority=dict(type='int',
+    priority=dict(type='int', editable=True,
                   description=[
                       'The priority of the target host for this Record.',
                       'Lower values are preferred.',
                       'Only valid for MX and SRV record requests.',
                       'Required for SRV record requests.'
                   ]),
-    protocol=dict(type='str',
+    protocol=dict(type='str', editable=True,
                   description=[
                       'The protocol this Record’s service communicates with.',
                       'An underscore (_) is prepended automatically to '
                       'the submitted value for this property.'
                   ]),
-    service=dict(type='str',
+    service=dict(type='str', editable=True,
                  description=[
                      'An underscore (_) is prepended and a period (.) '
                      'is appended automatically to the submitted value for this property.',
@@ -64,7 +64,7 @@ linode_domain_record_spec = dict(
     state=dict(type='str',
                description='The desired state of the target.',
                choices=['present', 'absent'], required=True),
-    tag=dict(type='str',
+    tag=dict(type='str', editable=True,
              description=[
                  'The tag portion of a CAA record.',
                  'Only valid and required for CAA record requests.'
@@ -73,7 +73,7 @@ linode_domain_record_spec = dict(
                 description=[
                     'The target for this Record.'
                 ], default=''),
-    ttl_sec=dict(type='int',
+    ttl_sec=dict(type='int', editable=True,
                  description=[
                      'The amount of time in seconds that this Domain’s '
                      'records may be cached by resolvers '
@@ -81,7 +81,7 @@ linode_domain_record_spec = dict(
                  ]),
     type=dict(type='str',
               description='The type of Record this is in the DNS system.'),
-    weight=dict(type='int',
+    weight=dict(type='int', editable=True,
                 description='The relative weight of this Record '
                             'used in the case of identical priority.')
 )

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -98,15 +98,15 @@ linode_firewall_spec: dict = dict(
                description=[
                     'The unique label to give this Firewall.'
                 ]),
-    devices=dict(type='list', elements='dict', options=linode_firewall_device_spec,
+    devices=dict(type='list', elements='dict', options=linode_firewall_device_spec, editable=True,
                  description=[
                      'The devices that are attached to this Firewall.'
                  ]),
-    rules=dict(type='dict', options=linode_firewall_rules_spec,
+    rules=dict(type='dict', options=linode_firewall_rules_spec, editable=True,
                description=[
                    'The inbound and outbound access rules to apply to this Firewall.'
                ]),
-    status=dict(type='str',
+    status=dict(type='str', editable=True,
                 description=[
                     'The status of this Firewall.'
                 ]),

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -37,6 +37,7 @@ SPEC = dict(
     ),
     description=dict(
         type='str',
+        editable=True,
         description='A description for the Image.',
     ),
     disk_id=dict(

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -52,7 +52,7 @@ linode_instance_disk_spec = dict(
         description='The root user’s password on the newly-created Linode.'),
 
     size=dict(
-        type='int', required=True,
+        type='int', required=True, editable=True,
         description='The size of the Disk in MB.'),
 
     stackscript_id=dict(
@@ -145,7 +145,7 @@ linode_instance_interface_spec = dict(
 
 linode_instance_config_spec = dict(
     comments=dict(
-        type='str',
+        type='str', editable=True,
         description='Arbitrary User comments on this Config.'),
 
     devices=dict(
@@ -157,7 +157,7 @@ linode_instance_config_spec = dict(
         description='Helpers enabled when booting to this Linode Config.'),
 
     kernel=dict(
-        type='str',
+        type='str', editable=True,
         description='A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.'),
 
     label=dict(
@@ -165,19 +165,19 @@ linode_instance_config_spec = dict(
         description='The label to assign to this config.'),
 
     memory_limit=dict(
-        type='int',
+        type='int', editable=True,
         description='Defaults to the total RAM of the Linode.'),
 
     root_device=dict(
-        type='str',
+        type='str', editable=True,
         description='The root device to boot.'),
 
     run_level=dict(
-        type='str',
+        type='str', editable=True,
         description='Defines the state of your Linode after booting.'),
 
     virt_mode=dict(
-        type='str',
+        type='str', editable=True,
         description='Controls the virtualization mode.',
         choices=[
             'paravirt',
@@ -234,7 +234,7 @@ linode_instance_spec = dict(
         description='If true, the created Linode will have private networking enabled.'),
 
     group=dict(
-        type='str',
+        type='str', editable=True,
         description=[
             'The group that the instance should be marked under.',
             'Please note, that group labelling is deprecated but still supported.',
@@ -244,6 +244,7 @@ linode_instance_spec = dict(
 
     configs=dict(
         type='list', elements='dict', options=linode_instance_config_spec,
+        editable=True,
         description=[
             'A list of Instance configs to apply to the Linode.',
             'See the [Linode API documentation](https://www.linode.com/docs'
@@ -252,6 +253,7 @@ linode_instance_spec = dict(
 
     disks=dict(
         type='list', elements='dict', options=linode_instance_disk_spec,
+        editable=True,
         description=[
             'A list of Disks to create on the Linode.',
             'See the [Linode API documentation](https://www.linode.com/'

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -25,19 +25,19 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 
 linode_lke_cluster_autoscaler = dict(
     enabled=dict(
-        type='bool',
+        type='bool', editable=True,
         description=[
             'Whether autoscaling is enabled for this Node Pool.',
             'NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.'
         ],
     ),
     max=dict(
-        type='int',
+        type='int', editable=True,
         description='The maximum number of nodes to autoscale to. '
                     'Defaults to the value provided by the count field.',
     ),
     min=dict(
-        type='int',
+        type='int', editable=True,
         description='The minimum number of nodes to autoscale to. '
                     'Defaults to the Node Pool’s count.',
     ),
@@ -58,7 +58,7 @@ linode_lke_cluster_disk = dict(
 
 linode_lke_cluster_node_pool_spec = dict(
     count=dict(
-        type='int',
+        type='int', editable=True,
         description='The number of nodes in the Node Pool.',
         required=True,
     ),
@@ -68,7 +68,7 @@ linode_lke_cluster_node_pool_spec = dict(
         required=True,
     ),
     autoscaler=dict(
-        type='dict',
+        type='dict', editable=True,
         description='When enabled, the number of nodes autoscales within the '
                     'defined minimum and maximum values.',
         suboptions=linode_lke_cluster_autoscaler,
@@ -82,7 +82,7 @@ linode_lke_cluster_spec = dict(
         description='This Kubernetes cluster’s unique label.'
     ),
     k8s_version=dict(
-        type='str',
+        type='str', editable=True,
         description=[
             'The desired Kubernetes version for this Kubernetes '
             'cluster in the format of <major>.<minor>, and the '
@@ -102,13 +102,14 @@ linode_lke_cluster_spec = dict(
     ),
 
     high_availability=dict(
-        type='bool',
+        type='bool', editable=True,
         description='Defines whether High Availability is enabled for the '
                     'Control Plane Components of the cluster. ',
         default=False
     ),
 
     node_pools=dict(
+        editable=True,
         type='list',
         elements='dict',
         suboptions=linode_lke_cluster_node_pool_spec,

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -22,19 +22,19 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_n
 
 linode_lke_pool_autoscaler = dict(
     enabled=dict(
-        type='bool',
+        type='bool', editable=True,
         description=[
             'Whether autoscaling is enabled for this Node Pool.',
             'NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.'
         ],
     ),
     max=dict(
-        type='int',
+        type='int', editable=True,
         description='The maximum number of nodes to autoscale to. '
                     'Defaults to the value provided by the count field.',
     ),
     min=dict(
-        type='int',
+        type='int', editable=True,
         description='The minimum number of nodes to autoscale to. '
                     'Defaults to the Node Pool’s count.',
     ),
@@ -65,14 +65,14 @@ MODULE_SPEC = dict(
         ),
 
     autoscaler=dict(
-        type='dict',
+        type='dict', editable=True,
         description='When enabled, the number of nodes autoscales within the '
                     'defined minimum and maximum values.',
         suboptions=linode_lke_pool_autoscaler,
     ),
 
     count=dict(
-        type='int',
+        type='int', editable=True,
         description='The number of nodes in the Node Pool.',
     ),
 
@@ -86,7 +86,7 @@ MODULE_SPEC = dict(
     ),
 
     tags=dict(
-        type='list', elements='str',
+        type='list', elements='str', editable=True,
         required=True,
         description=[
             'An array of tags applied to this object.',

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -31,19 +31,19 @@ linode_nodes_spec = dict(
         description='The label for this node.'),
 
     address=dict(
-        type='str', required=True,
+        type='str', required=True, editable=True,
         description=[
             'The private IP Address where this backend can be reached.',
             'This must be a private IP address.'
         ]),
 
     weight=dict(
-        type='int', required=False,
+        type='int', required=False, editable=True,
         description='Nodes with a higher weight will receive more traffic.',
     ),
 
     mode=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The mode this NodeBalancer should use when sending traffic to this backend.',
         choices=['accept', 'reject', 'drain', 'backup']),
 
@@ -51,22 +51,22 @@ linode_nodes_spec = dict(
 
 linode_configs_spec = dict(
     algorithm=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='What algorithm this NodeBalancer should use for routing traffic to backends.',
         choices=['roundrobin', 'leastconn', 'source']),
 
     check=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The type of check to perform against backends to ensure they are '
                     'serving requests.',
         choices=['none', 'connection', 'http', 'http_body']),
 
     check_attempts=dict(
-        type='int', required=False,
+        type='int', required=False, editable=True,
         description='How many times to attempt a check before considering a backend to be down.'),
 
     check_body=dict(
-        type='str', required=False, default='',
+        type='str', required=False, default='', editable=True,
         description=[
             'This value must be present in the response body of the check in order for it to pass.',
             'If this value is not present in the response body of a check request, the backend is '
@@ -74,40 +74,40 @@ linode_configs_spec = dict(
         ]),
 
     check_interval=dict(
-        type='int', required=False,
+        type='int', required=False, editable=True,
         description='How often, in seconds, to check that backends are up and serving requests.'),
 
     check_passive=dict(
-        type='bool', required=False,
+        type='bool', required=False, editable=True,
         description='If true, any response from this backend with a 5xx status code will be enough '
                     'for it to be considered unhealthy and taken out of rotation.'),
 
     check_path=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The URL path to check on each backend. If the backend does '
                     'not respond to this request it is considered to be down.'),
 
     check_timeout=dict(
-        type='int', required=False,
+        type='int', required=False, editable=True,
         description='How long, in seconds, to wait for a check attempt before considering it '
                     'failed.'),
 
     cipher_suite=dict(
-        type='str', required=False, default='recommended',
+        type='str', required=False, default='recommended', editable=True,
         description='What ciphers to use for SSL connections served by this NodeBalancer.',
         choices=['recommended', 'legacy']),
 
     port=dict(
-        type='int', required=False,
+        type='int', required=False, editable=True,
         description='The port this Config is for.'),
 
     protocol=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The protocol this port is configured to serve.',
         choices=['http', 'https', 'tcp']),
 
     proxy_protocol=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='ProxyProtocol is a TCP extension that sends initial TCP connection '
                     'information such as source/destination IPs and ports to backend devices.',
         choices=['none', 'v1', 'v2']),
@@ -119,23 +119,23 @@ linode_configs_spec = dict(
     ),
 
     ssl_cert=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The PEM-formatted public SSL certificate (or the combined '
                     'PEM-formatted SSL certificate and Certificate Authority chain) '
                     'that should be served on this NodeBalancerConfig’s port.'),
 
     ssl_key=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='The PEM-formatted private key for the SSL certificate '
                     'set in the ssl_cert field.'),
 
     stickiness=dict(
-        type='str', required=False,
+        type='str', required=False, editable=True,
         description='Controls how session stickiness is handled on this port.',
         choices=['none', 'table', 'http_cookie']),
 
     nodes=dict(
-        type='list', required=False, elements='dict', options=linode_nodes_spec,
+        type='list', required=False, elements='dict', options=linode_nodes_spec, editable=True,
         description='A list of nodes to apply to this config. '
                     'These can alternatively be configured through the nodebalancer_node module.')
 )
@@ -148,7 +148,7 @@ linode_nodebalancer_spec = dict(
     ),
 
     client_conn_throttle=dict(
-        type='int',
+        type='int', editable=True,
         description=[
             'Throttle connections per second.',
             'Set to 0 (zero) to disable throttling.'
@@ -164,7 +164,7 @@ linode_nodebalancer_spec = dict(
                choices=['present', 'absent'], required=True),
 
     configs=dict(
-        type='list', elements='dict', options=linode_configs_spec,
+        type='list', elements='dict', options=linode_configs_spec, editable=True,
         description='A list of configs to apply to the NodeBalancer.')
 )
 

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -37,7 +37,7 @@ MODULE_SPEC = dict(
     ),
 
     address=dict(
-        type='str',
+        type='str', editable=True,
         description='The private IP Address where this backend can be reached. '
                     'This must be a private IP address.',
     ),
@@ -50,13 +50,13 @@ MODULE_SPEC = dict(
     ),
 
     mode=dict(
-        type='str',
+        type='str', editable=True,
         description='The mode this NodeBalancer should use when sending traffic to this backend.',
         choices=['accept', 'reject', 'drain', 'backup'],
     ),
 
     weight=dict(
-        type='int',
+        type='int', editable=True,
         description='Nodes with a higher weight will receive more traffic.',
     ),
 )

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -35,25 +35,26 @@ SPEC = dict(
     ),
 
     description=dict(
-        type='str',
+        type='str', editable=True,
         description='A description for the StackScript.',
     ),
     images=dict(
         type='list',
         elements='str',
+        editable=True,
         description='Images that can be deployed using this StackScript.',
     ),
     is_public=dict(
-        type='bool',
+        type='bool', editable=True,
         description='This determines whether other users can use your StackScript.',
     ),
     rev_note=dict(
-        type='str',
+        type='str', editable=True,
         description='This field allows you to add notes for '
                     'the set of revisions made to this StackScript.',
     ),
     script=dict(
-        type='str',
+        type='str', editable=True,
         description='The script to execute when provisioning a new Linode with this StackScript.'
     )
 )

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -30,63 +30,75 @@ SPEC_GRANTS_GLOBAL = {
             'The level of access this User has to Account-level actions, '
             'like billing information.',
             'A restricted User will never be able to manage users.'],
-        'default': None
+        'default': None,
+        'editable': True,
     },
     'add_databases': {
         'type': 'bool',
         'description': 'If true, this User may add Managed Databases.',
         'default': False,
+        'editable': True,
     },
     'add_domains': {
         'type': 'bool',
         'description': 'If true, this User may add Domains.',
         'default': False,
+        'editable': True,
     },
     'add_firewalls': {
         'type': 'bool',
         'description': 'If true, this User may add firewalls.',
         'default': False,
+        'editable': True,
     },
     'add_images': {
         'type': 'bool',
         'description': 'If true, this User may add images.',
         'default': False,
+        'editable': True,
     },
     'add_linodes': {
         'type': 'bool',
         'description': 'If true, this User may add Linodes.',
         'default': False,
+        'editable': True,
     },
     'add_longview': {
         'type': 'bool',
         'description': 'If true, this User may add LongView.',
         'default': False,
+        'editable': True,
     },
     'add_nodebalancers': {
         'type': 'bool',
         'description': 'If true, this User may add NodeBalancers.',
         'default': False,
+        'editable': True,
     },
     'add_stackscripts': {
         'type': 'bool',
         'description': 'If true, this User may add StackScripts.',
         'default': False,
+        'editable': True,
     },
     'add_volumes': {
         'type': 'bool',
         'description': 'If true, this User may add volumes.',
         'default': False,
+        'editable': True,
     },
     'cancel_account': {
         'type': 'bool',
         'description': 'If true, this User may add cancel the entire account.',
         'default': False,
+        'editable': True,
     },
     'longview_subscription': {
         'type': 'bool',
         'description': 'If true, this User may manage the Account’s '
                        'Longview subscription.',
         'default': False,
+        'editable': True,
     },
 }
 
@@ -98,18 +110,21 @@ SPEC_GRANTS_RESOURCE = {
         'description': [
             'The type of resource to grant access to.'],
         'required': True,
+        'editable': True,
     },
     'id': {
         'type': 'int',
         'description': 'The ID of the resource to grant access to.',
         'required': True,
+        'editable': True,
     },
     'permissions': {
         'type': 'str',
         'choices': ['read_only', 'read_write'],
         'description': 'The level of access this User has to this entity. '
                        'If null, this User has no access.',
-        'required': True
+        'required': True,
+        'editable': True,
     },
 }
 
@@ -118,12 +133,14 @@ SPEC_GRANTS = {
         'type': 'dict',
         'description': 'A structure containing the Account-level grants a User has.',
         'options': SPEC_GRANTS_GLOBAL,
+        'editable': True,
     },
     'resources': {
         'description': 'A list of resource grants to give to the user.',
         'type': 'list',
         'elements': 'dict',
-        'options': SPEC_GRANTS_RESOURCE
+        'options': SPEC_GRANTS_RESOURCE,
+        'editable': True,
     }
 }
 
@@ -150,6 +167,7 @@ SPEC = {
         'description': 'If true, the User must be granted access to perform '
                        'actions or access entities on this Account.',
         'default': True,
+        'editable': True,
     },
     'email': {
         'type': 'str',
@@ -161,7 +179,8 @@ SPEC = {
     'grants': {
         'type': 'dict',
         'description': 'Update the grants a User has.',
-        'options': SPEC_GRANTS
+        'options': SPEC_GRANTS,
+        'editable': True,
     }
 }
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -30,7 +30,7 @@ linode_volume_spec = dict(
                     'to include the new Volume in.'),
 
     linode_id=dict(
-        type='int', default=None,
+        type='int', default=None, editable=True,
         description=[
             'The Linode this volume should be attached to upon creation.',
             'If not given, the volume will be created without an attachment.'
@@ -44,14 +44,14 @@ linode_volume_spec = dict(
         ]),
 
     size=dict(
-        type='int', default=None,
+        type='int', default=None, editable=True,
         description=[
             'The size of this volume, in GB.',
             'Be aware that volumes may only be resized up after creation.'
         ]),
 
     attached=dict(
-        type='bool', default=True,
+        type='bool', default=True, editable=True,
         description='If true, the volume will be attached to a Linode. '
                     'Otherwise, the volume will be detached.'),
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ botocore==1.20.23
 pylint==2.15.5
 ansible-doc-extractor==0.1.8
 mypy==0.982
-ansible-specdoc==0.0.9
+ansible-specdoc==0.0.10
 ansible==6.5.0
 Jinja2==3.0.1

--- a/template/module.md.j2
+++ b/template/module.md.j2
@@ -32,7 +32,21 @@
 {% set required_text = '**Required**' if spec.required else 'Optional' %}
 {% set type_text = '`%s`' % spec.type if spec.type else '' %}
 {% set name_fmt = '[`%s` (sub-options)](#%s)' % (name, name) if spec.suboptions else '`%s`' % name %}
-| {{ name_fmt }} | {{type_text}} | {{ required_text }} | {% for line in spec.description %}{{ line }} {% endfor %} {% if spec.default or spec.default == False or spec.choices %}({% if spec.choices %}Choices: {% for choice in spec.choices %} `{{ choice }}` {% endfor %}{% endif %}{% if spec.default or spec.default == False %}Default: `{{ spec.default }}`{% endif %}){% endif %} |
+{% set extras_fmt = [] %}
+{% set choices_fmt = [] %}
+{% if spec.choices -%}
+{% for choice in spec.choices -%}
+{{ choices_fmt.append('`{}`'.format(choice|string)) or ''}}
+{%- endfor %}
+{{ extras_fmt.append("Choices: " + ', '.join(choices_fmt)) or '' }}
+{%- endif %}
+{% if spec.default or spec.default == False -%}
+{{ extras_fmt.append('Default: `{}`'.format(spec.default)) or ''}}
+{%- endif %}
+{% if spec.editable -%}
+{{ extras_fmt.append("Updatable") or '' }}
+{%- endif %}
+| {{ name_fmt }} | <center>{{type_text}}</center> | <center>{{ required_text }}</center> | {% for line in spec.description %}{{ line }} {% endfor %} {% if extras_fmt | length > 0 %}**({{ extras_fmt|join(';') }})**{% endif %} |
 {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/template/module.md.j2
+++ b/template/module.md.j2
@@ -46,7 +46,7 @@
 {% if spec.editable -%}
 {{ extras_fmt.append("Updatable") or '' }}
 {%- endif %}
-| {{ name_fmt }} | <center>{{type_text}}</center> | <center>{{ required_text }}</center> | {% for line in spec.description %}{{ line }} {% endfor %} {% if extras_fmt | length > 0 %}**({{ extras_fmt|join(';') }})**{% endif %} |
+| {{ name_fmt }} | <center>{{type_text}}</center> | <center>{{ required_text }}</center> | {% for line in spec.description %}{{ line }} {% endfor %} {% if extras_fmt | length > 0 %}**({{ extras_fmt|join('; ') }})**{% endif %} |
 {% endif %}
 {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
## 📝 Description

This change adds an `Updatable` tag to documentation for fields that can be modified for an API resource. Additionally, this change refactors some of the template logic for defaults and enums.

## ✔️ How to Test

```
make gendocs
```

## 📷 Preview

<img width="1019" alt="7BFD53FB-1A79-4DDC-85C0-02CE6BAED27D" src="https://user-images.githubusercontent.com/114949949/203133570-53768a6a-2153-444a-9919-68a0b021c4b7.png">
