### PR TITLE
dep: updating specdoc to 0.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 linode-api4>=5.6.0
 polling>=0.3.2
 types-requests==2.31.0.1
-ansible-specdoc>=0.0.13
+ansible-specdoc>=0.0.14


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

updating specdoc version to match new release
