### PR TITLE
new: Use `lke_version_list` module in LKE-related tests

### DIFF
--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -10,7 +10,7 @@ List Kubernetes versions available for deployment to a Kubernetes cluster.
 
 ```yaml
 - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_versions: {}
+  linode.cloud.lke_version_list: {}
 ```
 
 
@@ -23,7 +23,7 @@ List Kubernetes versions available for deployment to a Kubernetes cluster.
 
 ## Return Values
 
-- `lke_versions` - The returned lke versions.
+- `lke_versions` - The returned LKE versions.
 
     - Sample Response:
         ```json

--- a/plugins/module_utils/doc_fragments/lke_version_list.py
+++ b/plugins/module_utils/doc_fragments/lke_version_list.py
@@ -2,7 +2,7 @@
 
 specdoc_examples = ['''
 - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_versions: {}''']
+  linode.cloud.lke_version_list: {}''']
 
 result_lke_versions_samples = ['''[
     {

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -53,7 +53,7 @@ SPECDOC_META = SpecDocMeta(
     examples=docs.specdoc_examples,
     return_values=dict(
         lke_versions=SpecReturnValue(
-            description="The returned lke versions.",
+            description="The returned LKE versions.",
             docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
             "#kubernetes-versions-list__response-samples",
             type=FieldType.list,
@@ -69,7 +69,7 @@ class Module(LinodeModuleBase):
 
     def __init__(self) -> None:
         self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"lke_versionss": []}
+        self.results: Dict[str, Any] = {"lke_versions": []}
 
         super().__init__(module_arg_spec=self.module_arg_spec)
 

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -4,13 +4,11 @@
         r: "{{ 1000000000 | random }}"
 
     - name: Resolve the latest K8s version
-      linode.cloud.api_request:
-        method: GET
-        path: lke/versions
+      linode.cloud.lke_version_list: {}
       register: lke_versions
 
     - set_fact:
-        kube_version: '{{ lke_versions.body.data[0].id }}'
+        kube_version: '{{ lke_versions.lke_versions[0].id }}'
 
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -4,10 +4,11 @@
         r: "{{ 1000000000 | random }}"
 
     - name: Resolve the latest K8s version
-      linode.cloud.api_request:
-        method: GET
-        path: lke/versions
+      linode.cloud.lke_version_list: {}
       register: lke_versions
+
+    - set_fact:
+        kube_version: '{{ lke_versions.lke_versions[0].id }}'
 
     - name: Create a read-only testing token
       linode.cloud.token:
@@ -15,9 +16,6 @@
         scopes: 'lke:read_only'
         state: present
       register: ro_token
-
-    - set_fact:
-        kube_version: '{{ lke_versions.body.data[0].id }}'
 
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -4,13 +4,11 @@
         r: "{{ 1000000000 | random }}"
 
     - name: Resolve the latest K8s version
-      linode.cloud.api_request:
-        method: GET
-        path: lke/versions
+      linode.cloud.lke_version_list: {}
       register: lke_versions
 
     - set_fact:
-        kube_version: '{{ lke_versions.body.data[0].id }}'
+        kube_version: '{{ lke_versions.lke_versions[0].id }}'
 
     - name: Create a minimal LKE cluster
       linode.cloud.lke_cluster:


### PR DESCRIPTION
## 📝 Description

This pull request switches direct API calls to the `lke_version_list` module when resolving an available Kubernetes version for testing.

## ✔️ How to Test

```
make TEST_ARGS="-v lke_cluster_basic" test
make TEST_ARGS="-v lke_cluster_info_ro" test
make TEST_ARGS="-v lke_node_pool_basic" test
```
