### PR TITLE
new: Support VPC interfaces in the `linode.cloud.instance` module

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -232,9 +232,13 @@ Manage Linode Instances, Configs, and Disks.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `purpose` | <center>`str`</center> | <center>**Required**</center> | The type of interface.  **(Choices: `public`, `vlan`)** |
+| `purpose` | <center>`str`</center> | <center>**Required**</center> | The type of interface.  **(Choices: `public`, `vlan`, `vpc`)** |
+| `primary` | <center>`bool`</center> | <center>Optional</center> | Whether this is a primary interface  **(Default: `False`)** |
+| `subnet_id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC subnet to assign this interface to.   |
+| `ipv4` | <center>`dict`</center> | <center>Optional</center> | The IPv4 configuration for this interface. (VPC only)   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The name of this interface. Required for vlan purpose interfaces. Must be an empty string or null for public purpose interfaces.   |
 | `ipam_address` | <center>`str`</center> | <center>Optional</center> | This Network Interface’s private IP address in Classless Inter-Domain Routing (CIDR) notation.   |
+| `ip_ranges` | <center>`list`</center> | <center>Optional</center> | Packets to these CIDR ranges are routed to the VPC network interface. (VPC only)   |
 
 ### disks
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -1,5 +1,5 @@
 """This module contains helper functions for various Linode modules."""
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
 import linode_api4
 import polling
@@ -40,13 +40,24 @@ def filter_null_values(input_dict: dict) -> dict:
     }
 
 
-def drop_empty_strings(input_dict: dict) -> dict:
+def drop_empty_strings(value: Union[dict], recursive=False) -> any:
     """Returns a copy of the given dict with all keys containing null and empty values removed"""
-    return {
-        key: value
-        for key, value in input_dict.items()
-        if value is not None and value != ""
-    }
+
+    if isinstance(value, dict):
+        result = {}
+
+        for key, item in value.items():
+            if item is None or item == "":
+                continue
+
+            if recursive:
+                result[key] = drop_empty_strings(item, recursive=recursive)
+            else:
+                result[key] = item
+
+        return result
+
+    return value
 
 
 def paginated_list_to_json(target_list: list) -> list:

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
+import json
 from typing import Any, Dict, List, Optional, Union, cast
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs
@@ -157,12 +158,40 @@ linode_instance_helpers_spec = {
     ),
 }
 
+linode_instance_interface_ipv4_spec = {
+    "vpc": SpecField(
+        type=FieldType.string,
+        default=None,
+        description=["The IP from the VPC subnet to use for this interface."],
+    ),
+    "nat_1_1": SpecField(
+        type=FieldType.string,
+        description=[
+            "The public IPv4 address assigned to the Linode "
+            "will be 1:1 with the VPC IPv4 address."
+        ],
+    ),
+}
+
 linode_instance_interface_spec = {
     "purpose": SpecField(
         type=FieldType.string,
         required=True,
         description=["The type of interface."],
-        choices=["public", "vlan"],
+        choices=["public", "vlan", "vpc"],
+    ),
+    "primary": SpecField(
+        type=FieldType.bool,
+        default=False,
+        description=["Whether this is a primary interface"],
+    ),
+    "subnet_id": SpecField(
+        type=FieldType.integer,
+        description=["The ID of the VPC subnet to assign this interface to."],
+    ),
+    "ipv4": SpecField(
+        type=FieldType.dict,
+        description=["The IPv4 configuration for this interface. (VPC only)"],
     ),
     "label": SpecField(
         type=FieldType.string,
@@ -177,6 +206,13 @@ linode_instance_interface_spec = {
         description=[
             "This Network Interface’s private IP address in Classless "
             "Inter-Domain Routing (CIDR) notation."
+        ],
+    ),
+    "ip_ranges": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        description=[
+            "Packets to these CIDR ranges are routed to the VPC network interface. (VPC only)"
         ],
     ),
 }
@@ -570,18 +606,6 @@ class LinodeInstance(LinodeModuleBase):
 
         return {id_key: device.id}
 
-    @staticmethod
-    def _filter_remote_interface(interface: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        This method serves as a temporary workaround for a
-        known API quirk that causes null IPAM addresses to be
-        returned as 222.
-        """
-        if interface["ipam_address"] == "222":
-            del interface["ipam_address"]
-
-        return interface
-
     def _compare_param_to_device(
         self, device_param: Dict[str, Any], device: Union[Disk, Volume]
     ) -> bool:
@@ -601,6 +625,54 @@ class LinodeInstance(LinodeModuleBase):
         return filter_null_values(device_mapping) == filter_null_values(
             device_param
         )
+
+    @staticmethod
+    def _normalize_local_interface(
+        local_interface: Dict[str, Any], remote_interface: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Normalizes the given param interface to the remote interface
+        for direct comparison.
+        """
+        result = copy.deepcopy(local_interface)
+
+        # The IPv4 field will be implicitly populated if is not defined
+        if "ipv4" not in local_interface and "ipv4" in remote_interface:
+            result["ipv4"] = remote_interface.get("ipv4")
+
+        # Primary is only allowed for public and VPC purposes, so we
+        # should implicitly populate a default
+        if (
+            local_interface.get("purpose") in ("public", "vpc")
+            and "primary" not in local_interface
+        ):
+            result["primary"] = False
+
+        return result
+
+    @staticmethod
+    def _compare_interfaces(
+        local_interfaces: List[Dict[str, Any]],
+        remote_interfaces: List[Dict[str, Any]],
+    ) -> bool:
+        """
+        Returns whether the two interface lists match
+        """
+        # Lengths are different, return immediately
+        if len(local_interfaces) != len(remote_interfaces):
+            return False
+
+        for i, local_interface in enumerate(local_interfaces):
+            remote_interface = remote_interfaces[i]
+            if (
+                LinodeInstance._normalize_local_interface(
+                    local_interface, remote_interface
+                )
+                != remote_interfaces[i]
+            ):
+                return False
+
+        return True
 
     def _create_instance(self) -> dict:
         """Creates a Linode instance"""
@@ -712,16 +784,24 @@ class LinodeInstance(LinodeModuleBase):
         if config is None or param_interfaces is None:
             return
 
-        param_interfaces = [drop_empty_strings(v) for v in param_interfaces]
+        param_interfaces = [
+            drop_empty_strings(v, recursive=True) for v in param_interfaces
+        ]
+
         remote_interfaces = [
-            drop_empty_strings(self._filter_remote_interface(v._serialize()))
+            drop_empty_strings(v._serialize(), recursive=True)
             for v in config.interfaces
         ]
 
-        if remote_interfaces == param_interfaces:
+        if self._compare_interfaces(param_interfaces, remote_interfaces):
             return
 
+        # TODO: Remove when related bug is fixed
+        config.interfaces = []
+        config.save()
+
         config.interfaces = [ConfigInterface(**v) for v in param_interfaces]
+
         config.save()
 
         self.register_action(
@@ -746,15 +826,23 @@ class LinodeInstance(LinodeModuleBase):
             if key == "interfaces":
                 old_value = filter_null_values_recursive(
                     [
-                        drop_empty_strings(
-                            self._filter_remote_interface(v._serialize())
-                        )
+                        drop_empty_strings(v._serialize(), recursive=True)
                         for v in old_value
                     ]
                 )
                 new_value = filter_null_values_recursive(
-                    [drop_empty_strings(v) for v in new_value]
+                    [drop_empty_strings(v, recursive=True) for v in new_value]
                 )
+
+                if not self._compare_interfaces(new_value, old_value):
+                    should_update = True
+                    config.interfaces = new_value
+                    self.register_action(
+                        f"Updated Interfaces for Config {config.id}: "
+                        f"{json.dumps(old_value)} -> {json.dumps(new_value)}"
+                    )
+
+                continue
 
             # Special diffing due to handling in linode_api4-python
             if key == "devices":
@@ -788,6 +876,13 @@ class LinodeInstance(LinodeModuleBase):
                 )
 
         if should_update:
+            # TODO: Hack to work around know bug; remove before release
+            old_interfaces = config.interfaces
+            config.interfaces = []
+            config.save()
+
+            config.interfaces = old_interfaces
+
             config.save()
 
     def _update_configs(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ disable = [
     "missing-timeout",
     "use-sequence-for-iteration",
     "broad-exception-raised",
+    "fixme" # Temporary "TODO" ignore
 ]
 py-version = "3.8"
 extension-pkg-whitelist = "math"

--- a/tests/integration/targets/instance_config_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vpc/tasks/main.yaml
@@ -1,0 +1,161 @@
+- name: instance_config_vpc
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet'
+        ipv4: '10.0.0.0/24'
+        state: present
+      register: create_subnet
+
+    - name: Create a Linode instance with interface
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: vpc
+                subnet_id: '{{ create_subnet.subnet.id }}'
+                primary: true
+                ipv4:
+                  vpc: 10.0.0.3
+                  nat_1_1: any
+                ip_ranges: [ "10.0.0.5/32" ]
+        wait: false
+        booted: false
+        state: present
+      register: create_instance
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create_instance.changed
+
+          - create_instance.configs[0].interfaces[0].purpose == 'vpc'
+          - create_instance.configs[0].interfaces[0].subnet_id == create_subnet.subnet.id
+          - create_instance.configs[0].interfaces[0].vpc_id == create_vpc.vpc.id
+          - create_instance.configs[0].interfaces[0].ip_ranges[0] == '10.0.0.5/32'
+          - create_instance.configs[0].interfaces[0].ipv4.nat_1_1 == create_instance.instance.ipv4[0]
+          - create_instance.configs[0].interfaces[0].ipv4.vpc == '10.0.0.3'
+
+    - name: Update the config interfaces
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: public
+                primary: true
+              - purpose: vpc
+                subnet_id: '{{ create_subnet.subnet.id }}'
+                ipv4:
+                  vpc: 10.0.0.4
+                ip_ranges: [ "10.0.0.7/32" ]
+        wait: false
+        booted: false
+        state: present
+      register: update_instance
+
+    - name: Assert instance updated
+      assert:
+        that:
+          - update_instance.changed
+
+          - update_instance.configs[0].interfaces[0].purpose == 'public'
+          - update_instance.configs[0].interfaces[0].primary
+
+          - update_instance.configs[0].interfaces[1].purpose == 'vpc'
+          - update_instance.configs[0].interfaces[1].subnet_id == create_subnet.subnet.id
+          - update_instance.configs[0].interfaces[1].vpc_id == create_vpc.vpc.id
+          - update_instance.configs[0].interfaces[1].ip_ranges[0] == '10.0.0.7/32'
+          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == ""
+          - update_instance.configs[0].interfaces[1].ipv4.vpc == '10.0.0.4'
+
+    - name: Don't change the config interfaces
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 10
+        configs:
+          - label: cool-config
+            devices:
+              sda:
+                disk_label: test-disk
+            interfaces:
+              - purpose: public
+                primary: true
+              - purpose: vpc
+                subnet_id: '{{ create_subnet.subnet.id }}'
+                ipv4:
+                  vpc: 10.0.0.4
+                ip_ranges: [ "10.0.0.7/32" ]
+        wait: false
+        booted: false
+        state: present
+      register: unchanged_instance
+
+    - name: Assert unchanged
+      assert:
+        that:
+          - unchanged_instance.changed == False
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_instance.instance.label }}'
+            state: absent
+          register: delete_instance
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create_instance.instance.id
+
+        - name: Delete the VPC
+          linode.cloud.vpc:
+            label: 'ansible-test-{{ r }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -1,0 +1,133 @@
+- name: instance_interfaces
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet'
+        ipv4: '10.0.0.0/24'
+        state: present
+      register: create_subnet
+
+    - name: Create a Linode instance with interface
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu22.04
+        interfaces:
+          - purpose: vpc
+            subnet_id: '{{ create_subnet.subnet.id }}'
+            primary: true
+            ipv4:
+              vpc: 10.0.0.3
+              nat_1_1: any
+            ip_ranges: ["10.0.0.5/32"]
+        wait: false
+        state: present
+      register: create_instance
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create_instance.changed
+
+          - create_instance.configs[0].interfaces[0].purpose == 'vpc'
+          - create_instance.configs[0].interfaces[0].subnet_id == create_subnet.subnet.id
+          - create_instance.configs[0].interfaces[0].vpc_id == create_vpc.vpc.id
+          - create_instance.configs[0].interfaces[0].ip_ranges[0] == '10.0.0.5/32'
+          - create_instance.configs[0].interfaces[0].ipv4.nat_1_1 == create_instance.instance.ipv4[0]
+          - create_instance.configs[0].interfaces[0].ipv4.vpc == '10.0.0.3'
+
+    - name: Update the instance interfaces
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu22.04
+        interfaces:
+          - purpose: public
+            primary: true
+          - purpose: vpc
+            subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4:
+              vpc: 10.0.0.4
+            ip_ranges: ["10.0.0.7/32"]
+        wait: false
+        state: present
+      register: update_instance
+
+    - name: Assert instance updated
+      assert:
+        that:
+          - update_instance.changed
+
+          - update_instance.configs[0].interfaces[0].purpose == 'public'
+          - update_instance.configs[0].interfaces[0].primary
+
+          - update_instance.configs[0].interfaces[1].purpose == 'vpc'
+          - update_instance.configs[0].interfaces[1].subnet_id == create_subnet.subnet.id
+          - update_instance.configs[0].interfaces[1].vpc_id == create_vpc.vpc.id
+          - update_instance.configs[0].interfaces[1].ip_ranges[0] == '10.0.0.7/32'
+          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == ""
+          - update_instance.configs[0].interfaces[1].ipv4.vpc == '10.0.0.4'
+
+    - name: Unchanged instance interface
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        image: linode/ubuntu22.04
+        interfaces:
+          - purpose: public
+            primary: true
+          - purpose: vpc
+            subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4:
+              vpc: 10.0.0.4
+            ip_ranges: ["10.0.0.7/32"]
+        wait: false
+        state: present
+      register: unchanged_instance
+
+    - assert:
+        that:
+          - unchanged_instance.changed == False
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_instance.instance.label }}'
+            state: absent
+          register: delete_instance
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create_instance.instance.id
+
+        - name: Delete the VPC
+          linode.cloud.vpc:
+            label: 'ansible-test-{{ r }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'


### PR DESCRIPTION
## 📝 Description

This change adds support for creating an managing VPC interfaces in the `linode.cloud.instance` module.

[Relevant Changes](https://github.com/linode/ansible_linode/pull/408/files/22eb435d1e03c760ca9c438374beb42635507ae4..24f55901eaba2f94dd898c9795c890c2771695cc)

This change relies on #404.

## ✔️ How to Test

NOTE: Before running tests, ensure you have installed the [linode_api4 `proj/vpc`](https://github.com/linode/linode_api4-python/tree/proj/vpc) branch in your local Python environment.

```
export TEST_API_URL=https://...
export TEST_CA_FILE=$PWD/...
export LINODE_TOKEN=...

make TEST_ARGS="-v instance_config_vpc" test
make TEST_ARGS="-v instance_interfaces_vpc" test
```
