### PR TITLE
fix: Use v4beta for VLAN test

### DIFF
--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -19,6 +19,7 @@
 
     - name: Resolve a VLAN
       linode.cloud.vlan_list:
+        api_version: v4beta
         count: 1
         order_by: created
         order: desc


### PR DESCRIPTION
## 📝 Description

This pull request makes the `vlan_list` test use the `v4beta` API version. This should resolve 404 errors when running the test suite.

## ✔️ How to Test

`make TEST_ARGS="-v vlan_list" test`
