### PR TITLE
fix: Depend on `create-integration-config` target in `make testall`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ integration-test: create-integration-config
 
 test: integration-test
 
-testall:
+testall: create-integration-config
 	./scripts/test_all.sh
 
 create-integration-config:


### PR DESCRIPTION
## 📝 Description

This change makes the `make testall` target depend on the `create-integration-config` target. This resolves the issue is currently causing GHA E2E tests to fail.

## ✔️ How to Test

`make testall`