### PR TITLE
 Simplified Acctest Command Dispatching Workflow

### DIFF
--- a/.github/workflows/acctest_command.yml
+++ b/.github/workflows/acctest_command.yml
@@ -9,15 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request }}
     steps:
-      - name: Generate App Installation Token
-        id: generate_token
-        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06 # pin@v1
-        with:
-          app_id: ${{ secrets.DX_ACCTEST_APP_ID }}
-          private_key: ${{ secrets.DX_ACCTEST_PRIV_KEY }}
-
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@ace7a198016ae74cd286677c7e7f7e266eb18bc4 # pin@v1
+        uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # pin@v3
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
         with:


### PR DESCRIPTION
## 📝 Description

When we created the acctest command workflows, GitHub doesn't support using `GITHUB_TOKEN` to trigger another workflow [but later they added some exception](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/).

We used a workaround to generate a token as a GitHub App to trigger an `repository_dispatch` event to trigger the integration test. With the newly added exception, now I believe we can trigger the integration test directly by the `repository_dispatch` event triggered by the built-in `GITHUB_TOKEN`, and we can now remove the action that was used to generate GitHub App token.

## ✔️ How to Test

Will only be testable in this repo after merging.

Success on my forked repo:
https://github.com/zliang-akamai/linodego/pull/2#issuecomment-1522019490