### PR TITLE
fix: Resolve diffing issue for `instance` configs

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -152,10 +152,14 @@ def parse_linode_types(value: any) -> any:
     if isinstance(value, list):
         return [parse_linode_types(elem) for elem in value]
 
+    if isinstance(value, dict):
+        return {k: parse_linode_types(elem) for k, elem in value.items()}
+
     if type(value) in {
         linode_api4.objects.linode.Type,
         linode_api4.objects.linode.Region,
         linode_api4.objects.linode.Image,
+        linode_api4.objects.linode.Kernel,
         linode_api4.objects.lke.KubeVersion,
     }:
         return value.id

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -9,7 +9,6 @@ import copy
 from typing import Any, Dict, List, Optional, Union, cast
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs
-import linode_api4
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
     LinodeModuleBase,
 )
@@ -25,9 +24,9 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     drop_empty_strings,
     filter_null_values,
     filter_null_values_recursive,
-    mapping_to_dict,
     paginated_list_to_json,
-    request_retry, parse_linode_types,
+    parse_linode_types,
+    request_retry,
 )
 from ansible_specdoc.objects import (
     FieldType,

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -27,7 +27,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     filter_null_values_recursive,
     mapping_to_dict,
     paginated_list_to_json,
-    request_retry,
+    request_retry, parse_linode_types,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -688,7 +688,7 @@ class LinodeInstance(LinodeModuleBase):
             if not hasattr(config, key):
                 continue
 
-            old_value = mapping_to_dict(getattr(config, key))
+            old_value = parse_linode_types(getattr(config, key))
 
             # Special handling for the ConfigInterface type
             if key == "interfaces":
@@ -835,15 +835,7 @@ class LinodeInstance(LinodeModuleBase):
             if key in {"configs", "disks", "boot_config_label"}:
                 continue
 
-            old_value = getattr(self._instance, key)
-
-            # Convert type objects to their string IDs
-            if type(old_value) in {
-                linode_api4.objects.linode.Type,
-                linode_api4.objects.linode.Region,
-                linode_api4.objects.linode.Image,
-            }:
-                old_value = old_value.id
+            old_value = parse_linode_types(getattr(self._instance, key))
 
             if new_value != old_value:
                 if key in linode_instance_mutable:

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -52,6 +52,39 @@
           - create.configs[0].label == 'cool-config'
           - create.configs[0].devices.sda.disk_id != None
 
+    - name: Keep the config unchanged
+      linode.cloud.instance:
+        label: 'ansible-test-dc-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        booted: false
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            comments: really cool config
+            kernel: linode/latest-64bit
+            memory_limit: 512
+            run_level: single
+            virt_mode: paravirt
+            helpers:
+              devtmpfs_automount: true
+              distro: true
+              modules_dep: true
+              network: true
+              updatedb_disabled: true
+            devices:
+              sda:
+                disk_label: test-disk
+        state: present
+      register: unchanged
+
+    - assert:
+        that:
+          - unchanged.changed == False
+
     - name: Update the config
       linode.cloud.instance:
         label: 'ansible-test-dc-{{ r }}'


### PR DESCRIPTION
## 📝 Description

This change corrects a diffing issue with the `kernel` field for `instance` module configs. This issue was the result of the kernel being diffed as a `Kernel` object rather than as a string.

Resolves #332 

## ✔️ How to Test

```
make TEST_ARGS="-v instance_config_disk" test
```
