### PR TITLE
Fix body_json parsing of api_request module

### DIFF
--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -102,6 +102,15 @@ class Module(LinodeModuleBase):
             mutually_exclusive=[("body", "body_json")],
         )
 
+    @staticmethod
+    def _parse_body_json(body_content: str) -> dict:
+        with contextlib.suppress(Exception):
+            # If this is a Python dict literal, parse and return
+            result = ast.literal_eval(body_content)
+            return result
+
+        return json.loads(body_content)
+
     def do_request(
         self, method: str, path: str, filters: dict = None, body: dict = None
     ) -> Tuple[int, Optional[dict]]:
@@ -136,18 +145,12 @@ class Module(LinodeModuleBase):
         param_body = self.module.params.get("body")
         param_body_json = self.module.params.get("body_json")
 
-        with contextlib.suppress(Exception):
-            parsed_body_json = ast.literal_eval(param_body_json)
-            parsed_body_json = json.dumps(parsed_body_json)
-
-            param_body_json = parsed_body_json
-
         request_body = None
 
         if param_body is not None:
             request_body = param_body
         elif param_body_json is not None:
-            request_body = json.loads(param_body_json)
+            request_body = self._parse_body_json(param_body_json)
 
         response_status, response_json = self.do_request(
             param_method, param_path, filters=param_filter, body=request_body

--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -5,6 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import ast
+import contextlib
+
 # pylint: disable=unused-import
 import json
 from typing import Any, Optional, Tuple
@@ -132,6 +135,12 @@ class Module(LinodeModuleBase):
 
         param_body = self.module.params.get("body")
         param_body_json = self.module.params.get("body_json")
+
+        with contextlib.suppress(Exception):
+            parsed_body_json = ast.literal_eval(param_body_json)
+            parsed_body_json = json.dumps(parsed_body_json)
+
+            param_body_json = parsed_body_json
 
         request_body = None
 

--- a/tests/integration/targets/api_request_extra/tasks/main.yaml
+++ b/tests/integration/targets/api_request_extra/tasks/main.yaml
@@ -1,0 +1,48 @@
+# this test is to test a json_body with integer inside as a value of a key
+
+- name: api_request_extra
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: List all available Linode regions
+      linode.cloud.region_list:
+      register: regions
+    
+    - name: Create a volume by the api_request module
+      linode.cloud.api_request:
+        path: "/volumes"
+        method: POST
+        body_json: >
+          {
+            "label": "ansible-test-{{ r }}",
+            "size": 10,
+            "region": "{{ regions.regions[0].id }}"
+          }
+      register: response
+
+    - name: Assert volume created
+      assert:
+        that:
+          - response.changed
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Delete the volume
+          linode.cloud.volume:
+            label: '{{ response.body.label }}'
+            state: absent
+          register: delete_volume
+          until: delete_volume.changed
+          retries: 5
+          delay: 10
+
+        - name: Assert the volume was deleted
+          assert:
+            that:
+              - delete_volume.changed
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'


### PR DESCRIPTION
## 📝 Description

closes #334

Translate `body_json` parameter to json to fix an issue that trouble the users.

## ✔️ How to Test

`make TEST_ARGS="-v api_request_extra" test`
`make TEST_ARGS="-v api_request_basic" test`