### PR TITLE
new: Support Jinja2 templating on the `api_token` field

### DIFF
--- a/plugins/inventory/instance.py
+++ b/plugins/inventory/instance.py
@@ -119,6 +119,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             except KeyError:
                 pass
 
+        if self.templar.is_template(api_token):
+            api_token = self.templar.template(
+                variable=api_token, disable_lookups=False
+            )
+
         if api_token is None:
             raise AnsibleError(
                 (

--- a/tests/integration/targets/instance_inventory/playbooks/teardown.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/teardown.yml
@@ -24,3 +24,4 @@
         - filter.instance.yml
         - nofilter.instance.yml
         - keyedgroups.instance.yml
+        - templatetoken.instance.yml

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_templatetoken.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_templatetoken.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - meta: refresh_inventory
+
+    - assert:
+        that:
+          - '"ansible-test-inventory" in hostvars'
+          - hostvars | length == 1

--- a/tests/integration/targets/instance_inventory/runme.sh
+++ b/tests/integration/targets/instance_inventory/runme.sh
@@ -17,5 +17,9 @@ ANSIBLE_INVENTORY=filter.instance.yml ansible-playbook playbooks/test_inventory_
 ansible-playbook playbooks/create_inventory.yml --extra-vars "template=keyedgroups.instance.yml" "$@"
 ANSIBLE_INVENTORY=keyedgroups.instance.yml ansible-playbook playbooks/test_inventory_keyedgroups.yml "$@"
 
+# Test an inventory with a templated `api_token` field
+ansible-playbook playbooks/create_inventory.yml --extra-vars "template=templatetoken.instance.yml" "$@"
+ANSIBLE_INVENTORY=templatetoken.instance.yml ansible-playbook playbooks/test_inventory_templatetoken.yml "$@"
+
 # Clean up
 ansible-playbook playbooks/teardown.yml "$@"

--- a/tests/integration/targets/instance_inventory/templates/templatetoken.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/templatetoken.instance.yml
@@ -1,0 +1,8 @@
+plugin: linode.cloud.instance
+api_token: '{{ "{{ \"" + api_token + "\" }}" }}'  # Hacky test for templating
+types:
+  - g6-nanode-1
+tags:
+  - ansible-inventory-node
+regions:
+  - us-east


### PR DESCRIPTION
## 📝 Description

This change adds support for Jinja2 templating on the `api_token` field in the instance inventory plugin. This change mirrors the corresponding change in the Ansible Community Collection.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_inventory" test
```