### PR TITLE
doc: Fix `instance_info` description mismatch

### DIFF
--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -25,8 +25,8 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`int`</center> | <center>Optional</center> | The instance’s label. Optional if `label` is defined.  **(Conflicts With: `label`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The unique ID of the Instance. Optional if `id` is defined.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The unique ID of the instance. Optional if `label` is defined.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The instance’s label. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -37,7 +37,7 @@ linode_instance_info_spec = dict(
         required=False,
         conflicts_with=["label"],
         description=[
-            "The instance’s label.",
+            "The unique ID of the instance.",
             "Optional if `label` is defined.",
         ],
     ),
@@ -46,7 +46,7 @@ linode_instance_info_spec = dict(
         required=False,
         conflicts_with=["id"],
         description=[
-            "The unique ID of the Instance.",
+            "The instance’s label.",
             "Optional if `id` is defined.",
         ],
     ),


### PR DESCRIPTION
## 📝 Description

This change resolves a small documentation inconsistency with the `label` and `id` fields in the `instance_info` module.
