### PR TITLE
Upgrade db versions to supported versions

### DIFF
--- a/docs/modules/database_engine_list.md
+++ b/docs/modules/database_engine_list.md
@@ -47,8 +47,8 @@ List and filter on Managed Database engine types.
         [
            {
               "engine": "mysql",
-              "id": "mysql/8.0.26",
-              "version": "8.0.26"
+              "id": "mysql/8.0.30",
+              "version": "8.0.30"
             }
         ]
         ```

--- a/docs/modules/database_mysql.md
+++ b/docs/modules/database_mysql.md
@@ -13,7 +13,7 @@ Manage a Linode MySQL database.
   linode.cloud.database_mysql:
     label: my-db
     region: us-east
-    engine: mysql/8.0.26
+    engine: mysql/8.0.30
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -25,7 +25,7 @@ Manage a Linode MySQL database.
   linode.cloud.database_mysql:
     label: my-db
     region: us-east
-    engine: mysql/8.0.26
+    engine: mysql/8.0.30
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -107,7 +107,7 @@ Manage a Linode MySQL database.
             "hour_of_day": 0,
             "week_of_month": null
           },
-          "version": "8.0.26"
+          "version": "8.0.30"
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-view__response-samples) for a list of returned fields

--- a/docs/modules/database_mysql_info.md
+++ b/docs/modules/database_mysql_info.md
@@ -63,7 +63,7 @@ Get info about a Linode MySQL Managed Database.
             "hour_of_day": 0,
             "week_of_month": null
           },
-          "version": "8.0.26"
+          "version": "8.0.30"
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-view__response-samples) for a list of returned fields

--- a/docs/modules/database_postgresql.md
+++ b/docs/modules/database_postgresql.md
@@ -13,7 +13,7 @@ Manage a Linode PostgreSQL database.
   linode.cloud.database_postgresql:
     label: my-db
     region: us-east
-    engine: postgresql/13.2
+    engine: postgresql/14.6
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -25,7 +25,7 @@ Manage a Linode PostgreSQL database.
   linode.cloud.database_postgresql:
     label: my-db
     region: us-east
-    engine: postgresql/13.2
+    engine: postgresql/14.6
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -110,7 +110,7 @@ Manage a Linode PostgreSQL database.
             "hour_of_day": 0,
             "week_of_month": null
           },
-          "version": "13.2"
+          "version": "14.6"
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-view__response-samples) for a list of returned fields

--- a/docs/modules/database_postgresql_info.md
+++ b/docs/modules/database_postgresql_info.md
@@ -64,7 +64,7 @@ Get info about a Linode PostgreSQL Managed Database.
             "hour_of_day": 0,
             "week_of_month": null
           },
-          "version": "13.2"
+          "version": "14.6"
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-view__response-samples) for a list of returned fields

--- a/plugins/module_utils/doc_fragments/database_engine_list.py
+++ b/plugins/module_utils/doc_fragments/database_engine_list.py
@@ -12,7 +12,7 @@ specdoc_examples = ['''
 result_engines_samples = ['''[
    {
       "engine": "mysql",
-      "id": "mysql/8.0.26",
-      "version": "8.0.26"
+      "id": "mysql/8.0.30",
+      "version": "8.0.30"
     }
 ]''']

--- a/plugins/module_utils/doc_fragments/database_mysql.py
+++ b/plugins/module_utils/doc_fragments/database_mysql.py
@@ -5,7 +5,7 @@ specdoc_examples = ['''
   linode.cloud.database_mysql:
     label: my-db
     region: us-east
-    engine: mysql/8.0.26
+    engine: mysql/8.0.30
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -14,7 +14,7 @@ specdoc_examples = ['''
   linode.cloud.database_mysql:
     label: my-db
     region: us-east
-    engine: mysql/8.0.26
+    engine: mysql/8.0.30
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -57,7 +57,7 @@ result_database_samples = ['''{
     "hour_of_day": 0,
     "week_of_month": null
   },
-  "version": "8.0.26"
+  "version": "8.0.30"
 }''']
 
 result_credentials_samples = ['''{

--- a/plugins/module_utils/doc_fragments/database_postgresql.py
+++ b/plugins/module_utils/doc_fragments/database_postgresql.py
@@ -5,7 +5,7 @@ specdoc_examples = ['''
   linode.cloud.database_postgresql:
     label: my-db
     region: us-east
-    engine: postgresql/13.2
+    engine: postgresql/14.6
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -14,7 +14,7 @@ specdoc_examples = ['''
   linode.cloud.database_postgresql:
     label: my-db
     region: us-east
-    engine: postgresql/13.2
+    engine: postgresql/14.6
     type: g6-standard-1
     allow_list:
       - 0.0.0.0/0
@@ -59,7 +59,7 @@ result_database_samples = ['''{
     "hour_of_day": 0,
     "week_of_month": null
   },
-  "version": "13.2"
+  "version": "14.6"
 }''']
 
 result_credentials_samples = ['''{

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -149,6 +149,7 @@ class LinodeVolume(LinodeModuleBase):
                 label, region, linode_id, size, **params
             )
         except Exception as exception:
+            print(label, region, linode_id, size, params)
             return self.fail(
                 msg="failed to create volume: {0}".format(exception)
             )

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -149,7 +149,6 @@ class LinodeVolume(LinodeModuleBase):
                 label, region, linode_id, size, **params
             )
         except Exception as exception:
-            print(label, region, linode_id, size, params)
             return self.fail(
                 msg="failed to create volume: {0}".format(exception)
             )

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -7,7 +7,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.26
+        engine: mysql/8.0.30
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -19,7 +19,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
-          - db_create.database.version == '8.0.26'
+          - db_create.database.version == '8.0.30'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -38,7 +38,7 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'mysql'
-          - by_label.database.version == '8.0.26'
+          - by_label.database.version == '8.0.30'
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_label.ssl_cert != None
@@ -47,7 +47,7 @@
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'mysql'
-          - by_id.database.version == '8.0.26'
+          - by_id.database.version == '8.0.30'
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
           - by_id.ssl_cert != None
@@ -59,7 +59,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.26
+        engine: mysql/8.0.30
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -101,7 +101,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.26
+        engine: mysql/8.0.30
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -7,7 +7,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.26
+        engine: mysql/8.0.30
         type: g6-standard-1
         allow_list:
           - 0.0.0.0
@@ -19,7 +19,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.26
+        engine: mysql/8.0.30
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -41,7 +41,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
-          - db_create.database.version == '8.0.26'
+          - db_create.database.version == '8.0.30'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -7,7 +7,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/13.2
+        engine: postgresql/14.6
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -19,7 +19,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == '13.2'
+          - db_create.database.version == '14.6'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -38,13 +38,13 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'postgresql'
-          - by_label.database.version == '13.2'
+          - by_label.database.version == '14.6'
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'postgresql'
-          - by_id.database.version == '13.2'
+          - by_id.database.version == '14.6'
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
 
@@ -52,7 +52,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/13.2
+        engine: postgresql/14.6
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -68,7 +68,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/13.2
+        engine: postgresql/14.6
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -7,7 +7,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/13.2
+        engine: postgresql/14.6
         type: g6-standard-1
         allow_list:
           - 0.0.0.0
@@ -19,7 +19,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/13.2
+        engine: postgresql/14.6
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -42,7 +42,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == '13.2'
+          - db_create.database.version == '14.6'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -99,7 +99,7 @@
           - not detach_volume.volume.linode_id|d(False)
 
   always:
-    - ignore_errors: yes
+    - ignore_errors: true
       block:
         - name: Delete the instance volume
           linode.cloud.volume:


### PR DESCRIPTION
## 📝 Description

DBaaS team removed some old database versions from the list after the maintenance, so we would need to upgrade the version number in our test, otherwise the test would fail.

## ✔️ How to Test

`make test`