### PR TITLE
fix: Resolve spec inconsistencies for the `label` and `type` fields in the `instance` module

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -90,7 +90,8 @@ Manage Linode Instances, Configs, and Disks.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `type` | <center>`str`</center> | <center>Optional</center> | The unique label to give this instance.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this instance.   |
+| `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type of the Linode you are creating.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |
 | `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.  **(Conflicts With: `disks`,`configs`)** |
 | `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -241,9 +241,13 @@ spec_additional_ipv4 = {
 }
 
 linode_instance_spec = {
-    "type": SpecField(
+    "label": SpecField(
         type=FieldType.string,
         description=["The unique label to give this instance."],
+    ),
+    "type": SpecField(
+        type=FieldType.string,
+        description=["The Linode Type of the Linode you are creating."],
     ),
     "region": SpecField(
         type=FieldType.string,


### PR DESCRIPTION
## 📝 Description

This change resolves a spec inconsistency in the `instance` module that was causing broken documentation for the `label` and `type` fields. Oddly the module was functioning as expected, so this seems to just be a visual change.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_basic" test
```