### PR TITLE
fix: Bypass OAuth errors in `lke_cluster_info` module

### DIFF
--- a/docs/modules/token.md
+++ b/docs/modules/token.md
@@ -2,6 +2,8 @@
 
 Manage a Linode Token.
 
+NOTE: The full Personal Access Token is only returned when a new token has been created.
+
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -277,7 +277,7 @@ def get_all_paginated(client: LinodeClient, endpoint: str, filters: Dict[str, An
 def format_api_error(err: ApiError) -> str:
     """Formats an API error into a readable string"""
 
-    return f"Error from Linode API: {';'.join(err.errors)}"
+    return f"Error from Linode API: [{err.status}] {';'.join(err.errors)}"
 
 
 def poll_condition(condition_func: Callable[[], bool], step: int, timeout: int) -> None:

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -137,10 +137,15 @@ class LinodeLKEClusterInfo(LinodeModuleBase):
         try:
             self.results['kubeconfig'] = cluster.kubeconfig
         except ApiError as err:
-            if err.status != 503:
+            ignored_error_messages = {
+                503: 'Kubeconfig not yet available...',
+                401: 'Current token is not authorized to view this endpoint.'
+            }
+
+            if err.status not in ignored_error_messages:
                 raise err
 
-            self.results['kubeconfig'] = 'Kubeconfig not yet available...'
+            self.results['kubeconfig'] = ignored_error_messages[err.status]
 
         try:
             self.results['dashboard_url'] = \

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -43,7 +43,9 @@ SPEC = dict(
 
 specdoc_meta = dict(
     description=[
-        'Manage a Linode Token.'
+        'Manage a Linode Token.',
+        'NOTE: The full Personal Access Token is only returned '
+        'when a new token has been created.'
     ],
     requirements=global_requirements,
     author=global_authors,
@@ -106,16 +108,25 @@ class Module(LinodeModuleBase):
         label = params.get('label')
 
         token = self._get_token_by_label(label)
+        full_pat: Optional[str] = None
 
         # Create the token if it does not already exist
         if token is None:
             token = self._create_token()
+            full_pat = token.token
             self.register_action('Created token {0}'.format(label))
 
         self._update_token(token)
 
         # Force lazy-loading
         token._api_get()
+
+        result_token = token._raw_json
+
+        # If the full PAT (only returned once) is present,
+        # inject it back into the result
+        if full_pat is not None:
+            result_token['token'] = full_pat
 
         self.results['token'] = token._raw_json
 

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -1,0 +1,75 @@
+- name: lke_cluster_info_ro
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Resolve the latest K8s version
+      linode.cloud.api_request:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        method: GET
+        path: lke/versions
+      register: lke_versions
+
+    - name: Create a read-only testing token
+      linode.cloud.token:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        scopes: 'lke:read_only'
+        state: present
+      register: ro_token
+
+    - set_fact:
+        kube_version: '{{ lke_versions.body.data[0].id }}'
+
+    - name: Create a Linode LKE cluster
+      linode.cloud.lke_cluster:
+        api_token: '{{ api_token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: 'ansible-test-{{ r }}'
+        region: us-southeast
+        k8s_version: '{{ kube_version }}'
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        skip_polling: true
+        state: present
+      register: create_cluster
+
+    - assert:
+        that:
+          - create_cluster.cluster.k8s_version == kube_version
+          - create_cluster.cluster.region == 'us-southeast'
+          - create_cluster.node_pools[0].type == 'g6-standard-1'
+          - create_cluster.node_pools[0].count == 1
+
+    - name: Attempt to view the cluster with a read-only token
+      linode.cloud.lke_cluster_info:
+        api_token: '{{ ro_token.token.token }}'
+        ua_prefix: '{{ ua_prefix }}'
+        label: '{{ create_cluster.cluster.label }}'
+      register: cluster_info
+
+    - assert:
+        that:
+          - cluster_info.cluster.k8s_version == kube_version
+          - cluster_info.cluster.region == 'us-southeast'
+          - cluster_info.node_pools[0].type == 'g6-standard-1'
+          - cluster_info.node_pools[0].count == 1
+          - '"not authorized" in cluster_info.kubeconfig'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.lke_cluster:
+            api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
+            label: '{{ create_cluster.cluster.label }}'
+            state: absent
+
+        - linode.cloud.token:
+            api_token: '{{ api_token }}'
+            ua_prefix: '{{ ua_prefix }}'
+            label: 'ansible-test-{{ r }}'
+            state: absent

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -18,6 +18,9 @@
         that:
           - create_token.token.id != None
 
+          # We want to make sure we're getting full-length API tokens
+          - create_token.token.token|length > 16
+
     - name: Update the Linode Token
       linode.cloud.token:
         api_token: '{{ api_token }}'


### PR DESCRIPTION
## 📝 Description

This change adds logic to the `lke_cluster_info` module to ignore OAuth errors when attempting to obtain a cluster's KubeConfig. This is necessary as `lke:read_only` users cannot read a cluster's KubeConfig but should be able to get other info about the cluster.

Additionally, this change alters the `token` module to return the full PAT after a token is created. This is necessary as the API returns a shortened token on subsequent GET requests.

Resolves #261 

## ✔️ How to Test

```
make TEST_ARGS="-v lke_cluster_info_ro" test
```

```
make TEST_ARGS="-v token_basic" test
```