### PR TITLE
new: Add support for defining interfaces in `instance` configs

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -112,7 +112,7 @@ Manage Linode Instances, Configs, and Disks.
 | `root_device` | <center>`str`</center> | <center>Optional</center> | The root device to boot.  **(Updatable)** |
 | `run_level` | <center>`str`</center> | <center>Optional</center> | Defines the state of your Linode after booting.  **(Updatable)** |
 | `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`; Updatable)** |
-| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create__request-body-schema).   |
+| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create__request-body-schema).  **(Updatable)** |
 
 
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -103,15 +103,16 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
+| [`devices` (sub-options)](#devices) | <center>`dict`</center> | <center>**Required**</center> | The devices to map to this configuration.   |
 | `label` | <center>`str`</center> | <center>**Required**</center> | The label to assign to this config.   |
 | `comments` | <center>`str`</center> | <center>Optional</center> | Arbitrary User comments on this Config.  **(Updatable)** |
-| [`devices` (sub-options)](#devices) | <center>`dict`</center> | <center>Optional</center> | The devices to map to this configuration.   |
 | [`helpers` (sub-options)](#helpers) | <center>`dict`</center> | <center>Optional</center> | Helpers enabled when booting to this Linode Config.   |
 | `kernel` | <center>`str`</center> | <center>Optional</center> | A Kernel ID to boot a Linode with. Defaults to “linode/latest-64bit”.  **(Updatable)** |
 | `memory_limit` | <center>`int`</center> | <center>Optional</center> | Defaults to the total RAM of the Linode.  **(Updatable)** |
 | `root_device` | <center>`str`</center> | <center>Optional</center> | The root device to boot.  **(Updatable)** |
 | `run_level` | <center>`str`</center> | <center>Optional</center> | Defines the state of your Linode after booting.  **(Updatable)** |
 | `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`; Updatable)** |
+| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create__request-body-schema).   |
 
 
 
@@ -244,6 +245,18 @@ Manage Linode Instances, Configs, and Disks.
 
 
 
+### interfaces
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `purpose` | <center>`str`</center> | <center>**Required**</center> | The type of interface.  **(Choices: `public`, `vlan`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The name of this interface. Required for vlan purpose interfaces. Must be an empty string or null for public purpose interfaces.   |
+| `ipam_address` | <center>`str`</center> | <center>Optional</center> | This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.   |
+
+
+
+
+
 ### disks
 
 | Field     | Type | Required | Description                                                                  |
@@ -257,18 +270,6 @@ Manage Linode Instances, Configs, and Disks.
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The root user’s password on the newly-created Linode.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-
-
-
-
-
-### interfaces
-
-| Field     | Type | Required | Description                                                                  |
-|-----------|------|----------|------------------------------------------------------------------------------|
-| `purpose` | <center>`str`</center> | <center>**Required**</center> | The type of interface.  **(Choices: `public`, `vlan`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The name of this interface. Required for vlan purpose interfaces. Must be an empty string or null for public purpose interfaces.   |
-| `ipam_address` | <center>`str`</center> | <center>Optional</center> | This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.   |
 
 
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -14,8 +14,8 @@ import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import \
     LinodeModuleBase
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import \
-    filter_null_values, paginated_list_to_json, drop_empty_strings, mapping_to_dict, request_retry, \
-    filter_null_values_recursive
+    filter_null_values, paginated_list_to_json, drop_empty_strings, mapping_to_dict, \
+    request_retry, filter_null_values_recursive
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -186,6 +186,7 @@ linode_instance_config_spec = dict(
         ]),
     interfaces=dict(
         type='list', elements='dict', options=linode_instance_interface_spec,
+        editable=True,
         description=[
             'A list of network interfaces to apply to the Linode.',
             'See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances'
@@ -364,6 +365,8 @@ class LinodeInstance(LinodeModuleBase):
         self.mutually_exclusive = [
             ('image', 'disks'),
             ('image', 'configs'),
+            ('interfaces', 'configs'),
+            ('interfaces', 'disks')
         ]
 
         self.results: dict = dict(

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -1,0 +1,117 @@
+- name: instance_config_vlan
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode instance with interface
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-southeast
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: vlan
+                label: really-cool-vlan
+        wait: false
+        booted: false
+        state: present
+      register: create_instance
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create_instance.changed
+          - create_instance.instance.ipv4|length == 1
+
+          - create_instance.configs[0].interfaces[0].purpose == 'vlan'
+          - create_instance.configs[0].interfaces[0].label == 'really-cool-vlan'
+
+    - name: Update the instance
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-southeast
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: public
+              - purpose: vlan
+                label: really-cool-vlan
+        wait: false
+        booted: false
+        state: present
+      register: update_instance
+
+    - assert:
+        that:
+          - update_instance.changed
+          - update_instance.instance.ipv4|length == 1
+
+          - update_instance.configs[0].interfaces[0].purpose == 'public'
+          - update_instance.configs[0].interfaces[1].purpose == 'vlan'
+          - update_instance.configs[0].interfaces[1].label == 'really-cool-vlan'
+
+    - name: Don't change the instance
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-southeast
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: public
+              - purpose: vlan
+                label: really-cool-vlan
+        wait: false
+        booted: false
+        state: present
+      register: unchanged_instance
+
+    - assert:
+        that:
+          - unchanged_instance.changed == False
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
+            label: '{{ create_instance.instance.label }}'
+            state: absent
+          register: delete_instance
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create_instance.instance.id


### PR DESCRIPTION
## 📝 Description

This change allows users to create and update config interfaces from the `linode.cloud.instance` module.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_config_vlan" test
```