### PR TITLE
Enable test all by acctest command on GitHub Repo

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions-ecosystem/action-regex-match@v2
-        id: validate-tests
+        id: disallowed-char-check
         with:
           text: ${{ github.event.client_payload.slash_command.tests }}
           regex: '[^a-z0-9_]'
@@ -57,7 +57,7 @@ jobs:
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
       - run: make deps && make TEST_ARGS="-v ${{ github.event.client_payload.slash_command.tests }}" test
-        if: ${{ steps.validate-tests.outputs.match == '' }}
+        if: ${{ steps.disallowed-char-check.outputs.match == '' }}
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 


### PR DESCRIPTION
## 📝 Description

This would enable the acctest command to run all test

Example usage:
/acctest sha=your_commit_hash
