### PR TITLE
Added support for additional IP allocations in `linode_instance` module

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -237,7 +237,7 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `public` | <center>`bool`</center> | <center>**Required**</center> | Additional IPv4 addresses allocated to a Linode.   |
+| `public` | <center>`bool`</center> | <center>**Required**</center> | Whether the allocated IPv4 address should be public or private.   |
 
 ## Return Values
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -29,6 +29,28 @@ Manage Linode Instances, Configs, and Disks.
 ```
 
 ```yaml
+- name: Create a new Linode instance with an additional public IPv4 address.
+  linode.cloud.instance:
+    label: my-linode
+    type: g6-nanode-1
+    region: us-east
+    image: linode/ubuntu20.04
+    root_pass: verysecurepassword!!!
+    private_ip: false
+    authorized_keys:
+      - "ssh-rsa ..."
+    stackscript_id: 1337
+    stackscript_data:
+      variable: value
+    group: app
+    tags:
+      - env=prod
+    state: present
+    additional_ipv4:
+      - "public"
+```
+
+```yaml
 - name: Create a Linode Instance with explicit configs and disks.
   linode.cloud.instance:
     label: 'my-complex-instance'
@@ -85,6 +107,7 @@ Manage Linode Instances, Configs, and Disks.
 | `backup_id` | <center>`int`</center> | <center>Optional</center> | The id of the Backup to restore to the new Instance. May not be provided if "image" is given.   |
 | `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the instance to have status "running" before returning.  **(Default: `True`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an instance to have status "running".  **(Default: `240`)** |
+| `additional_ipv4` | <center>`list`</center> | <center>Optional</center> | Additional ipv4 addresses to allocate.   |
 
 ### configs
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -237,7 +237,7 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `public` | <center>`bool`</center> | <center>**Required**</center> | fill this in   |
+| `public` | <center>`bool`</center> | <center>**Required**</center> | Additional IPv4 addresses allocated to a Linode.   |
 
 ## Return Values
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -47,7 +47,7 @@ Manage Linode Instances, Configs, and Disks.
       - env=prod
     state: present
     additional_ipv4:
-      - "public"
+      - public: true
 ```
 
 ```yaml
@@ -107,7 +107,7 @@ Manage Linode Instances, Configs, and Disks.
 | `backup_id` | <center>`int`</center> | <center>Optional</center> | The id of the Backup to restore to the new Instance. May not be provided if "image" is given.   |
 | `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the instance to have status "running" before returning.  **(Default: `True`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an instance to have status "running".  **(Default: `240`)** |
-| `additional_ipv4` | <center>`list`</center> | <center>Optional</center> | Additional ipv4 addresses to allocate.   |
+| [`additional_ipv4` (sub-options)](#additional_ipv4) | <center>`list`</center> | <center>Optional</center> | Additional ipv4 addresses to allocate.   |
 
 ### configs
 
@@ -232,6 +232,12 @@ Manage Linode Instances, Configs, and Disks.
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The root user’s password on the newly-created Linode.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+
+### additional_ipv4
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `public` | <center>`bool`</center> | <center>**Required**</center> | fill this in   |
 
 ## Return Values
 

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -36,7 +36,7 @@ specdoc_examples = ['''
       - env=prod
     state: present
     additional_ipv4:
-      - "public"''', '''
+      - public: true''', '''
 - name: Create a Linode Instance with explicit configs and disks.
   linode.cloud.instance:
     label: 'my-complex-instance'

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -18,6 +18,25 @@ specdoc_examples = ['''
     tags:
       - env=prod
     state: present''', '''
+- name: Create a new Linode instance with an additional public IPv4 address.
+  linode.cloud.instance:
+    label: my-linode
+    type: g6-nanode-1
+    region: us-east
+    image: linode/ubuntu20.04
+    root_pass: verysecurepassword!!!
+    private_ip: false
+    authorized_keys:
+      - "ssh-rsa ..."
+    stackscript_id: 1337
+    stackscript_data:
+      variable: value
+    group: app
+    tags:
+      - env=prod
+    state: present
+    additional_ipv4:
+      - "public"''', '''
 - name: Create a Linode Instance with explicit configs and disks.
   linode.cloud.instance:
     label: 'my-complex-instance'

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -866,20 +866,13 @@ class LinodeInstance(LinodeModuleBase):
 
         ipv4_length = len(self.module.params.get("additional_ipv4") or [])
 
-        if self.module.params.get("private_ip"):
-            if ipv4_length != len(getattr(self._instance, "ipv4")) - 2:
-                self.fail(
-                    "failed to update instance {0}:additional_ipv4 is a non-updatable field".format(
-                        self._instance.label
-                    )
+        min_ips = 2 if self.module.params.get("private_ip") else 1
+        if ipv4_length != len(getattr(self._instance, "ipv4")) - min_ips:
+            self.fail(
+                "failed to update instance {0}:additional_ipv4 is a non-updatable field".format(
+                    self._instance.label
                 )
-        else:
-            if ipv4_length != len(getattr(self._instance, "ipv4")) - 1:
-                self.fail(
-                    "failed to update instance {0}:additional_ipv4 is a non-updatable field".format(
-                        self._instance.label
-                    )
-                )
+            )
 
         # Update interfaces
         self._update_interfaces()

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -563,7 +563,7 @@ class LinodeInstance(LinodeModuleBase):
         response = request_retry(
             lambda: self.client.linode.instance_create(ltype, region, **params)
         )
-        
+
         # Weird variable return type
         if isinstance(response, tuple):
             result["instance"] = response[0]
@@ -857,9 +857,9 @@ class LinodeInstance(LinodeModuleBase):
             if key == "additional_ipv4":
                 if len(new_value) != len(old_value):
                     self.fail(
-                        "failed to update instance {0}: additional_ipv4 is a non-updatable field".format(
-                            self._instance.label
-                        )
+                        "failed to update instance {0}: additional_ipv4 "
+                        + "is a non-updatable field"
+                        + "self._instance.label"
                     )
 
         if should_update:

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -861,38 +861,22 @@ class LinodeInstance(LinodeModuleBase):
                     )
                 )
 
-            # if key == "ipv4":
-            #     if getattr(self._instance, "private"):
-            #         if len(new_value) != len(old_value) - 1:
-            #             self.fail(
-            #                 "failed to update instance {0}: {1} is a non-updatable field".format(
-            #                     self._instance.label, key
-            #                 )
-            #             )
-            #     else:
-            #         if len(new_value) != len(old_value):
-            #             self.fail(
-            #                 "failed to update instance {0}: {1} is a non-updatable field".format(
-            #                     self._instance.label, key
-            #                 )
-            #             )
-
         if should_update:
             self._instance.save()
 
-        ipv4Length = len(self.module.params.get("additional_ipv4") or [])
+        ipv4_length = len(self.module.params.get("additional_ipv4") or [])
 
         if self.module.params.get("private_ip"):
-            if ipv4Length != len(getattr(self._instance, "ipv4")) - 2:
+            if ipv4_length != len(getattr(self._instance, "ipv4")) - 2:
                 self.fail(
-                    "failed to update instance {0}: additional_ipv4 is a non-updatable field".format(
+                    "failed to update instance {0}:additional_ipv4 is a non-updatable field".format(
                         self._instance.label
                     )
                 )
         else:
-            if ipv4Length != len(getattr(self._instance, "ipv4")) - 1:
+            if ipv4_length != len(getattr(self._instance, "ipv4")) - 1:
                 self.fail(
-                    "failed to update instance {0}: additional_ipv4 is a non-updatable field".format(
+                    "failed to update instance {0}:additional_ipv4 is a non-updatable field".format(
                         self._instance.label
                     )
                 )

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -237,7 +237,7 @@ linode_instance_config_spec = dict(
 spec_additional_ipv4 = dict(
     public=SpecField(
         type=FieldType.bool,
-        description="Additional IPv4 addresses allocated to a Linode.",
+        description="Whether the allocated IPv4 address should be public or private.",
         required=True,
     )
 )

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -236,7 +236,9 @@ linode_instance_config_spec = dict(
 
 spec_additional_ipv4 = dict(
     public=SpecField(
-        type=FieldType.bool, description="fill this in", required=True
+        type=FieldType.bool,
+        description="Additional IPv4 addresses allocated to a Linode.",
+        required=True,
     )
 )
 

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -21,6 +21,26 @@
           - create.instance.ipv4|length > 1
           - create.networking.ipv4.public[0].address != None
 
+    - name: Create a Linode instance with additional ips and without a root password
+      linode.cloud.instance:
+        label: 'ansible-test-additional-ips-nopass-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu20.04
+        private_ip: true
+        wait: false
+        state: present
+        additional_ipv4:
+          - "public"
+      register: create_additional_ips
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create_additional_ips.changed
+          - create_additional_ips.instance.ipv4|length == 3
+          - create_additional_ips.networking.ipv4.public[0].address != None
+
     - name: Update the instance region and type (recreate disallowed)
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
@@ -33,6 +53,35 @@
       register: invalid_update
       failed_when:
         - invalid_update.changed == true
+
+    - name: Attempt to add additional ips to an instance
+      linode.cloud.instance:
+        label: '{{ create_additional_ips.instance.label }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu20.04
+        private_ip: true
+        wait: false
+        state: present
+        additional_ipv4:
+          - "public"
+          - "public"
+      register: invalid_update_add_ips
+      failed_when:
+        - invalid_update_add_ips.changed == true
+
+    - name: Attempt to remove additional ips from an instance
+      linode.cloud.instance:
+        label: '{{ create_additional_ips.instance.label }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu20.04
+        private_ip: true
+        wait: false
+        state: present
+      register: invalid_update_remove_ips
+      failed_when:
+        - invalid_update_remove_ips.changed == true
 
     - name: Update the instance
       linode.cloud.instance:
@@ -89,6 +138,18 @@
             that:
               - delete_nopass.changed
               - delete_nopass.instance.id == update.instance.id
+
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_additional_ips.instance.label }}'
+            state: absent
+          register: delete_nopass_ips
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_nopass_ips.changed
+              - delete_nopass_ips.instance.id == create_additional_ips.instance.id
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -31,7 +31,7 @@
         wait: false
         state: present
         additional_ipv4:
-          - "public"
+          - public: true
       register: create_additional_ips
 
     - name: Assert instance created
@@ -64,11 +64,11 @@
         wait: false
         state: present
         additional_ipv4:
-          - "public"
-          - "public"
+          - public: true
+          - public: true
       register: invalid_update_add_ips
       failed_when:
-        - invalid_update_add_ips.changed == true
+        - "'additional_ipv4' not in invalid_update_add_ips.msg"
 
     - name: Attempt to remove additional ips from an instance
       linode.cloud.instance:
@@ -81,7 +81,7 @@
         state: present
       register: invalid_update_remove_ips
       failed_when:
-        - invalid_update_remove_ips.changed == true
+        - "'additional_ipv4' not in invalid_update_remove_ips.msg"
 
     - name: Update the instance
       linode.cloud.instance:


### PR DESCRIPTION
## 📝 Description

Added support for additional IP allocations in `linode_instance` module. Additional IPv4 addresses can be allocated upon creation.

## ✔️ How to Test

`make TEST_ARGS="-v instance_basic" test`