### PR TITLE
fix: Remove code quality badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Linode Ansible Collection
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-linode.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/linode/cloud/) 
 ![Tests](https://img.shields.io/github/actions/workflow/status/linode/ansible_linode/integration-tests.yml?branch=main)
-![Code Quality](https://img.shields.io/lgtm/grade/python/github/linode/ansible_linode?label=code%20quality)
 
 The Ansible Linode Collection contains various plugins for managing Linode services.
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -1,7 +1,6 @@
 # Linode Ansible Collection
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-linode.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/linode/cloud/) 
 ![Tests](https://img.shields.io/github/actions/workflow/status/linode/ansible_linode/integration-tests.yml?branch=main)
-![Code Quality](https://img.shields.io/lgtm/grade/python/github/linode/ansible_linode?label=code%20quality)
 
 The Ansible Linode Collection contains various plugins for managing Linode services.
 


### PR DESCRIPTION
## 📝 Description

This change removes the `Code Quality` badge from README.md as this feature is no longer available.
