### PR TITLE
new: Add graceful error handling for known error types

### DIFF
--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -23,7 +23,8 @@ from ansible.module_utils.basic import (AnsibleModule, env_fallback,
 try:
     from linode_api4 import (ApiError, Base as LinodeAPIType, Image, LinodeClient,
                              MySQLDatabase, PersonalAccessToken,
-                             PostgreSQLDatabase, SSHKey, StackScript, IPAddress, UnexpectedResponseError)
+                             PostgreSQLDatabase, SSHKey, StackScript,
+                             IPAddress, UnexpectedResponseError)
 
     HAS_LINODE = True
 except ImportError:

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -7,7 +7,7 @@ from typing import Any, Type
 
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import \
-    format_api_error
+    format_api_error, format_generic_error
 from ansible_collections.linode.cloud.plugins.module_utils.linode_timeout import \
     TimeoutContext
 
@@ -23,7 +23,7 @@ from ansible.module_utils.basic import (AnsibleModule, env_fallback,
 try:
     from linode_api4 import (ApiError, Base as LinodeAPIType, Image, LinodeClient,
                              MySQLDatabase, PersonalAccessToken,
-                             PostgreSQLDatabase, SSHKey, StackScript, IPAddress)
+                             PostgreSQLDatabase, SSHKey, StackScript, IPAddress, UnexpectedResponseError)
 
     HAS_LINODE = True
 except ImportError:
@@ -132,6 +132,11 @@ class LinodeModuleBase:
                 self.fail(msg=format_api_error(err))
             except polling.TimeoutException as err:
                 self.fail(msg='failed to wait for condition: timeout period expired')
+            except (
+                    ValueError, RuntimeError, UnexpectedResponseError,
+                    TypeError, IndexError
+            ) as err:
+                self.fail(msg=format_generic_error(err))
 
             self.module.exit_json(**res)
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -280,6 +280,12 @@ def format_api_error(err: ApiError) -> str:
     return f"Error from Linode API: [{err.status}] {';'.join(err.errors)}"
 
 
+def format_generic_error(err: Exception) -> str:
+    """Formats a generic error into a readable string"""
+
+    return f"{type(err).__name__}: {str(err)}"
+
+
 def poll_condition(condition_func: Callable[[], bool], step: int, timeout: int) -> None:
     """Polls for the given condition using the given step and timeout values."""
     # Initial attempt


### PR DESCRIPTION
## 📝 Description

This change adds graceful error handling for common/known error types to be encountered when running modules. For more detailed info about an error (including a trace), users can use verbosity arguments (e.g. `-vvv`).
