### PR TITLE
dep: Bump linode_api4 -> v5.5.0 and remove legacy request retry helper

### DIFF
--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -103,6 +103,10 @@ RESOURCE_NAMES = (
     else {}
 )
 
+MAX_RETRIES = 5
+RETRY_INTERVAL_SECONDS = float(4)
+RETRY_STATUSES = {408, 429, 502}
+
 
 class LinodeModuleBase:
     """A base for all Linode resource modules."""
@@ -240,7 +244,9 @@ class LinodeModuleBase:
                 api_token,
                 base_url="https://api.linode.com/{0}".format(api_version),
                 user_agent=user_agent,
-                retry_rate_limit_interval=10.0,
+                retry_rate_limit_interval=RETRY_INTERVAL_SECONDS,
+                retry_max=MAX_RETRIES,
+                retry_statuses=RETRY_STATUSES,
             )
 
         return self._client

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -240,7 +240,7 @@ class LinodeModuleBase:
                 api_token,
                 base_url="https://api.linode.com/{0}".format(api_version),
                 user_agent=user_agent,
-                retry_rate_limit_interval=10,
+                retry_rate_limit_interval=10.0,
             )
 
         return self._client

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -18,10 +18,6 @@ from linode_api4.objects.filtering import (
     FilterableMetaclass,
 )
 
-MAX_RETRIES = 5
-RETRY_INTERVAL_SECONDS = 4
-RETRY_STATUSES = {408}
-
 
 def dict_select_spec(target: dict, spec: dict) -> dict:
     """Returns a new dictionary that only selects the keys from target that are specified in spec"""

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -1,6 +1,5 @@
 """This module contains helper functions for various Linode modules."""
 import math
-import time
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
 
 import linode_api4
@@ -203,41 +202,6 @@ def validate_required(required_fields: Set[str], params: Dict[str, Any]):
 
     if has_missing_field:
         raise Exception("missing fields: {}".format(", ".join(missing_fields)))
-
-
-def request_retry(
-    request_func: Callable,
-    retry_statuses=None,
-    retry_interval=RETRY_INTERVAL_SECONDS,
-    max_retries=MAX_RETRIES,
-) -> any:
-    """Retries requests if the response status code matches the retry_statuses set."""
-    # Default value for set
-    if retry_statuses is None:
-        retry_statuses = RETRY_STATUSES
-
-    number_attempts = 0
-
-    while number_attempts < max_retries:
-        number_attempts += 1
-
-        try:
-            response = request_func()
-        except ApiError as exception:
-            if exception.status not in retry_statuses:
-                raise exception
-
-            time.sleep(retry_interval)
-
-            continue
-        except Exception as exception:
-            raise exception
-
-        return response
-
-    raise Exception(
-        "exceeded maximum number of retries: {0}".format(max_retries)
-    )
 
 
 def filter_null_values_recursive(obj: Any) -> Any:

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -26,7 +26,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     filter_null_values_recursive,
     paginated_list_to_json,
     parse_linode_types,
-    request_retry,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -579,9 +578,7 @@ class LinodeInstance(LinodeModuleBase):
         result = {"instance": None, "root_pass": ""}
 
         # We want to retry on 408s
-        response = request_retry(
-            lambda: self.client.linode.instance_create(ltype, region, **params)
-        )
+        response = self.client.linode.instance_create(ltype, region, **params)
 
         # Weird variable return type
         if isinstance(response, tuple):

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -20,9 +20,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
 from ansible_collections.linode.cloud.plugins.module_utils.linode_event_poller import (
     EventPoller,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    request_retry,
-)
 from ansible_specdoc.objects import (
     FieldType,
     SpecDocMeta,
@@ -216,11 +213,9 @@ class LinodeVolume(LinodeModuleBase):
             )
 
         # Perform the clone operation
-        vol = request_retry(
-            lambda: self.client.post(
-                "/volumes/{}/clone".format(source_id),
-                data={"label": params.get("label")},
-            )
+        vol = self.client.post(
+            "/volumes/{}/clone".format(source_id),
+            data={"label": params.get("label")},
         )
 
         cloned_volume = Volume(self.client, vol.get("id"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linode-api4>=5.5.0
+linode-api4>=5.5.1
 polling>=0.3.2
 types-requests>=2.30.0.0
 ansible-specdoc>=0.0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linode-api4==5.4.0
-polling==0.3.2
-types-requests==2.30.0.0
-ansible-specdoc==0.0.13
+linode-api4>=5.5.0
+polling>=0.3.2
+types-requests>=2.30.0.0
+ansible-specdoc>=0.0.13

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.13
+        image: linode/alpine3.17
         state: present
       register: create_instance
 
@@ -16,7 +16,7 @@
         label: 'ansible-test-{{ r }}-2'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.13
+        image: linode/alpine3.17
         state: present
       register: create_instance_2
 

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.13
+        image: linode/alpine3.17
         state: present
       register: inst
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.13
+        image: linode/alpine3.17
         state: present
       register: create_instance
 

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -158,7 +158,7 @@
         label: '{{ create.instance.label }}'
         region: us-east
         type: g6-standard-1
-        image: linode/alpine3.13
+        image: linode/alpine3.17
         booted: false
         disks:
           - label: test-disk
@@ -179,7 +179,7 @@
 
           - label: boot-disk
             size: 4096
-            image: linode/alpine3.13
+            image: linode/alpine3.17
 
         configs:
           - label: boot-config


### PR DESCRIPTION
## 📝 Description

This change bumps the `linode_api4` dependency to `v5.5.0` and removes the legacy `request_retry` helper, which is no longer necessary due to native retries in `linode_api4`.

Blocked by https://github.com/linode/linode_api4-python/pull/291

## ✔️ How to Test

```
make test
```