### PR TITLE
new: add `type_list` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Name | Description |
 [linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Linode events.|
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Linode images.|
 [linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on Linode stackscripts.|
+[linode.cloud.type_list](./docs/modules/type_list.md)|List and filter on Linode Instance Types.|
 [linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on Linode VLANs.|
 
 

--- a/docs/modules/type_list.md
+++ b/docs/modules/type_list.md
@@ -1,0 +1,95 @@
+# type_list
+
+List and filter on Linode Instance Types.
+
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the Linode Instance Types
+  linode.cloud.type_list: {}
+```
+
+```yaml
+- name: List a Linode Instance Type named Nanode 1GB
+  linode.cloud.type_list:
+    filter:
+      - name: label
+        values: Nanode 1GB
+
+```
+
+
+
+
+
+
+
+
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | `str` | Optional | The order to list Instance Types in.  (Choices:  `desc`  `asc` Default: `asc`) |
+| `order_by` | `str` | Optional | The attribute to order Instance Types by.   |
+| [`filters` (sub-options)](#filters) | `list` | Optional | A list of filters to apply to the resulting Instance Types.   |
+| `count` | `int` | Optional | The number of results to return. If undefined, all results will be returned.   |
+
+
+
+
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | `str` | **Required** | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/linode-types/#types-list__response-samples   |
+| `values` | `list` | **Required** | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+
+
+
+
+
+## Return Values
+
+- `types` - The returned Instance Types.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "addons": {
+                    "backups": {
+                        "price": {
+                            "hourly": 0.008,
+                            "monthly": 5
+                        }
+                    }
+                },
+                "class": "standard",
+                "disk": 81920,
+                "gpus": 0,
+                "id": "g6-standard-2",
+                "label": "Linode 4GB",
+                "memory": 4096,
+                "network_out": 1000,
+                "price": {
+                    "hourly": 0.03,
+                    "monthly": 20
+                },
+                "successor": null,
+                "transfer": 4000,
+                "vcpus": 2
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-types/#types-list__response-samples) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/type_list.py
+++ b/plugins/module_utils/doc_fragments/type_list.py
@@ -1,0 +1,38 @@
+"""Documentation fragments for the type_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode Instance Types
+  linode.cloud.type_list: {}''', '''
+- name: List a Linode Instance Type named Nanode 1GB
+  linode.cloud.type_list:
+    filter:
+      - name: label
+        values: Nanode 1GB
+''']
+
+result_type_samples = ['''[
+    {
+        "addons": {
+            "backups": {
+                "price": {
+                    "hourly": 0.008,
+                    "monthly": 5
+                }
+            }
+        },
+        "class": "standard",
+        "disk": 81920,
+        "gpus": 0,
+        "id": "g6-standard-2",
+        "label": "Linode 4GB",
+        "memory": 4096,
+        "network_out": 1000,
+        "price": {
+            "hourly": 0.03,
+            "monthly": 20
+        },
+        "successor": null,
+        "transfer": 4000,
+        "vcpus": 2
+    }
+]''']

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Instance Types."""
+
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=unused-import
+from typing import Any, Optional, Dict
+
+from ansible.module_utils.basic import env_fallback
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import create_filter_and, \
+    filter_null_values, construct_api_filter, get_all_paginated
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
+    global_requirements
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.type_list as docs
+
+spec_filter = dict(
+    name=dict(type='str', required=True,
+              description=[
+                  'The name of the field to filter on.',
+                  'Valid filterable attributes can be found here: '
+                  'https://www.linode.com/docs/api/linode-types/#types-list__response-samples',
+              ]),
+    values=dict(type='list', elements='str', required=True,
+                description=[
+                    'A list of values to allow for this field.',
+                    'Fields will pass this filter if at least one of these values matches.'
+                ])
+)
+
+spec = dict(
+    # Disable the default values
+    state=dict(type='str', required=False, doc_hide=True),
+    label=dict(type='str', required=False, doc_hide=True),
+    order=dict(type='str', description='The order to list Instance Types in.',
+               default='asc', choices=['desc', 'asc']),
+    order_by=dict(type='str', description='The attribute to order Instance Types by.'),
+    filters=dict(type='list', elements='dict', options=spec_filter,
+                 description='A list of filters to apply to the resulting Instance Types.'),
+    count=dict(type='int',
+               description=[
+                   'The number of results to return.',
+                   'If undefined, all results will be returned.'])
+)
+
+specdoc_meta = dict(
+    description=[
+        'List and filter on Linode Instance Types.'
+    ],
+    requirements=global_requirements,
+    author=global_authors,
+    spec=spec,
+    examples=docs.specdoc_examples,
+    return_values=dict(
+        types=dict(
+            description='The returned Instance Types.',
+            docs_url='https://www.linode.com/docs/api/linode-types/#types-list__response-samples',
+            type='list',
+            elements='dict',
+            sample=docs.result_type_samples
+        )
+    )
+)
+
+
+class Module(LinodeModuleBase):
+    """Module for getting info about a Linode Instance Types"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = spec
+        self.results: Dict[str, Any] = {
+            'types': []
+        }
+
+        super().__init__(module_arg_spec=self.module_arg_spec)
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Instance Types list module"""
+
+        filter_dict = construct_api_filter(self.module.params)
+
+        self.results['types'] = get_all_paginated(self.client, '/linode/types', filter_dict,
+                                                   num_results=self.module.params['count'])
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the module"""
+    Module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -1,0 +1,19 @@
+- name: type_list
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Resolve a Linode Type
+      linode.cloud.type_list:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        count: 1
+        filters:
+          - name: label
+            values: Nanode 1GB
+      register: filter
+
+    - assert:
+        that:
+          - filter.types | length == 1
+          - filter.types[0].label == 'Nanode 1GB'


### PR DESCRIPTION
## 📝 Description

Allows the listing of Linode Instance Types
https://www.linode.com/docs/api/linode-types/#types-list

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

```bash
make TEST_ARGS='-v type_list' test
```
```yaml
- linode.cloud.type_list:
     filter:
       - name: label
          values: Nanode 1GB
```