### PR TITLE
Dynamically resolve available db engine versions

### DIFF
--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -34,7 +34,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
-          - db_create.database.version == version
+          - db_create.database.version == '{{ version }}'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -53,7 +53,7 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'mysql'
-          - by_label.database.version == version
+          - by_label.database.version == '{{ version }}'
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_label.ssl_cert != None
@@ -62,7 +62,7 @@
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'mysql'
-          - by_id.database.version == version
+          - by_id.database.version == '{{ version }}'
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
           - by_id.ssl_cert != None

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -3,11 +3,26 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Get available mysql engines list
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: mysql
+      register: available_engines
+
+    - assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ available_engines.database_engines[0]['id'] }}"
+        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
+
     - name: Create a database
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.30
+        engine: '{{engine_id}}'
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -19,7 +34,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
-          - db_create.database.version == '8.0.30'
+          - db_create.database.version == version
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -38,7 +53,7 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'mysql'
-          - by_label.database.version == '8.0.30'
+          - by_label.database.version == version
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_label.ssl_cert != None
@@ -47,7 +62,7 @@
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'mysql'
-          - by_id.database.version == '8.0.30'
+          - by_id.database.version == version
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
           - by_id.ssl_cert != None
@@ -59,7 +74,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.30
+        engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -101,7 +116,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.30
+        engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -111,7 +126,7 @@
       failed_when: '"non-updatable" not in db_update_invalid.msg'
 
   always:
-    - ignore_errors: yes
+    - ignore_errors: true
       block:
         - linode.cloud.database_mysql:
             label: '{{ db_create.database.label }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -2,12 +2,27 @@
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
+  
+    - name: Get available mysql engines list
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: mysql
+      register: available_engines
+
+    - assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ available_engines.database_engines[0]['id'] }}"
+        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
 
     - name: Validation check
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.30
+        engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
           - 0.0.0.0
@@ -19,7 +34,7 @@
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: mysql/8.0.30
+        engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -41,7 +56,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
-          - db_create.database.version == '8.0.30'
+          - db_create.database.version == '{{ engine_version }}'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3
@@ -58,7 +73,7 @@
           - db_create.database.updates.week_of_month == 2
 
   always:
-    - ignore_errors: yes
+    - ignore_errors: true
       block:
         - linode.cloud.database_mysql:
             label: '{{ db_create.database.label }}'

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -3,11 +3,26 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Get available postgresql engines list
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: postgresql
+      register: available_engines
+
+    - assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ available_engines.database_engines[0]['id'] }}"
+        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
+
     - name: Create a database
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/14.6
+        engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -19,7 +34,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == '14.6'
+          - db_create.database.version == ''{{ engine_version }}''
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -38,13 +53,13 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'postgresql'
-          - by_label.database.version == '14.6'
+          - by_label.database.version == ''{{ engine_version }}''
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'postgresql'
-          - by_id.database.version == '14.6'
+          - by_id.database.version == ''{{ engine_version }}''
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
 
@@ -52,7 +67,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/14.6
+        engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -68,7 +83,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/14.6
+        engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
           - 10.0.0.1/32
@@ -78,7 +93,7 @@
       failed_when: '"non-updatable" not in db_update_invalid.msg'
 
   always:
-    - ignore_errors: yes
+    - ignore_errors: true
       block:
         - linode.cloud.database_postgresql:
             label: '{{ db_create.database.label }}'

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -34,7 +34,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == ''{{ engine_version }}''
+          - db_create.database.version == '{{ engine_version }}'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
 
@@ -53,13 +53,13 @@
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'postgresql'
-          - by_label.database.version == ''{{ engine_version }}''
+          - by_label.database.version == '{{ engine_version }}'
           - by_label.database.region == 'us-east'
           - by_label.database.type == 'g6-standard-1'
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'postgresql'
-          - by_id.database.version == ''{{ engine_version }}''
+          - by_id.database.version == '{{ engine_version }}'
           - by_id.database.region == 'us-east'
           - by_id.database.type == 'g6-standard-1'
 

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -57,7 +57,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == ''{{ engine_version }}''
+          - db_create.database.version == '{{ engine_version }}'
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -3,11 +3,26 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Get available postgresql engines list
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: postgresql
+      register: available_engines
+
+    - assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ available_engines.database_engines[0]['id'] }}"
+        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
+
     - name: Validation check
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/14.6
+        engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
           - 0.0.0.0
@@ -19,7 +34,7 @@
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
         region: us-east
-        engine: postgresql/14.6
+        engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
           - 0.0.0.0/0
@@ -42,7 +57,7 @@
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
-          - db_create.database.version == '14.6'
+          - db_create.database.version == ''{{ engine_version }}''
           - db_create.database.region == 'us-east'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3
@@ -60,7 +75,7 @@
           - db_create.database.updates.week_of_month == 2
 
   always:
-    - ignore_errors: yes
+    - ignore_errors: true
       block:
         - linode.cloud.database_postgresql:
             label: '{{ db_create.database.label }}'


### PR DESCRIPTION
## 📝 Description

DBaaS upgrade led to failure tests in this repo last time because the db engine versions we used were no longer supported. A version update PR solved that but ideally, we would want to dynamically get the available engine versions and apply them to the tests to prevent this issue permanently.

## ✔️ How to Test

`make TEST_ARGS="-v mysql_basic" test`
`make TEST_ARGS="-v mysql_complex" test`

`make TEST_ARGS="-v postgresql_basic" test`
`make TEST_ARGS="-v postgresql_complex" test`
