### PR TITLE
fix: Resolve division-by-zero error for empty list responses

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -252,16 +252,11 @@ def get_all_paginated(
     page_size = 100
     num_pages = 1
 
-    # Return whether the number of results meets the
-    # user-specified result cap.
-    def results_met_cap():
-        return num_results is None or len(result) >= num_results
-
     if num_results is not None and num_results < page_size:
         # Clamp the page size
         page_size = max(min(num_results, 100), 25)
 
-    while current_page <= num_pages and not results_met_cap():
+    while current_page <= num_pages and (num_results is None or len(result) < num_results):
         response = client.get(
             endpoint + "?page={}&page_size={}".format(current_page, page_size),
             filters=filters,
@@ -272,7 +267,7 @@ def get_all_paginated(
 
         result.extend(response["data"])
 
-        if results_met_cap():
+        if num_results is not None and len(result) >= num_results:
             break
 
         current_page += 1

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -1,5 +1,6 @@
 """This module contains helper functions for various Linode modules."""
 import math
+import sys
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
 
 import linode_api4
@@ -251,13 +252,17 @@ def get_all_paginated(
     result = []
     current_page = 1
     page_size = 100
-    num_pages = -1
+    num_pages = 1
+
+    # Don't cap the number of results if
+    # num_results is not defined.
+    num_results = sys.maxsize if num_results is None else num_results
 
     if num_results is not None and num_results < page_size:
         # Clamp the page size
         page_size = max(min(num_results, 100), 25)
 
-    while current_page <= num_pages or num_pages == -1:
+    while current_page <= num_pages and len(result) < num_results:
         response = client.get(
             endpoint + "?page={}&page_size={}".format(current_page, page_size),
             filters=filters,
@@ -266,18 +271,11 @@ def get_all_paginated(
         if "data" not in response or "page" not in response:
             raise Exception("Invalid list response")
 
-        # There are no pages for this request.
-        # Break early to avoid division by zero error.
-        if response["pages"] == 0:
+        result.extend(response["data"])
+
+        if len(result) >= num_results:
             break
 
-        if num_pages == -1:
-            if num_results is not None:
-                num_pages = math.floor(num_results / response["pages"])
-            else:
-                num_pages = math.floor(response["results"] / response["pages"])
-
-        result.extend(response["data"])
         current_page += 1
 
     if num_results is not None:

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -266,6 +266,11 @@ def get_all_paginated(
         if "data" not in response or "page" not in response:
             raise Exception("Invalid list response")
 
+        # There are no pages for this request.
+        # Break early to avoid division by zero error.
+        if response["pages"] == 0:
+            break
+
         if num_pages == -1:
             if num_results is not None:
                 num_pages = math.floor(num_results / response["pages"])

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -256,7 +256,9 @@ def get_all_paginated(
         # Clamp the page size
         page_size = max(min(num_results, 100), 25)
 
-    while current_page <= num_pages and (num_results is None or len(result) < num_results):
+    while current_page <= num_pages and (
+        num_results is None or len(result) < num_results
+    ):
         response = client.get(
             endpoint + "?page={}&page_size={}".format(current_page, page_size),
             filters=filters,

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -26,6 +26,18 @@
           - filter.images | length == 1
           - filter.images[0].id == 'linode/alpine3.16'
 
+    - name: Resolve an empty list of images
+      linode.cloud.image_list:
+        filters:
+          - name: vendor
+            values: DefinitelyRealVendor
+      register: filter_empty
+
+    - assert:
+        that:
+          - filter_empty.images | length == 0
+
+
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'


### PR DESCRIPTION
## 📝 Description

This change fixes a division-by-zero error that would occur when no entries are returned from a list module.

## ✔️ How to Test

```
make TEST_ARGS="-v image_list" test
```
