### PR TITLE
fix: Dynamically resolve K8s version in LKE test suite

### DIFF
--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -3,13 +3,24 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Resolve the latest K8s version
+      linode.cloud.api_request:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        method: GET
+        path: lke/versions
+      register: lke_versions
+
+    - set_fact:
+        kube_version: '{{ lke_versions.body.data[0].id }}'
+
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
-        k8s_version: 1.23
+        k8s_version: '{{ kube_version }}'
         node_pools:
           - type: g6-standard-1
             count: 3
@@ -25,7 +36,7 @@
 
     - assert:
         that:
-          - create_cluster.cluster.k8s_version == '1.23'
+          - create_cluster.cluster.k8s_version == kube_version
           - create_cluster.cluster.region == 'us-southeast'
           - create_cluster.node_pools[0].type == 'g6-standard-1'
           - create_cluster.node_pools[0].count == 3
@@ -39,7 +50,7 @@
         ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_cluster.cluster.label }}'
         region: us-southeast
-        k8s_version: 1.23
+        k8s_version: '{{ kube_version }}'
         skip_polling: true
         node_pools:
           - type: g6-standard-1
@@ -53,7 +64,7 @@
 
     - assert:
         that:
-          - update_pools.cluster.k8s_version == '1.23'
+          - update_pools.cluster.k8s_version == kube_version
           - update_pools.cluster.region == 'us-southeast'
 
           - update_pools.node_pools | length == 3
@@ -73,7 +84,7 @@
         ua_prefix: '{{ ua_prefix }}'
         label: '{{ create_cluster.cluster.label }}'
         region: us-southeast
-        k8s_version: 1.23
+        k8s_version: '{{ kube_version }}'
         high_availability: true
         skip_polling: true
         node_pools:
@@ -88,7 +99,7 @@
 
     - assert:
         that:
-          - upgrade.cluster.k8s_version == '1.23'
+          - upgrade.cluster.k8s_version == kube_version
           - upgrade.cluster.control_plane.high_availability == True
           - upgrade.cluster.region == 'us-southeast'
 
@@ -110,7 +121,7 @@
 
     - assert:
         that:
-          - info_by_id.cluster.k8s_version == '1.23'
+          - info_by_id.cluster.k8s_version == kube_version
           - info_by_id.cluster.region == 'us-southeast'
 
           - info_by_id.node_pools | length == 1
@@ -128,7 +139,7 @@
 
     - assert:
         that:
-          - info_by_label.cluster.k8s_version == '1.23'
+          - info_by_label.cluster.k8s_version == kube_version
           - info_by_label.cluster.region == 'us-southeast'
 
           - info_by_label.node_pools | length == 1

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -3,13 +3,24 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Resolve the latest K8s version
+      linode.cloud.api_request:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        method: GET
+        path: lke/versions
+      register: lke_versions
+
+    - set_fact:
+        kube_version: '{{ lke_versions.body.data[0].id }}'
+
     - name: Create a minimal LKE cluster
       linode.cloud.lke_cluster:
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
         label: 'ansible-test-{{ r }}'
         region: us-southeast
-        k8s_version: 1.23
+        k8s_version: '{{ kube_version }}'
         node_pools:
           - type: g6-standard-1
             count: 1
@@ -19,7 +30,7 @@
 
     - assert:
         that:
-          - create_cluster.cluster.k8s_version == '1.23'
+          - create_cluster.cluster.k8s_version == kube_version
           - create_cluster.cluster.region == 'us-southeast'
           - create_cluster.node_pools[0].type == 'g6-standard-1'
           - create_cluster.node_pools[0].count == 1


### PR DESCRIPTION
## 📝 Description

This change switches the LKE test suite from using hard-coded K8s versions to dynamically resolved K8s versions through the Linode API. This is necessary as using deprecated K8s versions will cause the test suite to fail.

## ✔️ How to Test

`make TEST_ARGS="-v lke_cluster_basic" test`

`make TEST_ARGS="-v  lke_node_pool_basic" test`