### PR TITLE
Update Makefile to Utilize `LINODE_TOKEN` Environmental Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 *.pyc
 __pycache__/
 galaxy.yml
+venv

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,12 @@ testall:
 	./scripts/test_all.sh
 
 $(INTEGRATION_CONFIG):
-	@if test "$(LINODE_API_TOKEN)" = "" && "$(LINODE_TOKEN)" = ""; then \
-	  echo "LINODE_API_TOKEN must be set"; \
-	  exit 1; \
-	fi
-	echo "api_token: $(LINODE_API_TOKEN)" > $(INTEGRATION_CONFIG)
+ifneq ("$(LINODE_TOKEN)", "")
+	echo "api_token: $(LINODE_API_TOKEN)" > $(INTEGRATION_CONFIG);
+else ifneq ("$(LINODE_API_TOKEN)", "")
+	echo "api_token: $(LINODE_TOKEN)" > $(INTEGRATION_CONFIG);
+else
+	echo "LINODE_API_TOKEN must be set"; \
+	exit 1;
+endif
 	echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)


### PR DESCRIPTION
Fix an issue that when `LINODE_API` environmental variable is set and `LINODE_API_API` isn't, `Make` would generate an `integration_config.yml` file with an empty API token.