### PR TITLE
fix: Fix typo in `database_list` test

### DIFF
--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -90,7 +90,7 @@
       linode.cloud.database_list:
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
-        filter:
+        filters:
           - name: engine
             values: mysql
           - name: label


### PR DESCRIPTION
## 📝 Description

This change resolves a typo that was causing the `mysql_basic` test to fail.

## ✔️ How to Test

```
make TEST_ARGS="-v mysql_basic" test
```