### PR TITLE
new: Add improved timeout system for polling modules

### DIFF
--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -8,6 +8,7 @@ from typing import Any
 import polling
 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import format_api_error
+from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION
@@ -97,6 +98,13 @@ class LinodeModuleBase:
         self.results: dict = self.results or dict(
             changed=False,
             actions=[]
+        )
+
+        # This field may or may not be present depending on the module
+        timeout_param = self.module.params.get('wait_timeout', 120)
+
+        self._timeout_ctx: TimeoutContext = TimeoutContext(
+            timeout_seconds=timeout_param
         )
 
         if not HAS_LINODE:

--- a/plugins/module_utils/linode_timeout.py
+++ b/plugins/module_utils/linode_timeout.py
@@ -1,26 +1,38 @@
+"""
+This module holds various utilities for managing module polling timeouts.
+"""
+
 import datetime
 
 
 class TimeoutContext:
+    """
+    TimeoutContext should be used by polling resources to track their provisioning time.
+    """
+
     def __init__(self, timeout_seconds=120):
         self._start_time = datetime.datetime.now()
         self._timeout_seconds = timeout_seconds
 
     def start(self, start_time=datetime.datetime.now()):
-        """Sets the timeout start time to the current time"""
+        """Sets the timeout start time to the current time."""
         self._start_time = start_time
 
     def extend(self, seconds):
+        """Extends the timeout window."""
         self._timeout_seconds += seconds
 
     @property
     def expired(self):
+        """Whether the current timeout period has been exceeded."""
         return self.seconds_remaining > self._timeout_seconds
 
     @property
     def valid(self):
+        """Whether the current timeout period has not been exceeded."""
         return not self.expired
 
     @property
     def seconds_remaining(self):
+        """The number of seconds until the timeout period has expired."""
         return (datetime.datetime.now() - self._start_time).seconds

--- a/plugins/module_utils/linode_timeout.py
+++ b/plugins/module_utils/linode_timeout.py
@@ -1,0 +1,26 @@
+import datetime
+
+
+class TimeoutContext:
+    def __init__(self, timeout_seconds=120):
+        self._start_time = datetime.datetime.now()
+        self._timeout_seconds = timeout_seconds
+
+    def start(self, start_time=datetime.datetime.now()):
+        """Sets the timeout start time to the current time"""
+        self._start_time = start_time
+
+    def extend(self, seconds):
+        self._timeout_seconds += seconds
+
+    @property
+    def expired(self):
+        return self.seconds_remaining > self._timeout_seconds
+
+    @property
+    def valid(self):
+        return not self.expired
+
+    @property
+    def seconds_remaining(self):
+        return (datetime.datetime.now() - self._start_time).seconds

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -26,7 +26,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     handle_updates, filter_null_values, paginated_list_to_json, mapping_to_dict, poll_condition
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.database_mysql as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 SPEC = dict(
     label=dict(
@@ -169,8 +168,6 @@ class Module(LinodeModuleBase):
             ssl_cert=None,
         )
 
-        self._timeout_ctx: Optional[TimeoutContext] = None
-
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=[('state', 'label')],
                          required_if=[('state', 'present', ['region', 'engine', 'type'], True)])
@@ -303,8 +300,6 @@ class Module(LinodeModuleBase):
             validate_shared_db_input(self.module.params)
         except ValueError as err:
             self.fail(msg='Invalid param: {}'.format(err))
-
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
 
         state = kwargs.get('state')
 

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -23,7 +23,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.database_postgresql \
     as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 SPEC = dict(
     label=dict(
@@ -177,8 +176,6 @@ class Module(LinodeModuleBase):
             ssl_cert=None,
         )
 
-        self._timeout_ctx: Optional[TimeoutContext] = None
-
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=[('state', 'label')],
                          required_if=[('state', 'present', ['region', 'engine', 'type'], True)])
@@ -312,8 +309,6 @@ class Module(LinodeModuleBase):
             validate_shared_db_input(self.module.params)
         except ValueError as err:
             self.fail(msg='Invalid param: {}'.format(err))
-
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
 
         state = kwargs.get('state')
 

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -23,7 +23,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     handle_updates, filter_null_values
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 SPEC = dict(
     label=dict(
@@ -103,8 +102,6 @@ class Module(LinodeModuleBase):
             actions=[],
             image=None,
         )
-
-        self._timeout_ctx: Optional[TimeoutContext] = None
 
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=[('state', 'label')],
@@ -239,7 +236,6 @@ class Module(LinodeModuleBase):
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for Image module"""
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
 
         state = kwargs.get('state')
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -18,7 +18,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     request_retry, filter_null_values_recursive
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_authors, \
     global_requirements
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs
 
@@ -380,8 +379,6 @@ class LinodeInstance(LinodeModuleBase):
 
         self._instance: Optional[Instance] = None
         self._root_pass: str = ''
-
-        self._timeout_ctx: Optional[TimeoutContext] = None
 
         super().__init__(
             module_arg_spec=self.module_arg_spec,
@@ -847,8 +844,6 @@ class LinodeInstance(LinodeModuleBase):
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for Instance module"""
-
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
 
         state = kwargs.get('state')
 

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -22,7 +22,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import gl
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_cluster as docs
 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import handle_updates
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 linode_lke_cluster_autoscaler = dict(
     enabled=dict(
@@ -197,8 +196,6 @@ class LinodeLKECluster(LinodeModuleBase):
             dashboard_url=None,
             kubeconfig=None
         )
-
-        self._timeout_ctx: Optional[TimeoutContext] = None
 
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
@@ -480,8 +477,6 @@ class LinodeLKECluster(LinodeModuleBase):
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for Domain module"""
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
-
         state = kwargs.get('state')
 
         if state == 'absent':

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -19,7 +19,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     filter_null_values, jsonify_node_pool, handle_updates
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_node_pool as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 linode_lke_pool_autoscaler = dict(
     enabled=dict(
@@ -154,8 +153,6 @@ class LinodeLKENodePool(LinodeModuleBase):
             node_pool=None,
         )
 
-        self._timeout_ctx: Optional[TimeoutContext] = None
-
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
 
@@ -275,7 +272,6 @@ class LinodeLKENodePool(LinodeModuleBase):
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for lke_node_pool module"""
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
 
         state = kwargs.get('state')
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -17,7 +17,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import gl
     global_requirements
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import TimeoutContext
 
 linode_volume_spec = dict(
     label=dict(
@@ -99,7 +98,6 @@ class LinodeVolume(LinodeModuleBase):
         )
 
         self._volume: Optional[Volume] = None
-        self._timeout_ctx: Optional[TimeoutContext] = None
 
         super().__init__(module_arg_spec=self.module_arg_spec,
                          required_one_of=self.required_one_of)
@@ -206,8 +204,6 @@ class LinodeVolume(LinodeModuleBase):
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for volume module"""
-        self._timeout_ctx = TimeoutContext(kwargs.get('wait_timeout'))
-
         state = kwargs.get('state')
 
         if state == 'absent':

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -1,0 +1,27 @@
+- name: instance_timeout
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode instance with an immediate timeout
+      linode.cloud.instance:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu20.04
+        wait: yes
+        wait_timeout: 0
+        booted: yes
+        state: present
+      register: timeout
+      failed_when: "'timeout period expired' not in timeout.msg"
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.instance:
+            api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
+            label: 'ansible-test-{{ r }}'
+            state: absent


### PR DESCRIPTION
## 📝 Description

This change implements a new context-based timeout system for modules that poll for resources statuses. This makes timeout periods significantly more predictable and reliable, and adds a standard way for handling timeouts in the future.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_timeout" test
```