### PR TITLE
Implement changes for DC-specific pricing

### DIFF
--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -59,7 +59,7 @@ List and filter on Linode Instance Types.
                       "monthly": 20
                     },
                     {
-                      "id": "ap-northeast",
+                  	  "id": "ap-northeast",
                       "hourly": 0.02,
                       "monthly": 20
                     }

--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -51,9 +51,33 @@ List and filter on Linode Instance Types.
                   "price": {
                     "hourly": 0.008,
                     "monthly": 5
-                  }
+                  },
+                  "region_prices": [
+                    {
+                      "id": "ap-west",
+                      "hourly": 0.02,
+                      "monthly": 20
+                    },
+                    {
+                      "id": "ap-northeast",
+                      "hourly": 0.02,
+                      "monthly": 20
+                    }
+                  ]
                 }
               },
+              "region_prices": [
+                {
+                  "id": "ap-west",
+                  "hourly": 0.02,
+                  "monthly": 20
+                },
+                {
+                  "id": "ap-northeast",
+                  "hourly": 0.02,
+                  "monthly": 20
+                }
+              ],
               "class": "standard",
               "disk": 81920,
               "gpus": 0,

--- a/plugins/module_utils/doc_fragments/instance_type_list.py
+++ b/plugins/module_utils/doc_fragments/instance_type_list.py
@@ -16,9 +16,33 @@ result_instance_type_samples = ['''[
           "price": {
             "hourly": 0.008,
             "monthly": 5
-          }
+          },
+          "region_prices": [
+            {
+              "id": "ap-west",
+              "hourly": 0.02,
+              "monthly": 20
+            },
+            {
+          	  "id": "ap-northeast",
+              "hourly": 0.02,
+              "monthly": 20
+            }
+          ]
         }
       },
+      "region_prices": [
+        {
+          "id": "ap-west",
+          "hourly": 0.02,
+          "monthly": 20
+        },
+        {
+          "id": "ap-northeast",
+          "hourly": 0.02,
+          "monthly": 20
+        }
+      ],
       "class": "standard",
       "disk": 81920,
       "gpus": 0,

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -19,6 +19,7 @@
         that:
           - filter.instance_types | length >= 1
           - filter.instance_types[0].class == 'nanode'
+          - filter.instance_types[0].region_prices | length >= 1
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'


### PR DESCRIPTION
## 📝 Description

Adds DC-specific pricing language to doc fragments for instance_type_list module.

## ✔️ How to Test

In order to test this change, you will need to install linode_api4-python from the [proj/dc-specific-pricing](https://github.com/linode/linode_api4-python/tree/proj/dc-specific-pricing) branch.