### PR TITLE
issue-257: Remote rules may contain ipv4 or ipv6 addresses that

### DIFF
--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -22,32 +22,88 @@
         that:
           - create.changed
 
-    - name: "Try ... Rescue"
-      block:
-        - name: "Expect fatal: Try to Update Linode Firewall rule that does not exist"
-          linode.cloud.firewall:
-            state: update
-            api_token: '{{ api_token }}'
-            api_version: v4beta
-            label: '{{ create.firewall.label }}'
-            devices: []
-            rules:
-              inbound:
-                - label: NOTTHERE
-                  action: DROP
-                  addresses:
-                    ipv4: ['0.0.0.0/0']
-                    ipv6: ['ff00::/8']
-                  description: 'Really cool firewall rule.'
-                  ports: '80,443'
-                  protocol: TCP
-          register: failedupdaterules
+    - name: Set Linode Firewall with ipv6 addresses
+      linode.cloud.firewall:
+        state: present
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound_policy: DROP
+          inbound:
+            - label: tcpacl
+              action: ACCEPT
+              addresses:
+                ipv6: ['ff00::/8']
+              protocol: TCP
+          outbound_policy: DROP
+          outbound: []
+        status: disabled
+      register: initialfirewall
 
-      rescue:
-        - name: "Caught fatal update. Checking return values."
-          assert:
-            that:
-              - not failedupdaterules.changed
+    - name: Assert firewall created properly
+      assert:
+        that:
+          - initialfirewall.changed
+          - initialfirewall.firewall.rules.inbound | length == 1
+          - initialfirewall.firewall.rules.inbound[0].addresses['ipv6'] is defined
+          - initialfirewall.firewall.rules.inbound[0].addresses['ipv6'] == ['ff00::/8']
+          - initialfirewall.firewall.rules.inbound[0].addresses['ipv4'] is not defined
+
+    - name: Update Linode Firewall with ipv4 addresses (issue 257)
+      linode.cloud.firewall:
+        state: update
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+        devices: []
+        rules:
+          inbound_policy: DROP
+          inbound:
+            - label: tcpacl
+              action: ACCEPT
+              addresses:
+                ipv4: ['0.0.0.0/0']
+              protocol: TCP
+          outbound_policy: DROP
+          outbound: []
+      register: updated_firewall
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+      register: firewall_info
+
+    - name: Assert firewall updated properly with ipv4 addresses and retaining ipv6 addresses
+      assert:
+        that:
+          - updated_firewall.changed
+          - updated_firewall.firewall.rules.inbound | length == 1
+          - (updated_firewall.firewall.rules.inbound[0].addresses['ipv4'] is defined) and (updated_firewall.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0'])
+          - (updated_firewall.firewall.rules.inbound[0].addresses['ipv6'] is defined) and (updated_firewall.firewall.rules.inbound[0].addresses['ipv6'] == ['ff00::/8'])
+          
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Set Linode Firewall disabled
       linode.cloud.firewall:
@@ -62,13 +118,40 @@
           outbound: []
           outbound_policy: DROP
         status: disabled
-      register: updaterules
+      register: updated_firewall
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+      register: firewall_info
 
     - name: Assert firewall updated to disabled
       assert:
         that:
-          - updaterules.changed
-          - updaterules.firewall.status == 'disabled'
+          - updated_firewall.changed
+          - updated_firewall.firewall.status == 'disabled'
+          
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update Linode Firewall to enabled
       linode.cloud.firewall:
@@ -78,13 +161,7 @@
         label: '{{ create.firewall.label }}'
         devices: []
         status: enabled
-      register: updaterules
-
-    - name: Assert firewall updated to enabled
-      assert:
-        that:
-          - updaterules.changed
-          - updaterules.firewall.status == 'enabled'
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -93,13 +170,31 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info same as updatedrules
+    - name: Assert firewall updated to enabled and has the same info as updated_firewall
       assert:
         that:
-          - firewall_info.devices|length == 0
-
+          - updated_firewall.changed
+          - updated_firewall.firewall.status == 'enabled'
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update Linode Firewall inbound/outbound policy to ACCEPT
       linode.cloud.firewall:
@@ -112,14 +207,41 @@
           inbound_policy: ACCEPT
           outbound_policy: ACCEPT
         status: enabled
-      register: update
+      register: updated_firewall
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+        api_token: '{{ api_token }}'
+        api_version: v4beta
+        label: '{{ create.firewall.label }}'
+      register: firewall_info
 
     - name: Assert firewall updated
       assert:
         that:
-          - update.changed
-          - update.firewall.rules.inbound_policy == 'ACCEPT'
-          - update.firewall.rules.outbound_policy == 'ACCEPT'
+          - updated_firewall.changed
+          - updated_firewall.firewall.rules.inbound_policy == 'ACCEPT'
+          - updated_firewall.firewall.rules.outbound_policy == 'ACCEPT'
+          
+          - firewall_info.firewall.id == create.firewall.id
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Set Linode Firewall inbound/outbound rules + policy to DROP
       linode.cloud.firewall:
@@ -150,30 +272,7 @@
               description: 'Really cool firewall rule.'
               ports: '80,443'
               protocol: TCP
-      register: updaterules
-
-    - name: Assert firewall rules set
-      assert:
-        that:
-          - updaterules.changed
-
-          - updaterules.devices|length == 0
-
-          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-          - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
-          - updaterules.firewall.rules.inbound[0].ports == '80,443'
-          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.inbound[0].action == 'DROP'
-          - updaterules.firewall.rules.inbound_policy == 'DROP'
-          - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0']
-
-          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-          - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
-          - updaterules.firewall.rules.outbound[0].ports == '80,443'
-          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.outbound[0].action == 'DROP'
-          - updaterules.firewall.rules.outbound_policy == 'DROP'
-          - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -182,55 +281,47 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info same as updatedrules
+    - name: Assert firewall rules set
       assert:
         that:
-          - firewall_info.devices|length == 0
+          - updated_firewall.changed
+          - updated_firewall.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updated_firewall.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+          - updated_firewall.firewall.rules.inbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.inbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.inbound[0].action == 'DROP'
+          - updated_firewall.firewall.rules.inbound_policy == 'DROP'
+          - updated_firewall.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+          - updated_firewall.firewall.rules.inbound[0].addresses['ipv6'] == ['ff00::/8']
 
+          - updated_firewall.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updated_firewall.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+          - updated_firewall.firewall.rules.outbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.outbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.outbound[0].action == 'DROP'
+          - updated_firewall.firewall.rules.outbound_policy == 'DROP'
+          - updated_firewall.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0']
+          - updated_firewall.firewall.rules.outbound[0].addresses['ipv6'] == ['ff00::/8']
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
-
-
-    - name: "Try ... Rescue (2)"
-      block:
-        - name: "Expect fatal: Try to Update Linode Firewall (2) rule that does not exist"
-          linode.cloud.firewall:
-            state: update
-            api_token: '{{ api_token }}'
-            api_version: v4beta
-            label: '{{ create.firewall.label }}'
-            devices: []
-            rules:
-              inbound:
-              - label: NOTTHERE
-                action: DROP
-                addresses:
-                  ipv4: ['0.0.0.0/0']
-                  ipv6: ['ff00::/8']
-                description: 'Really cool firewall rule.'
-                ports: '80,443'
-                protocol: TCP
-          register: failedupdaterules
-
-      rescue:
-        - name: "Caught fatal update. Checking return values."
-          assert:
-            that:
-              - not failedupdaterules.changed
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update labeled rules to action=ACCEPT
       linode.cloud.firewall:
@@ -246,29 +337,7 @@
           outbound:
             - label: cool-http-out
               action: ACCEPT
-      register: updaterules
-
-
-    - name: Assert firewall rules updated
-      assert:
-        that:
-          - updaterules.changed
-
-          - updaterules.devices|length == 0
-
-          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-          - updaterules.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
-          - updaterules.firewall.rules.inbound[0].ports == '80,443'
-          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.inbound_policy == 'DROP'
-
-          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-          - updaterules.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
-          - updaterules.firewall.rules.outbound[0].ports == '80,443'
-          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.outbound_policy == 'DROP'
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -277,28 +346,45 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info same as updatedrules
+    - name: Assert firewall rules updated
       assert:
         that:
-          - firewall_info.devices|length == 0
+          - updated_firewall.changed
 
+          - updated_firewall.devices|length == 0
+          - updated_firewall.firewall.rules.inbound_policy == 'DROP'
+          - updated_firewall.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updated_firewall.firewall.rules.inbound[0].description == 'Really cool firewall rule.'
+          - updated_firewall.firewall.rules.inbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.inbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.inbound[0].action == 'ACCEPT'
+
+          - updated_firewall.firewall.rules.outbound_policy == 'DROP'
+          - updated_firewall.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updated_firewall.firewall.rules.outbound[0].description == 'Really cool firewall rule.'
+          - updated_firewall.firewall.rules.outbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.outbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.outbound[0].action == 'ACCEPT'
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
-
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update labeled rules description to "Amazing rule."
       linode.cloud.firewall:
@@ -316,28 +402,7 @@
             - label: cool-http-out
               action: ACCEPT
               description: 'Amazing rule.'
-      register: updaterules
-
-    - name: Assert firewall rules updated
-      assert:
-        that:
-          - updaterules.changed
-
-          - updaterules.devices|length == 0
-
-          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-          - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
-          - updaterules.firewall.rules.inbound[0].ports == '80,443'
-          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.inbound_policy == 'DROP'
-
-          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-          - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
-          - updaterules.firewall.rules.outbound[0].ports == '80,443'
-          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.outbound_policy == 'DROP'
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -346,28 +411,46 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info same as updatedrules
+    - name: Assert firewall rules updated
       assert:
         that:
-          - firewall_info.devices|length == 0
+          - updated_firewall.changed
 
+          - updated_firewall.devices|length == 0
+
+          - updated_firewall.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updated_firewall.firewall.rules.inbound[0].description == 'Amazing rule.'
+          - updated_firewall.firewall.rules.inbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.inbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.inbound[0].action == 'ACCEPT'
+          - updated_firewall.firewall.rules.inbound_policy == 'DROP'
+
+          - updated_firewall.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updated_firewall.firewall.rules.outbound[0].description == 'Amazing rule.'
+          - updated_firewall.firewall.rules.outbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.outbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.outbound[0].action == 'ACCEPT'
+          - updated_firewall.firewall.rules.outbound_policy == 'DROP'
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update labeled rules ipv4 addresses
       linode.cloud.firewall:
@@ -387,30 +470,7 @@
               action: ACCEPT
               addresses:
                 ipv4: ['0.0.0.0/0','8.8.8.8/32' ]
-      register: updaterules
-
-    - name: Assert firewall rules updated
-      assert:
-        that:
-          - updaterules.changed
-
-          - updaterules.devices|length == 0
-
-          - updaterules.firewall.rules.inbound[0].label == 'cool-http-in'
-          - updaterules.firewall.rules.inbound[0].description == 'Amazing rule.'
-          - updaterules.firewall.rules.inbound[0].ports == '80,443'
-          - updaterules.firewall.rules.inbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.inbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
-          - updaterules.firewall.rules.inbound_policy == 'DROP'
-
-          - updaterules.firewall.rules.outbound[0].label == 'cool-http-out'
-          - updaterules.firewall.rules.outbound[0].description == 'Amazing rule.'
-          - updaterules.firewall.rules.outbound[0].ports == '80,443'
-          - updaterules.firewall.rules.outbound[0].protocol == 'TCP'
-          - updaterules.firewall.rules.outbound[0].action == 'ACCEPT'
-          - updaterules.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
-          - updaterules.firewall.rules.outbound_policy == 'DROP'
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -419,30 +479,50 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info same as updatedrules
+    - name: Assert firewall rules updated
       assert:
         that:
-          - firewall_info.devices|length == 0
+          - updated_firewall.changed
 
+          - updated_firewall.devices|length == 0
+          - updated_firewall.firewall.rules.inbound[0].label == 'cool-http-in'
+          - updated_firewall.firewall.rules.inbound[0].description == 'Amazing rule.'
+          - updated_firewall.firewall.rules.inbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.inbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.inbound[0].action == 'ACCEPT'
+          - updated_firewall.firewall.rules.inbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+          - updated_firewall.firewall.rules.inbound_policy == 'DROP'
+          - updated_firewall.firewall.rules.outbound[0].label == 'cool-http-out'
+          - updated_firewall.firewall.rules.outbound[0].description == 'Amazing rule.'
+          - updated_firewall.firewall.rules.outbound[0].ports == '80,443'
+          - updated_firewall.firewall.rules.outbound[0].protocol == 'TCP'
+          - updated_firewall.firewall.rules.outbound[0].action == 'ACCEPT'
+          - updated_firewall.firewall.rules.outbound[0].addresses['ipv4'] == ['0.0.0.0/0','8.8.8.8/32' ]
+          - updated_firewall.firewall.rules.outbound_policy == 'DROP'
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update Description of Linode Firewall rules
       linode.cloud.firewall:
+        state: update
         api_token: '{{ api_token }}'
         api_version: v4beta
         label: '{{ create.firewall.label }}'
@@ -456,8 +536,7 @@
             - label: cool-http-out
               action: ACCEPT
               description: 'Amazing firewall rule.'
-        state: update
-      register: updaterules
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -469,24 +548,29 @@
     - name: Assert firewall info
       assert:
         that:
-          - firewall_info.devices|length == 0
-
+          - updated_firewall.changed
+          - updated_firewall.firewall.rules.inbound[0].description == 'Amazing firewall rule.'
+          - updated_firewall.firewall.rules.outbound[0].description == 'Amazing firewall rule.'
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Update IP addresses Linode Firewall rules
       linode.cloud.firewall:
@@ -506,7 +590,7 @@
               addresses:
                 ipv4: ['0.0.0.0/0']
         state: update
-      register: updaterules
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -519,23 +603,26 @@
       assert:
         that:
           - firewall_info.devices|length == 0
-
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
 
     - name: Make update that should not cause any Linode Firewall changes
       linode.cloud.firewall:
@@ -555,12 +642,7 @@
               addresses:
                 ipv4: ['0.0.0.0/0']
         state: update
-      register: updaterules
-
-    - name: Assert firewall rules did not update
-      assert:
-        that:
-          - not updaterules.changed
+      register: updated_firewall
 
     - name: Get info about the firewall
       linode.cloud.firewall_info:
@@ -569,28 +651,30 @@
         label: '{{ create.firewall.label }}'
       register: firewall_info
 
-    - name: Assert firewall info
+    - name: Assert firewall rules did not update
       assert:
         that:
-          - firewall_info.devices|length == 0
-
+          - not updated_firewall.changed
+          
           - firewall_info.firewall.id == create.firewall.id
-          - firewall_info.firewall.status == updaterules.firewall.status
-
-          - firewall_info.firewall.rules.inbound[0].label == updaterules.firewall.rules.inbound[0].label
-          - firewall_info.firewall.rules.inbound[0].description == updaterules.firewall.rules.inbound[0].description
-          - firewall_info.firewall.rules.inbound[0].ports == updaterules.firewall.rules.inbound[0].ports
-          - firewall_info.firewall.rules.inbound[0].protocol == updaterules.firewall.rules.inbound[0].protocol
-          - firewall_info.firewall.rules.inbound[0].action == updaterules.firewall.rules.inbound[0].action
-          - firewall_info.firewall.rules.inbound_policy == updaterules.firewall.rules.inbound_policy
-
-          - firewall_info.firewall.rules.outbound[0].label == updaterules.firewall.rules.outbound[0].label
-          - firewall_info.firewall.rules.outbound[0].description == updaterules.firewall.rules.outbound[0].description
-          - firewall_info.firewall.rules.outbound[0].ports == updaterules.firewall.rules.outbound[0].ports
-          - firewall_info.firewall.rules.outbound[0].protocol == updaterules.firewall.rules.outbound[0].protocol
-          - firewall_info.firewall.rules.outbound[0].action == updaterules.firewall.rules.outbound[0].action
-          - firewall_info.firewall.rules.outbound_policy == updaterules.firewall.rules.outbound_policy
-
+          - firewall_info.devices|length == updated_firewall.devices|length
+          - firewall_info.firewall.status == updated_firewall.firewall.status
+          - firewall_info.firewall.rules.inbound_policy == updated_firewall.firewall.rules.inbound_policy
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.inbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.inbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.inbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].label is not defined and updated_firewall.firewall.rules.inbound[0].label is not defined) or (firewall_info.firewall.rules.inbound[0].label == updated_firewall.firewall.rules.inbound[0].label))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].description is not defined and updated_firewall.firewall.rules.inbound[0].description is not defined) or (firewall_info.firewall.rules.inbound[0].description == updated_firewall.firewall.rules.inbound[0].description))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].ports is not defined and updated_firewall.firewall.rules.inbound[0].ports is not defined) or (firewall_info.firewall.rules.inbound[0].ports == updated_firewall.firewall.rules.inbound[0].ports))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].protocol is not defined and updated_firewall.firewall.rules.inbound[0].protocol is not defined) or (firewall_info.firewall.rules.inbound[0].protocol == updated_firewall.firewall.rules.inbound[0].protocol))
+          - (firewall_info.firewall.rules.inbound | length == 0 and updated_firewall.firewall.rules.inbound | length == 0) or ((firewall_info.firewall.rules.inbound[0].action is not defined and updated_firewall.firewall.rules.inbound[0].action is not defined) or (firewall_info.firewall.rules.inbound[0].action == updated_firewall.firewall.rules.inbound[0].action))
+          - firewall_info.firewall.rules.outbound_policy == updated_firewall.firewall.rules.outbound_policy
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv4'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv4'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv4']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined and firewall_info.firewall.rules.outbound[0].addresses['ipv6'] is not defined) or (firewall_info.firewall.rules.outbound[0].addresses['ipv6'] == updated_firewall.firewall.rules.outbound[0].addresses['ipv6']))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].label is not defined and updated_firewall.firewall.rules.outbound[0].label is not defined) or (firewall_info.firewall.rules.outbound[0].label == updated_firewall.firewall.rules.outbound[0].label))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].description is not defined and updated_firewall.firewall.rules.outbound[0].description is not defined) or (firewall_info.firewall.rules.outbound[0].description == updated_firewall.firewall.rules.outbound[0].description))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].ports is not defined and updated_firewall.firewall.rules.outbound[0].ports is not defined) or (firewall_info.firewall.rules.outbound[0].ports == updated_firewall.firewall.rules.outbound[0].ports))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].protocol is not defined and updated_firewall.firewall.rules.outbound[0].protocol is not defined) or (firewall_info.firewall.rules.outbound[0].protocol == updated_firewall.firewall.rules.outbound[0].protocol))
+          - (firewall_info.firewall.rules.outbound | length == 0 and updated_firewall.firewall.rules.outbound | length == 0) or ((firewall_info.firewall.rules.outbound[0].action is not defined and updated_firewall.firewall.rules.outbound[0].action is not defined) or (firewall_info.firewall.rules.outbound[0].action == updated_firewall.firewall.rules.outbound[0].action))
   always:
     - ignore_errors: yes
       block:


### PR DESCRIPTION
are not being updated. This change focuses on increased fidelity to only update what's being updated. Added more unit tests and assertion to validate this assumption.

## 📝 Description

Firewall updates are intended to only make changes to specific firewall fields. A bug was found where if the firewall had an ipv6 address in one of its rules and the firewall update was just for ipv4, then all ipv6 addresses would be dropped/deleted.  Ditto vice versa when updating just ipv6 and not ipv4.

## ✔️ How to Test

The updated firewall_update/tasks/main.yml unit test validates correctness.