### PR TITLE
new: Add Python dependency validation and enforcement

### DIFF
--- a/.github/workflows/embedded-deps.yml
+++ b/.github/workflows/embedded-deps.yml
@@ -1,0 +1,44 @@
+name: Run Embedded Requirements Validation
+
+on: pull_request
+
+jobs:
+  run-req-validation:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/linode/cloud
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: .ansible/collections/ansible_collections/linode/cloud
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install packages
+        run: sudo apt-get install -y make
+
+      - name: setup python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: install dependencies
+        run: pip install -r requirements-dev.txt -r requirements.txt
+
+      - name: make temp directory
+        run: mkdir tmp
+
+      - name: copy over old deps
+        run: cp plugins/module_utils/linode_deps.py tmp/linode_deps.py
+
+      - name: generate and embed the dependency file
+        run: make embed-deps
+
+      - name: compare README
+        run: diff -r plugins/module_utils/linode_deps.py tmp/linode_deps.py
+
+      - name: clean up
+        run: rm -rf tmp

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 clean:
 	rm -f *.tar.gz && rm -rf galaxy.yml
 
-build: clean gendocs
+build: clean gendocs embed-deps
 	python scripts/render_galaxy.py $(COLLECTION_VERSION) && ansible-galaxy collection build
 
 publish: build
@@ -54,7 +54,10 @@ gendocs:
 	ansible-doc-extractor --template=template/module.rst.j2 $(DOCS_PATH)/inventory plugins/inventory/*.py
 	python scripts/render_readme.py $(COLLECTION_VERSION)
 
-integration-test: create-integration-config
+embed-deps:
+	python scripts/embed_deps.py
+
+integration-test: create-integration-config embed-deps
 	ansible-test integration $(TEST_ARGS)
 
 test: integration-test

--- a/plugins/module_utils/linode_deps.py
+++ b/plugins/module_utils/linode_deps.py
@@ -1,0 +1,7 @@
+REQUIREMENTS = """
+linode-api4>=5.5.1
+polling>=0.3.2
+types-requests==2.31.0.1
+ansible-specdoc>=0.0.13
+
+"""

--- a/scripts/embed_deps.py
+++ b/scripts/embed_deps.py
@@ -1,0 +1,25 @@
+"""
+This script embeds the requirements found in `requirements.txt` into the `module_utils.linode_deps` module.
+This is necessary because Ansible does not enforce Python dependency verification and
+this project treats `requirements.txt` as the source of truth for Python requirements.
+
+Additionally, installed Ansible Collections cannot reliably access static project files.
+"""
+
+from pathlib import Path
+
+embedded_path = Path(__file__).parent.parent / "plugins/module_utils/linode_deps.py"
+
+
+def main():
+    with open("requirements.txt") as req_file, \
+            open(embedded_path, "w") as emb_file:
+        requirements = req_file.read()
+
+        emb_file.write(
+            f"REQUIREMENTS = \"\"\"\n{requirements}\n\"\"\"\n"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📝 Description

This change adds automatic dependency enforcement treating `requirements.txt` as the single source of truth. This allows for a better user-experience by informing users when their Python dependency versions are not compatible with the current collection version.

Due to limitations outlined in `scripts/embed_deps.py`, requirements are automatically embedded into the collection as a small Python module that is imported from `linode_common.py`. This module is automatically generated and embedded when the `make embed-deps` target is run.

Additionally, this change introduces a new GitHub actions workflow to ensure the embedded dependency module matches the dependencies found in `requirements.txt`.
