### PR TITLE
new: Add VPC and VPC Subnet modules

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: make temp directory
         run: mkdir tmp

--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: install ansible dependencies
         run: ansible-galaxy collection install amazon.aws:==6.0.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.10'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: install ansible dependencies
         run: ansible-galaxy collection install amazon.aws:==6.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: run linter
         run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: install ansible dependencies
         run: ansible-galaxy collection install amazon.aws:==6.0.1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.10'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: Run unit tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ DOCS_PATH ?= docs
 COLLECTION_VERSION ?=
 
 TEST_ARGS := -v
-TEST_API_URL := https://api.linode.com/
-TEST_API_VERSION := v4beta
+TEST_API_URL ?= https://api.linode.com/
+TEST_API_VERSION ?= v4beta
 INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 clean:
 	rm -f *.tar.gz && rm -rf galaxy.yml
 
-build: clean gendocs
+build: deps clean gendocs
 	python scripts/render_galaxy.py $(COLLECTION_VERSION) && ansible-galaxy collection build
 
 publish: build
@@ -26,7 +26,7 @@ install: build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
 deps:
-	pip install -r requirements.txt -r requirements-dev.txt
+	pip install --upgrade -r requirements.txt -r requirements-dev.txt
 
 lint:
 	pylint plugins

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ COLLECTION_VERSION ?=
 TEST_ARGS := -v
 TEST_API_URL ?= https://api.linode.com/
 TEST_API_VERSION ?= v4beta
+TEST_CA_FILE ?=
 INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 
 clean:
@@ -79,3 +80,4 @@ endif
 	@echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)
 	@echo "api_url: $(TEST_API_URL)" >> $(INTEGRATION_CONFIG)
 	@echo "api_version: $(TEST_API_VERSION)" >> $(INTEGRATION_CONFIG)
+	@echo "ca_file: $(TEST_CA_FILE)" >> $(INTEGRATION_CONFIG)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Name | Description |
 [linode.cloud.token](./docs/modules/token.md)|Manage a Linode Token.|
 [linode.cloud.user](./docs/modules/user.md)|Manage a Linode User.|
 [linode.cloud.volume](./docs/modules/volume.md)|Manage a Linode Volume.|
+[linode.cloud.vpc](./docs/modules/vpc.md)|Create, read, and update a Linode VPC.|
+[linode.cloud.vpc_subnet](./docs/modules/vpc_subnet.md)|Create, read, and update a Linode VPC Subnet.|
 
 
 ### Info Modules
@@ -98,6 +100,7 @@ Name | Description |
 [linode.cloud.user_list](./docs/modules/user_list.md)|List Users.|
 [linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on Linode VLANs.|
 [linode.cloud.volume_list](./docs/modules/volume_list.md)|List and filter on Linode Volumes.|
+[linode.cloud.vpc_list](./docs/modules/vpc_list.md)|List and filter on VPCs in the Linode profile.|
 
 
 ### Inventory Plugins

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Name | Description |
 [linode.cloud.user_info](./docs/modules/user_info.md)|Get info about a Linode User.|
 [linode.cloud.vlan_info](./docs/modules/vlan_info.md)|Get info about a Linode VLAN.|
 [linode.cloud.volume_info](./docs/modules/volume_info.md)|Get info about a Linode Volume.|
+[linode.cloud.vpc_info](./docs/modules/vpc_info.md)|Get info about a Linode VPC.|
+[linode.cloud.vpc_subnet_info](./docs/modules/vpc_subnet_info.md)|Get info about a Linode VPC Subnet.|
 
 
 ### List Modules
@@ -100,7 +102,8 @@ Name | Description |
 [linode.cloud.user_list](./docs/modules/user_list.md)|List Users.|
 [linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on Linode VLANs.|
 [linode.cloud.volume_list](./docs/modules/volume_list.md)|List and filter on Linode Volumes.|
-[linode.cloud.vpc_list](./docs/modules/vpc_list.md)|List and filter on VPCs in the Linode profile.|
+[linode.cloud.vpc_list](./docs/modules/vpc_list.md)|List and filter on VPCs.|
+[linode.cloud.vpc_subnet_list](./docs/modules/vpc_subnet_list.md)|List and filter on VPC Subnets.|
 
 
 ### Inventory Plugins

--- a/docs/modules/token.md
+++ b/docs/modules/token.md
@@ -29,7 +29,7 @@ NOTE: The full Personal Access Token is only returned when a new token has been 
 ```yaml
 - name: Delete a token
   linode.cloud.token:
-    domain: my-token
+    label: my-token
     state: absent
 ```
 

--- a/docs/modules/vpc.md
+++ b/docs/modules/vpc.md
@@ -1,0 +1,61 @@
+# vpc
+
+Create, read, and update a Linode VPC.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Create a simple token 
+  linode.cloud.token:
+    label: my-token
+    state: present
+```
+
+```yaml
+- name: Create a token with expiry date and scopes 
+  linode.cloud.token:
+    label: my-token
+    expiry: 2022-07-09T16:59:26
+    scope: '*'
+    state: present
+```
+
+```yaml
+- name: Delete a token
+  linode.cloud.token:
+    domain: my-token
+    state: absent
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
+| `description` | <center>`str`</center> | <center>Optional</center> | A description describing this VPC.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The region this VPC is located in.   |
+
+## Return Values
+
+- `vpc` - The VPC in JSON serialized form.
+
+    - Sample Response:
+        ```json
+        {
+          "created": "2018-01-01T00:01:01",
+          "expiry": "2018-01-01T13:46:32",
+          "id": 123,
+          "label": "linode-cli",
+          "scopes": "*",
+          "token": "abcdefghijklmnop"
+        }
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -25,12 +25,12 @@ Get info about a Linode VPC.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC.  **(Conflicts With: `label`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC.  **(Conflicts With: `id`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC to resolve.   |
 
 ## Return Values
 
-- `vpc` - The VPC in JSON serialized form.
+- `vpc` - The returned VPC.
 
     - Sample Response:
         ```json
@@ -44,6 +44,5 @@ Get info about a Linode VPC.
             "updated": "2023-08-31T18:35:03"
         }
         ```
-    - See the [Linode API response documentation](TODO) for a list of returned fields
 
 

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -1,6 +1,6 @@
-# vpc
+# vpc_info
 
-Create, read, and update a Linode VPC.
+Get info about a Linode VPC.
 
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -9,19 +9,15 @@ Create, read, and update a Linode VPC.
 ## Examples
 
 ```yaml
-- name: Create a VPC 
-  linode.cloud.vpc:
+- name: Get info about a VPC by label
+  linode.cloud.vpc_info:
     label: my-vpc
-    region: us-east
-    description: A description of this VPC.
-    state: present
 ```
 
 ```yaml
-- name: Delete a VPC
-  linode.cloud.vpc:
-    label: my-vpc
-    state: absent
+- name: Get info about a VPC by ID
+  linode.cloud.vpc_info:
+    id: 12345
 ```
 
 
@@ -29,10 +25,8 @@ Create, read, and update a Linode VPC.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
-| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
-| `description` | <center>`str`</center> | <center>Optional</center> | A description describing this VPC.   |
-| `region` | <center>`str`</center> | <center>Optional</center> | The region this VPC is located in.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -1,0 +1,78 @@
+# vpc_list
+
+List and filter on VPCs in the Linode profile.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the SSH keys for the current Linode Account
+  linode.cloud.ssh_key_list: {}
+```
+
+```yaml
+- name: List the latest 5 SSH keys for the current Linode Account
+  linode.cloud.ssh_key_list:
+
+    count: 5
+    order_by: created
+    order: desc
+```
+
+```yaml
+- name: List filtered personal SSH keys for the current Linode Account
+  linode.cloud.ssh_key_list:
+
+    filters:
+      - name: label-or-some-other-field
+        values: MySSHKey1
+```
+
+```yaml
+- name: List filtered personal SSH keys for the current Linode Account
+  linode.cloud.ssh_key_list:
+    filters:
+      - name: label-or-some-other-field
+        values:
+          - MySSHKey1
+          - MySSHKey2
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPCs in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPCs by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPCs.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of VPCs to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on.   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `vpcs` - The returned VPCs.
+
+    - Sample Response:
+        ```json
+        [
+            {
+              "created": "2018-01-01T00:01:01",
+              "id": 42,
+              "label": "MySSHKey1",
+              "ssh_key": "ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -1,6 +1,6 @@
 # vpc_list
 
-List and filter on VPCs in the Linode profile.
+List and filter on VPCs.
 
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -9,36 +9,16 @@ List and filter on VPCs in the Linode profile.
 ## Examples
 
 ```yaml
-- name: List all of the SSH keys for the current Linode Account
-  linode.cloud.ssh_key_list: {}
+- name: List all of the VPCs for the current user
+  linode.cloud.vpc_list: {}
 ```
 
 ```yaml
-- name: List the latest 5 SSH keys for the current Linode Account
-  linode.cloud.ssh_key_list:
-
-    count: 5
-    order_by: created
-    order: desc
-```
-
-```yaml
-- name: List filtered personal SSH keys for the current Linode Account
-  linode.cloud.ssh_key_list:
-
+- name: List all of the VPCS for the current user with the given label
+  linode.cloud.vpc_list:
     filters:
-      - name: label-or-some-other-field
-        values: MySSHKey1
-```
-
-```yaml
-- name: List filtered personal SSH keys for the current Linode Account
-  linode.cloud.ssh_key_list:
-    filters:
-      - name: label-or-some-other-field
-        values:
-          - MySSHKey1
-          - MySSHKey2
+      - name: label
+        values: my-vpc
 ```
 
 
@@ -66,10 +46,13 @@ List and filter on VPCs in the Linode profile.
         ```json
         [
             {
-              "created": "2018-01-01T00:01:01",
-              "id": 42,
-              "label": "MySSHKey1",
-              "ssh_key": "ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"
+                "created": "2023-08-31T18:35:01",
+                "description": "A description of this VPC",
+                "id": 344,
+                "label": "my-vpc",
+                "region": "us-east",
+                "subnets": [],
+                "updated": "2023-08-31T18:35:03"
             }
         ]
         ```

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -35,7 +35,7 @@ List and filter on VPCs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -56,6 +56,5 @@ List and filter on VPCs.
             }
         ]
         ```
-    - See the [Linode API response documentation](TODO) for a list of returned fields
 
 

--- a/docs/modules/vpc_subnet.md
+++ b/docs/modules/vpc_subnet.md
@@ -1,0 +1,61 @@
+# vpc_subnet
+
+Create, read, and update a Linode VPC Subnet.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Create a simple token 
+  linode.cloud.token:
+    label: my-token
+    state: present
+```
+
+```yaml
+- name: Create a token with expiry date and scopes 
+  linode.cloud.token:
+    label: my-token
+    expiry: 2022-07-09T16:59:26
+    scope: '*'
+    state: present
+```
+
+```yaml
+- name: Delete a token
+  linode.cloud.token:
+    domain: my-token
+    state: absent
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the parent VPC for this subnet.   |
+| `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
+| `ipv4` | <center>`str`</center> | <center>Optional</center> | The IPV4 range for this subnet in CIDR format.   |
+
+## Return Values
+
+- `subnet` - The VPC in JSON serialized form.
+
+    - Sample Response:
+        ```json
+        {
+          "created": "2018-01-01T00:01:01",
+          "expiry": "2018-01-01T13:46:32",
+          "id": 123,
+          "label": "linode-cli",
+          "scopes": "*",
+          "token": "abcdefghijklmnop"
+        }
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/docs/modules/vpc_subnet_info.md
+++ b/docs/modules/vpc_subnet_info.md
@@ -1,6 +1,6 @@
-# vpc_subnet
+# vpc_subnet_info
 
-Create, read, and update a Linode VPC Subnet.
+Get info about a Linode VPC Subnet.
 
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -9,20 +9,17 @@ Create, read, and update a Linode VPC Subnet.
 ## Examples
 
 ```yaml
-- name: Create a VPC Subnet
-  linode.cloud.vpc_subnet:
+- name: Get info about a VPC Subnet by label
+  linode.cloud.vpc_subnet_info:
     vpc_id: 12345
     label: my-subnet
-    ipv4: '10.0.0.0/24'
-    state: present
 ```
 
 ```yaml
-- name: Delete a VPC Subnet
-  linode.cloud.vpc_subnet:
+- name: Get info about a VPC Subnet by ID
+  linode.cloud.vpc_subnet_info:
     vpc_id: 12345
-    label: my-subnet
-    state: absent
+    id: 123
 ```
 
 
@@ -30,14 +27,13 @@ Create, read, and update a Linode VPC Subnet.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the parent VPC for this subnet.   |
-| `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
-| `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
-| `ipv4` | <center>`str`</center> | <center>Optional</center> | The IPV4 range for this subnet in CIDR format.   |
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC.  **(Conflicts With: `label`)** |
 
 ## Return Values
 
-- `subnet` - The VPC in JSON serialized form.
+- `subnet` - The VPC Subnet in JSON serialized form.
 
     - Sample Response:
         ```json

--- a/docs/modules/vpc_subnet_info.md
+++ b/docs/modules/vpc_subnet_info.md
@@ -27,13 +27,13 @@ Get info about a Linode VPC Subnet.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC.   |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC.  **(Conflicts With: `id`)** |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC.  **(Conflicts With: `label`)** |
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC for this resource.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC Subnet to resolve.   |
 
 ## Return Values
 
-- `subnet` - The VPC Subnet in JSON serialized form.
+- `subnet` - The returned VPC Subnet.
 
     - Sample Response:
         ```json
@@ -46,6 +46,5 @@ Get info about a Linode VPC Subnet.
             "updated": "2023-08-31T18:53:04"
         }
         ```
-    - See the [Linode API response documentation](TODO) for a list of returned fields
 
 

--- a/docs/modules/vpc_subnet_list.md
+++ b/docs/modules/vpc_subnet_list.md
@@ -29,7 +29,7 @@ List and filter on VPC Subnets.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for this VPC Subnet   |
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for this VPC Subnet.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPC Subnets in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPC Subnets by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPC Subnets.   |
@@ -39,7 +39,7 @@ List and filter on VPC Subnets.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on.   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -59,6 +59,5 @@ List and filter on VPC Subnets.
             }
         ]
         ```
-    - See the [Linode API response documentation](TODO) for a list of returned fields
 
 

--- a/docs/modules/vpc_subnet_list.md
+++ b/docs/modules/vpc_subnet_list.md
@@ -1,0 +1,64 @@
+# vpc_subnet_list
+
+List and filter on VPC Subnets.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the subnets under a VPC
+  linode.cloud.vpc_subnet_list:
+    vpc_id: 12345
+  
+```
+
+```yaml
+- name: List all of the subnets with a given label under a VPC
+  linode.cloud.vpc_subnet_list:
+    vpc_id: 12345
+    filters:
+      - name: label
+        values: my-subnet
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for this VPC Subnet   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPC Subnets in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPC Subnets by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPC Subnets.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of VPC Subnets to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on.   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `subnets` - The returned VPC Subnets.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "created": "2023-08-31T18:53:04",
+                "id": 271,
+                "ipv4": "10.0.0.0/24",
+                "label": "test-subnet",
+                "linodes": [],
+                "updated": "2023-08-31T18:53:04"
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/token.py
+++ b/plugins/module_utils/doc_fragments/token.py
@@ -13,7 +13,7 @@ specdoc_examples = ['''
     state: present''', '''
 - name: Delete a token
   linode.cloud.token:
-    domain: my-token
+    label: my-token
     state: absent''']
 
 result_token_samples = ['''{

--- a/plugins/module_utils/doc_fragments/vpc.py
+++ b/plugins/module_utils/doc_fragments/vpc.py
@@ -1,0 +1,23 @@
+"""Documentation fragments for the vpc module"""
+
+specdoc_examples = ['''
+- name: Create a VPC 
+  linode.cloud.vpc:
+    label: my-vpc
+    region: us-east
+    description: A description of this VPC.
+    state: present''', '''
+- name: Delete a VPC
+  linode.cloud.vpc:
+    label: my-vpc
+    state: absent''']
+
+result_vpc_samples = ['''{
+    "created": "2023-08-31T18:35:01",
+    "description": "A description of this VPC",
+    "id": 344,
+    "label": "my-vpc",
+    "region": "us-east",
+    "subnets": [],
+    "updated": "2023-08-31T18:35:03"
+}''']

--- a/plugins/module_utils/doc_fragments/vpc_info.py
+++ b/plugins/module_utils/doc_fragments/vpc_info.py
@@ -1,0 +1,9 @@
+"""Documentation fragments for the vpc_info module"""
+
+specdoc_examples = ['''
+- name: Get info about a VPC by label
+  linode.cloud.vpc_info:
+    label: my-vpc''', '''
+- name: Get info about a VPC by ID
+  linode.cloud.vpc_info:
+    id: 12345''']

--- a/plugins/module_utils/doc_fragments/vpc_list.py
+++ b/plugins/module_utils/doc_fragments/vpc_list.py
@@ -1,0 +1,22 @@
+"""Documentation fragments for the vpc_list module"""
+
+specdoc_examples = ['''
+- name: List all of the VPCs for the current user
+  linode.cloud.vpc_list: {}''', '''
+- name: List all of the VPCS for the current user with the given label
+  linode.cloud.vpc_list:
+    filters:
+      - name: label
+        values: my-vpc''']
+
+result_vpc_samples = ['''[
+    {
+        "created": "2023-08-31T18:35:01",
+        "description": "A description of this VPC",
+        "id": 344,
+        "label": "my-vpc",
+        "region": "us-east",
+        "subnets": [],
+        "updated": "2023-08-31T18:35:03"
+    }
+]''']

--- a/plugins/module_utils/doc_fragments/vpc_subnet.py
+++ b/plugins/module_utils/doc_fragments/vpc_subnet.py
@@ -1,0 +1,23 @@
+"""Documentation fragments for the vpc module"""
+
+specdoc_examples = ['''
+- name: Create a VPC Subnet
+  linode.cloud.vpc_subnet:
+    vpc_id: 12345
+    label: my-subnet
+    ipv4: '10.0.0.0/24'
+    state: present''', '''
+- name: Delete a VPC Subnet
+  linode.cloud.vpc_subnet:
+    vpc_id: 12345
+    label: my-subnet
+    state: absent''']
+
+result_subnet_samples = ['''{
+    "created": "2023-08-31T18:53:04",
+    "id": 271,
+    "ipv4": "10.0.0.0/24",
+    "label": "test-subnet",
+    "linodes": [],
+    "updated": "2023-08-31T18:53:04"
+}''']

--- a/plugins/module_utils/doc_fragments/vpc_subnet_info.py
+++ b/plugins/module_utils/doc_fragments/vpc_subnet_info.py
@@ -1,0 +1,11 @@
+"""Documentation fragments for the vpc_info module"""
+
+specdoc_examples = ['''
+- name: Get info about a VPC Subnet by label
+  linode.cloud.vpc_subnet_info:
+    vpc_id: 12345
+    label: my-subnet''', '''
+- name: Get info about a VPC Subnet by ID
+  linode.cloud.vpc_subnet_info:
+    vpc_id: 12345
+    id: 123''']

--- a/plugins/module_utils/doc_fragments/vpc_subnet_list.py
+++ b/plugins/module_utils/doc_fragments/vpc_subnet_list.py
@@ -1,0 +1,24 @@
+"""Documentation fragments for the vpc_list module"""
+
+specdoc_examples = ['''
+- name: List all of the subnets under a VPC
+  linode.cloud.vpc_subnet_list:
+    vpc_id: 12345
+  ''', '''
+- name: List all of the subnets with a given label under a VPC
+  linode.cloud.vpc_subnet_list:
+    vpc_id: 12345
+    filters:
+      - name: label
+        values: my-subnet''']
+
+result_vpc_samples = ['''[
+    {
+        "created": "2023-08-31T18:53:04",
+        "id": 271,
+        "ipv4": "10.0.0.0/24",
+        "label": "test-subnet",
+        "linodes": [],
+        "updated": "2023-08-31T18:53:04"
+    }
+]''']

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -108,7 +108,7 @@ RESOURCE_NAMES = (
         StackScript: "stackscript",
         IPAddress: "IP address",
         VPC: "VPC",
-        VPCSubnet: "VPCSubnet",
+        VPCSubnet: "VPC Subnet",
     }
     if HAS_LINODE
     else {}

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -25,7 +25,7 @@ from ansible.module_utils.basic import (
 )
 
 try:
-    from linode_api4 import ApiError
+    from linode_api4 import VPC, ApiError
     from linode_api4 import Base as LinodeAPIType
     from linode_api4 import (
         Image,
@@ -37,6 +37,7 @@ try:
         SSHKey,
         StackScript,
         UnexpectedResponseError,
+        VPCSubnet,
     )
     from linode_api4.polling import TimeoutContext
 
@@ -106,6 +107,8 @@ RESOURCE_NAMES = (
         SSHKey: "SSH key",
         StackScript: "stackscript",
         IPAddress: "IP address",
+        VPC: "VPC",
+        VPCSubnet: "VPCSubnet",
     }
     if HAS_LINODE
     else {}
@@ -218,10 +221,18 @@ class LinodeModuleBase:
         self.results["actions"].append(description)
 
     def _get_resource_by_id(
-        self, resource_type: Type[LinodeAPIType], resource_id: int
+        self,
+        resource_type: Type[LinodeAPIType],
+        resource_id: int,
+        parent_id: int = None,
     ):
         try:
-            resource = resource_type(self.client, resource_id)
+            if parent_id is not None:
+                resource = resource_type(
+                    self.client, resource_id, parent_id=parent_id
+                )
+            else:
+                resource = resource_type(self.client, resource_id)
             resource._api_get()
             return resource
         except Exception as exception:

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list SSH keys in their Linode profile."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Dict, Optional
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    construct_api_filter,
+    get_all_paginated,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+
+spec_filter = {
+    "name": SpecField(
+        type=FieldType.string,
+        required=True,
+        description=[
+            "The name of the field to filter on.",
+        ],
+    ),
+    "values": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        required=True,
+        description=[
+            "A list of values to allow for this field.",
+            "Fields will pass this filter if at least one of these values matches.",
+        ],
+    ),
+}
+
+
+class ListModuleBase(LinodeModuleBase):
+    """Module for getting a list of SSH keys in the Linode profile"""
+
+    display_name = ""
+    result_field = ""
+    endpoint = ""
+    docs_url = ""
+    examples = []
+    response_samples = []
+
+    def __init__(self) -> None:
+        self.module_arg_spec = self.spec.ansible_spec
+        self.results: Dict[str, Any] = {self.result_field: []}
+
+        super().__init__(module_arg_spec=self.module_arg_spec)
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for list module"""
+
+        filter_dict = construct_api_filter(self.module.params)
+
+        self.results[self.result_field] = get_all_paginated(
+            self.client,
+            self.endpoint,
+            filter_dict,
+            num_results=self.module.params["count"],
+        )
+        return self.results
+
+    @classmethod
+    @property
+    def spec(cls):
+        return SpecDocMeta(
+            description=[f"List and filter on {cls.display_name}s."],
+            requirements=global_requirements,
+            author=global_authors,
+            options={
+                # Disable the default values
+                "state": SpecField(
+                    type=FieldType.string, required=False, doc_hide=True
+                ),
+                "label": SpecField(
+                    type=FieldType.string, required=False, doc_hide=True
+                ),
+                "order": SpecField(
+                    type=FieldType.string,
+                    description=[f"The order to list {cls.display_name}s in."],
+                    default="asc",
+                    choices=["desc", "asc"],
+                ),
+                "order_by": SpecField(
+                    type=FieldType.string,
+                    description=[
+                        f"The attribute to order {cls.display_name}s by."
+                    ],
+                ),
+                "filters": SpecField(
+                    type=FieldType.list,
+                    element_type=FieldType.dict,
+                    suboptions=spec_filter,
+                    description=[
+                        f"A list of filters to apply to the resulting {cls.display_name}s."
+                    ],
+                ),
+                "count": SpecField(
+                    type=FieldType.integer,
+                    description=[
+                        f"The number of {cls.display_name}s to return.",
+                        "If undefined, all results will be returned.",
+                    ],
+                ),
+            },
+            examples=cls.examples,
+            return_values={
+                cls.result_field: SpecReturnValue(
+                    description=f"The returned {cls.display_name}s.",
+                    docs_url=cls.docs_url,
+                    type=FieldType.list,
+                    elements=FieldType.dict,
+                    sample=cls.response_samples,
+                )
+            },
+        )

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -307,21 +307,31 @@ def poll_condition(
     )
 
 
-def get_resource_safe(list_func: Callable[[], List[Any]]):
+def get_resource_safe(list_func: Callable[[], List[Any]]) -> Any:
+    """
+    Wraps a resource list function with error handling.
+    If no entries are returned, this function returns None rather than
+    raising an error.
+    """
     try:
-        return list_func()[0]
-    except IndexError:
-        return None
+        list_results = list_func()
+        return None if len(list_results) < 1 else list_results[0]
     except Exception as exception:
-        raise Exception(f"failed to get resource: {exception}")
+        raise Exception(f"failed to get resource: {exception}") from exception
 
 
 def get_resource_safe_condition(
     list_func: Callable[[], List[Any]], condition_func: Callable[[Any], bool]
-):
+) -> Any:
+    """
+    Wraps a resource list function with error handling and checks the given
+    condition for each returned entry.
+    If no entries are returned, this function returns None rather than
+    raising an error.
+    """
+
     try:
-        return [v for v in list_func() if condition_func(v)][0]
-    except IndexError:
-        return None
+        list_results = [v for v in list_func() if condition_func(v)]
+        return None if len(list_results) < 1 else list_results[0]
     except Exception as exception:
-        raise Exception(f"failed to get resource: {exception}")
+        raise Exception(f"failed to get resource: {exception}") from exception

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -305,3 +305,23 @@ def poll_condition(
         step=step,
         timeout=timeout,
     )
+
+
+def get_resource_safe(list_func: Callable[[], List[Any]]):
+    try:
+        return list_func()[0]
+    except IndexError:
+        return None
+    except Exception as exception:
+        raise Exception(f"failed to get resource: {exception}")
+
+
+def get_resource_safe_condition(
+    list_func: Callable[[], List[Any]], condition_func: Callable[[Any], bool]
+):
+    try:
+        return [v for v in list_func() if condition_func(v)][0]
+    except IndexError:
+        return None
+    except Exception as exception:
+        raise Exception(f"failed to get resource: {exception}")

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Optional
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token as docs
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
     LinodeModuleBase,
 )
@@ -64,7 +64,7 @@ SPECDOC_META = SpecDocMeta(
             description="The VPC in JSON serialized form.",
             docs_url="TODO",
             type=FieldType.dict,
-            sample=docs.result_token_samples,
+            sample=docs.result_vpc_samples,
         )
     },
 )
@@ -95,7 +95,7 @@ class Module(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg="failed to create VPC: {0}".format(exception))
 
-    def _update(self, vpc: VPC):
+    def _update(self, vpc: VPC) -> None:
         handle_updates(
             vpc, self.module.params, MUTABLE_FIELDS, self.register_action
         )

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode VPCs."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    get_resource_safe,
+    handle_updates,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import VPC
+
+SPEC = {
+    "label": SpecField(
+        type=FieldType.string,
+        required=True,
+        description=["This VPC's unique label."],
+    ),
+    "state": SpecField(
+        type=FieldType.string,
+        choices=["present", "absent"],
+        required=True,
+        description=["The state of this token."],
+    ),
+    "description": SpecField(
+        type=FieldType.string,
+        default=None,
+        description=["A description describing this VPC."],
+    ),
+    "region": SpecField(
+        type=FieldType.string,
+        description=["The region this VPC is located in."],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=[
+        "Create, read, and update a Linode VPC.",
+    ],
+    requirements=global_requirements,
+    author=global_authors,
+    options=SPEC,
+    examples=docs.specdoc_examples,
+    return_values={
+        "vpc": SpecReturnValue(
+            description="The VPC in JSON serialized form.",
+            docs_url="TODO",
+            type=FieldType.dict,
+            sample=docs.result_token_samples,
+        )
+    },
+)
+
+CREATE_FIELDS = {"label", "region", "description"}
+MUTABLE_FIELDS = {"description"}
+
+
+class Module(LinodeModuleBase):
+    """Module for creating and destroying Linode VPCS"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.results = {"changed": False, "actions": [], "vpc": None}
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_if=[("state", "present", ["region"])],
+        )
+
+    def _create(self) -> Optional[VPC]:
+        params = filter_null_values(
+            {k: v for k, v in self.module.params.items() if k in CREATE_FIELDS}
+        )
+
+        try:
+            return self.client.vpcs.create(**params)
+        except Exception as exception:
+            return self.fail(msg="failed to create VPC: {0}".format(exception))
+
+    def _update(self, vpc: VPC):
+        handle_updates(
+            vpc, self.module.params, MUTABLE_FIELDS, self.register_action
+        )
+
+    def _handle_present(self) -> None:
+        params = self.module.params
+
+        vpc = get_resource_safe(
+            lambda: self.client.vpcs(VPC.label == params.get("label"))
+        )
+        if vpc is None:
+            vpc = self._create()
+            self.register_action("Created VPC {0}".format(vpc))
+
+        self._update(vpc)
+
+        # Force lazy-loading
+        vpc._api_get()
+
+        self.results["vpc"] = vpc._raw_json
+
+    def _handle_absent(self) -> None:
+        params = self.module.params
+        label = params.get("label")
+
+        vpc = get_resource_safe(lambda: self.client.vpcs(VPC.label == label))
+
+        if vpc is not None:
+            self.results["vpc"] = vpc._raw_json
+            vpc.delete()
+            self.register_action(f"Deleted VPC {label}")
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for token module"""
+        state = kwargs.get("state")
+
+        if state == "absent":
+            self._handle_absent()
+            return self.results
+
+        self._handle_present()
+
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the Linode VPC module"""
+    Module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vpc_info.py
+++ b/plugins/modules/vpc_info.py
@@ -50,5 +50,7 @@ module = InfoModule(
     examples=docs.specdoc_examples,
 )
 
+SPECDOC_META = module.spec
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_info.py
+++ b/plugins/modules/vpc_info.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode VPC."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    get_resource_safe,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import VPC
+
+spec = {
+    # Disable the default values
+    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
+    "id": SpecField(
+        type=FieldType.integer,
+        description=["The ID of the VPC."],
+        conflicts_with=["label"],
+    ),
+    "label": SpecField(
+        type=FieldType.string,
+        description=["The label of the VPC."],
+        conflicts_with=["id"],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Get info about a Linode VPC."],
+    requirements=global_requirements,
+    author=global_authors,
+    options=spec,
+    examples=docs.specdoc_examples,
+    return_values={
+        "vpc": SpecReturnValue(
+            description="The VPC in JSON serialized form.",
+            docs_url="TODO",
+            type=FieldType.dict,
+            sample=docs_parent.result_vpc_samples,
+        )
+    },
+)
+
+
+class Module(LinodeModuleBase):
+    """Module for getting info about a Linode VPC"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.results = {"vpc": None}
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_one_of=[("id", "label")],
+            mutually_exclusive=[("id", "label")],
+        )
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for token info module"""
+
+        params = filter_null_values(self.module.params)
+        vpc = None
+
+        if "id" in params:
+            vpc = self._get_resource_by_id(VPC, params.get("id"))
+        elif "label" in params:
+            label = params.get("label")
+            vpc = get_resource_safe(
+                lambda: self.client.vpcs(VPC.label == label)
+            )
+
+        if vpc is None:
+            raise ValueError("Could not find VPC with the provided information")
+
+        self.results["vpc"] = vpc._raw_json
+
+        return self.results
+
+
+if __name__ == "__main__":
+    Module()

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode VPCs."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModuleBase,
+)
+
+
+class ListModule(ListModuleBase):
+    display_name = "VPC"
+    result_field = "vpcs"
+    endpoint = "/vpcs"
+    docs_url = "TODO"
+
+
+SPECDOC_META = ListModule.spec
+
+if __name__ == "__main__":
+    ListModule()

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -1,20 +1,27 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module contains all of the functionality for Linode VPCs."""
+"""This module contains all of the functionality for listing Linode VPCs."""
 
 from __future__ import absolute_import, division, print_function
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModuleBase,
 )
 
 
 class ListModule(ListModuleBase):
+    """
+    Allows users to list VPCs that meet a set of filters.
+    """
+
     display_name = "VPC"
     result_field = "vpcs"
     endpoint = "/vpcs"
     docs_url = "TODO"
+    examples = docs.specdoc_examples
+    response_samples = docs.result_vpc_samples
 
 
 SPECDOC_META = ListModule.spec

--- a/plugins/modules/vpc_subnet.py
+++ b/plugins/modules/vpc_subnet.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Optional
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token as docs
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_subnet as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
     LinodeModuleBase,
 )
@@ -65,7 +65,7 @@ SPECDOC_META = SpecDocMeta(
             description="The VPC in JSON serialized form.",
             docs_url="TODO",
             type=FieldType.dict,
-            sample=docs.result_token_samples,
+            sample=docs.result_subnet_samples,
         )
     },
 )
@@ -94,7 +94,7 @@ class Module(LinodeModuleBase):
         except Exception as exception:
             return self.fail(msg="failed to create VPC: {0}".format(exception))
 
-    def _update(self, subnet: VPCSubnet):
+    def _update(self, subnet: VPCSubnet) -> None:
         # VPC Subnets cannot be updated
         handle_updates(subnet, self.module.params, set(), self.register_action)
 

--- a/plugins/modules/vpc_subnet_info.py
+++ b/plugins/modules/vpc_subnet_info.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode VPC Subnet."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_subnet as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_subnet_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    get_resource_safe_condition,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import VPC, VPCSubnet
+
+spec = {
+    # Disable the default values
+    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
+    "vpc_id": SpecField(
+        type=FieldType.integer,
+        description=["The ID of the VPC."],
+        required=True,
+    ),
+    "label": SpecField(
+        type=FieldType.string,
+        description=["The label of the VPC."],
+        conflicts_with=["id"],
+    ),
+    "id": SpecField(
+        type=FieldType.integer,
+        description=["The ID of the VPC."],
+        conflicts_with=["label"],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Get info about a Linode VPC Subnet."],
+    requirements=global_requirements,
+    author=global_authors,
+    options=spec,
+    examples=docs.specdoc_examples,
+    return_values={
+        "subnet": SpecReturnValue(
+            description="The VPC Subnet in JSON serialized form.",
+            docs_url="TODO",
+            type=FieldType.dict,
+            sample=docs_parent.result_subnet_samples,
+        )
+    },
+)
+
+
+class Module(LinodeModuleBase):
+    """Module for getting info about a Linode VPC"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.results = {"subnet": None}
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_one_of=[("id", "label")],
+            mutually_exclusive=[("id", "label")],
+        )
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for token info module"""
+
+        params = filter_null_values(self.module.params)
+        subnet = None
+
+        if "id" in params:
+            subnet = self._get_resource_by_id(
+                VPCSubnet, params.get("id"), parent_id=params.get("vpc_id")
+            )
+        elif "label" in params:
+            subnet = get_resource_safe_condition(
+                lambda: VPC(self.client, params.get("vpc_id")).subnets,
+                lambda v: v.label == params.get("label"),
+            )
+
+        if subnet is None:
+            raise ValueError(
+                "Could not find VPC Subnet with the provided information"
+            )
+
+        self.results["subnet"] = subnet._raw_json
+
+        return self.results
+
+
+if __name__ == "__main__":
+    Module()

--- a/plugins/modules/vpc_subnet_info.py
+++ b/plugins/modules/vpc_subnet_info.py
@@ -71,5 +71,7 @@ module = InfoModule(
     examples=docs.specdoc_examples,
 )
 
+SPECDOC_META = module.spec
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet_list.py
+++ b/plugins/modules/vpc_subnet_list.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains the functionality for listing subnets under a VPC."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_subnet_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModuleBase,
+    ListModuleParent,
+)
+from ansible_specdoc.objects import FieldType
+
+
+class ListModule(ListModuleBase):
+    """
+    Allows users to list subnets under a given VPC.
+    """
+
+    display_name = "VPC Subnet"
+    result_field = "subnets"
+    endpoint = "/vpcs/{vpc_id}/subnets"
+    docs_url = "TODO"
+    parents = [ListModuleParent("vpc_id", "VPC", FieldType.integer)]
+    examples = docs.specdoc_examples
+    response_samples = docs.result_vpc_samples
+
+
+SPECDOC_META = ListModule.spec
+
+if __name__ == "__main__":
+    ListModule()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-linode-api4>=5.7.2
+# TODO: Revert once VPC support is released in linode_api4
+# linode-api4>=5.7.2
+git+https://github.com/linode/linode_api4-python@proj/vpc
 polling>=0.3.2
 types-requests==2.31.0.2
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -63,4 +63,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -63,3 +63,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -25,4 +25,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -25,3 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -95,4 +95,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -95,3 +95,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -72,3 +72,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -72,4 +72,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -245,3 +245,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -245,4 +245,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -60,3 +60,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -60,4 +60,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -43,3 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -43,4 +43,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -283,3 +283,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -283,4 +283,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -75,4 +75,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -75,3 +75,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -91,4 +91,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -91,3 +91,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -64,3 +64,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -64,4 +64,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -887,3 +887,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -887,4 +887,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -94,3 +94,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -94,4 +94,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -43,3 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -43,4 +43,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -39,3 +39,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -39,4 +39,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -156,3 +156,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -156,4 +156,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -59,3 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -59,4 +59,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -224,4 +224,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -224,3 +224,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -113,4 +113,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -113,3 +113,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -89,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -89,4 +89,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -63,4 +63,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -63,3 +63,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -41,3 +41,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -41,4 +41,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -27,3 +27,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -27,4 +27,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -25,4 +25,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -25,3 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -34,3 +34,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -34,4 +34,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -52,3 +52,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
+

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -52,5 +52,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
 

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -93,3 +93,4 @@
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -93,4 +93,3 @@
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -53,3 +53,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -53,4 +53,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -149,4 +149,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -149,3 +149,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -67,4 +67,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -67,3 +67,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -98,4 +98,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -98,3 +98,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -13,3 +13,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -13,4 +13,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -137,3 +137,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -137,4 +137,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -84,3 +84,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -84,4 +84,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -112,3 +112,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -112,4 +112,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -58,3 +58,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -58,4 +58,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -126,4 +126,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -126,3 +126,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -325,3 +325,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -325,4 +325,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -114,3 +114,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
+

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -114,5 +114,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
 

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -126,4 +126,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -126,3 +126,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -25,4 +25,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -25,3 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -104,3 +104,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -104,4 +104,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -86,3 +86,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -86,4 +86,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -13,3 +13,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -13,4 +13,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -25,4 +25,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -25,3 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -44,3 +44,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -44,4 +44,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -60,3 +60,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -60,4 +60,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -54,3 +54,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -54,4 +54,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -42,3 +42,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -42,4 +42,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -40,3 +40,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -40,4 +40,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -44,3 +44,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -44,4 +44,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -54,3 +54,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -54,4 +54,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -21,4 +21,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -21,3 +21,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -42,3 +42,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -42,4 +42,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -89,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -89,4 +89,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -37,3 +37,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -37,4 +37,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -59,3 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -59,4 +59,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -53,3 +53,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -53,4 +53,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -278,4 +278,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -278,3 +278,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -59,3 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -59,4 +59,3 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -89,4 +89,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+
+    # Temporary testing override; remove before merge to dev
     REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -89,4 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '...' # Temporary override for testing overrides
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -52,6 +52,29 @@
         filters:
           - name: label
             values: '{{ no_update_vpc.vpc.label }}'
+      register: list_vpc
+
+    - name: Assert VPC is returned
+      assert:
+        that:
+          - list_vpc.vpcs[0].id == create_vpc.vpc.id
+
+    - name: Get information about the VPC by ID
+      linode.cloud.vpc_info:
+        id: '{{ create_vpc.vpc.id }}'
+      register: vpc_info_id
+
+    - name: Get information about the VPC by label
+      linode.cloud.vpc_info:
+        label: '{{ create_vpc.vpc.label }}'
+      register: vpc_info_label
+
+    - name: Assert results
+      assert:
+        that:
+          - vpc_info_id.vpc.id == create_vpc.vpc.id
+          - vpc_info_id.vpc.id == vpc_info_label.vpc.id
+
   always:
     - ignore_errors: yes
       block:
@@ -66,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '...' # Temporary override for testing overrides

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -46,6 +46,12 @@
       assert:
         that:
           - no_update_vpc.changed == False
+
+    - name: List VPCs
+      linode.cloud.vpc_list:
+        filters:
+          - name: label
+            values: '{{ no_update_vpc.vpc.label }}'
   always:
     - ignore_errors: yes
       block:

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -1,0 +1,63 @@
+- name: vpc_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'us-east'
+          - create_vpc.vpc.description == 'test description'
+
+    - name: Update the VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        description: test description updated
+        state: present
+      register: update_vpc
+
+    - name: Assert VPC updated
+      assert:
+        that:
+          - create_vpc.changed
+          - update_vpc.vpc.id == create_vpc.vpc.id
+          - update_vpc.vpc.description == 'test description updated'
+
+    - name: Don't update the VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        description: test description updated
+        state: present
+      register: no_update_vpc
+
+    - name: Assert VPC not updated
+      assert:
+        that:
+          - no_update_vpc.changed == False
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.instance.label }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '/Users/lgarber/Projects/dx-devenv/repos/ansible_linode/ansible_collections/linode/cloud/cacert.pem'

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -89,4 +89,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+
+    # Temporary testing override; remove before merge to dev
     REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -89,4 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '...' # Temporary override for testing overrides
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -19,36 +19,34 @@
           - create_vpc.vpc.region == 'us-east'
           - create_vpc.vpc.description == 'test description'
 
-    - name: Update the VPC
-      linode.cloud.vpc:
-        label: 'ansible-test-{{ r }}'
-        region: us-east
-        description: test description updated
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet'
+        ipv4: '10.0.0.0/24'
         state: present
-      register: update_vpc
+      register: create_subnet
 
-    - name: Assert VPC updated
+    - name: Assert Subnet created
       assert:
         that:
-          - create_vpc.changed
-          - update_vpc.vpc.id == create_vpc.vpc.id
-          - update_vpc.vpc.description == 'test description updated'
+          - create_subnet.changed
+          - create_subnet.subnet.label == 'test-subnet'
+          - create_subnet.subnet.ipv4 == '10.0.0.0/24'
+          - create_subnet.subnet.created != None
+          - create_subnet.subnet.updated != None
+          - create_subnet.subnet.linodes | length == 0
 
-    - name: Don't update the VPC
-      linode.cloud.vpc:
-        label: 'ansible-test-{{ r }}'
-        region: us-east
-        description: test description updated
-        state: present
-      register: no_update_vpc
-
-    - name: Assert VPC not updated
-      assert:
-        that:
-          - no_update_vpc.changed == False
   always:
     - ignore_errors: yes
       block:
+        - name: Delete a subnet
+          linode.cloud.vpc_subnet:
+            vpc_id: '{{ create_vpc.vpc.id }}'
+            label: 'test-subnet'
+            state: absent
+          register: delete_subnet
+
         - name: Delete a VPC
           linode.cloud.vpc:
             label: '{{ create_vpc.vpc.label }}'

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -37,6 +37,37 @@
           - create_subnet.subnet.updated != None
           - create_subnet.subnet.linodes | length == 0
 
+    - name: List Subnets
+      linode.cloud.vpc_subnet_list:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        filters:
+          - name: label
+            values: '{{ create_subnet.subnet.label }}'
+      register: list_subnets
+
+    - name: Assert Subnets
+      assert:
+        that:
+          - list_subnets.subnets[0].id == create_subnet.subnet.id
+
+    - name: Get information about the Subnet by ID
+      linode.cloud.vpc_subnet_info:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        id: '{{ create_subnet.subnet.id }}'
+      register: subnet_info_id
+
+    - name: Get information about the Subnet by label
+      linode.cloud.vpc_subnet_info:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: '{{ create_subnet.subnet.label }}'
+      register: subnet_info_label
+
+    - name: Assert results
+      assert:
+        that:
+          - subnet_info_label.subnet.id == create_subnet.subnet.id
+          - subnet_info_label.subnet.id == subnet_info_id.subnet.id
+
   always:
     - ignore_errors: yes
       block:
@@ -58,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '...' # Temporary override for testing overrides


### PR DESCRIPTION
This change adds modules for the VPC and VPCSubnet API objects, as well as a new `ListModuleBase` helper class to significantly reduce the amount of boilerplate needed when creating list modules. In the future we could likely implement something similar for info modules.

This PR does **not** include the corresponding interface-related changes.

In order to test this change, you will need to install `linode_api4-python` from the [proj/vpc](https://github.com/linode/linode_api4-python/tree/proj/vpc) branch.

New modules:
- `vpc`
- `vpc_info`
- `vpc_list`
- `vpc_subnet`
- `vpc_subnet_info`
- `vpc_subnet_list`

```
export TEST_API_URL=https://...
export TEST_CA_FILE=...

make TEST_ARGS="-v vpc_basic" test
make TEST_ARGS="-v vpc_subnet" test
```
