### PR TITLE
fix: Use shell environment variable for Makefile config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ testall:
 	./scripts/test_all.sh
 
 create-integration-config:
-ifneq ("$(LINODE_TOKEN)", "")
-	@echo "api_token: $(LINODE_API_TOKEN)" > $(INTEGRATION_CONFIG);
-else ifneq ("$(LINODE_API_TOKEN)", "")
-	@echo "api_token: $(LINODE_TOKEN)" > $(INTEGRATION_CONFIG);
+ifneq ("${LINODE_TOKEN}", "")
+	@echo "api_token: ${LINODE_API_TOKEN}" > $(INTEGRATION_CONFIG);
+else ifneq ("${LINODE_API_TOKEN}", "")
+	@echo "api_token: ${LINODE_TOKEN}" > $(INTEGRATION_CONFIG);
 else
 	echo "LINODE_API_TOKEN must be set"; \
 	exit 1;


### PR DESCRIPTION
## 📝 Description

This change alters the `create-integration-config` target to resolve the Linode Token from the shell environment rather than as a Makefile var.

## ✔️ How to Test

`make test`
