### PR TITLE
fix: Uncomment has_user_data check

### DIFF
--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -20,9 +20,7 @@
       assert:
         that:
           - create.changed
-          # This check is temporarily disabled until the corresponding
-          # API feature is available.
-          # - create.instance.has_user_data == True
+          - create.instance.has_user_data == True
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

This change uncomments the test checks for the has_user_data field now that the field is accessible through the API.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_metadata
```
