### PR TITLE
fix: Remove `make install` from documentation validation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,6 @@ jobs:
       - name: install dependencies
         run: pip install -r requirements-dev.txt -r requirements.txt
 
-      - name: install collection
-        run: make install
-
       - name: make temp directory
         run: mkdir tmp
 


### PR DESCRIPTION
## 📝 Description

This change removes a redundant `make install` from the documentation validation workflow. This change is necessary because `make install` is not necessary in this context and has a side-effect of regenerating the documentation, which overrides the user-committed documentation.
