### PR TITLE
new: Add InfoModule class to simplify info module implementations

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,9 +8,14 @@ name: Run Unit test
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/linode/cloud
     steps:
       - name: checkout repo
         uses: actions/checkout@v3
+        with:
+          path: .ansible/collections/ansible_collections/linode/cloud
 
       - name: update packages
         run: sudo apt-get update -y

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tmp
 __pycache__/
 galaxy.yml
 venv
+collections
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ testall: create-integration-config
 	./scripts/test_all.sh
 
 unittest:
-	python -m pytest tests/unit/
+	ansible-test units --target-python default
 
 create-integration-config:
 ifneq ("${LINODE_TOKEN}", "")

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -156,62 +156,13 @@ Get info about a Linode Instance.
         ```json
         [
           {
-            "comments": "This is my main Config",
-            "devices": {
-              "sda": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdb": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdc": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdd": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sde": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdf": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdg": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdh": {
-                "disk_id": 124458,
-                "volume_id": null
-              }
-            },
-            "helpers": {
-              "devtmpfs_automount": false,
-              "distro": true,
-              "modules_dep": true,
-              "network": true,
-              "updatedb_disabled": true
-            },
-            "id": 23456,
-            "interfaces": [
-              {
-                "ipam_address": "10.0.0.1/24",
-                "label": "example-interface",
-                "purpose": "vlan"
-              }
-            ],
-            "kernel": "linode/latest-64bit",
-            "label": "My Config",
-            "memory_limit": 2048,
-            "root_device": "/dev/sda",
-            "run_level": "default",
-            "virt_mode": "paravirt"
+            "created": "2018-01-01T00:01:01",
+            "filesystem": "ext4",
+            "id": 25674,
+            "label": "Debian 9 Disk",
+            "size": 48640,
+            "status": "ready",
+            "updated": "2018-01-01T00:01:01"
           }
         ]
         ```
@@ -222,66 +173,93 @@ Get info about a Linode Instance.
 
     - Sample Response:
         ```json
-        [
-          {
-            "comments": "This is my main Config",
-            "devices": {
-              "sda": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdb": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdc": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdd": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sde": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdf": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdg": {
-                "disk_id": 124458,
-                "volume_id": null
-              },
-              "sdh": {
-                "disk_id": 124458,
-                "volume_id": null
-              }
-            },
-            "helpers": {
-              "devtmpfs_automount": false,
-              "distro": true,
-              "modules_dep": true,
-              "network": true,
-              "updatedb_disabled": true
-            },
-            "id": 23456,
-            "interfaces": [
+        
+        {
+          "ipv4": {
+            "private": [
               {
-                "ipam_address": "10.0.0.1/24",
-                "label": "example-interface",
-                "purpose": "vlan"
+                "address": "192.168.133.234",
+                "gateway": null,
+                "linode_id": 123,
+                "prefix": 17,
+                "public": false,
+                "rdns": null,
+                "region": "us-east",
+                "subnet_mask": "255.255.128.0",
+                "type": "ipv4"
               }
             ],
-            "kernel": "linode/latest-64bit",
-            "label": "My Config",
-            "memory_limit": 2048,
-            "root_device": "/dev/sda",
-            "run_level": "default",
-            "virt_mode": "paravirt"
+            "public": [
+              {
+                "address": "97.107.143.141",
+                "gateway": "97.107.143.1",
+                "linode_id": 123,
+                "prefix": 24,
+                "public": true,
+                "rdns": "test.example.org",
+                "region": "us-east",
+                "subnet_mask": "255.255.255.0",
+                "type": "ipv4"
+              }
+            ],
+            "reserved": [
+              {
+                "address": "97.107.143.141",
+                "gateway": "97.107.143.1",
+                "linode_id": 123,
+                "prefix": 24,
+                "public": true,
+                "rdns": "test.example.org",
+                "region": "us-east",
+                "subnet_mask": "255.255.255.0",
+                "type": "ipv4"
+              }
+            ],
+            "shared": [
+              {
+                "address": "97.107.143.141",
+                "gateway": "97.107.143.1",
+                "linode_id": 123,
+                "prefix": 24,
+                "public": true,
+                "rdns": "test.example.org",
+                "region": "us-east",
+                "subnet_mask": "255.255.255.0",
+                "type": "ipv4"
+              }
+            ]
+          },
+          "ipv6": {
+            "global": {
+              "prefix": 124,
+              "range": "2600:3c01::2:5000:0",
+              "region": "us-east",
+              "route_target": "2600:3c01::2:5000:f"
+            },
+            "link_local": {
+              "address": "fe80::f03c:91ff:fe24:3a2f",
+              "gateway": "fe80::1",
+              "linode_id": 123,
+              "prefix": 64,
+              "public": false,
+              "rdns": null,
+              "region": "us-east",
+              "subnet_mask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "type": "ipv6"
+            },
+            "slaac": {
+              "address": "2600:3c03::f03c:91ff:fe24:3a2f",
+              "gateway": "fe80::1",
+              "linode_id": 123,
+              "prefix": 64,
+              "public": true,
+              "rdns": null,
+              "region": "us-east",
+              "subnet_mask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "type": "ipv6"
+            }
           }
-        ]
+        }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses) for a list of returned fields
 

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -25,12 +25,12 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`int`</center> | <center>Optional</center> | The unique ID of the instance. Optional if `label` is defined.  **(Conflicts With: `label`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The instance’s label. Optional if `id` is defined.  **(Conflicts With: `id`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Instance to resolve.   |
 
 ## Return Values
 
-- `instance` - The instance description in JSON serialized form.
+- `instance` - The returned Instance.
 
     - Sample Response:
         ```json
@@ -82,7 +82,7 @@ Get info about a Linode Instance.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linode-view__responses) for a list of returned fields
 
 
-- `configs` - A list of configs tied to this Linode Instance.
+- `configs` - The returned Configs.
 
     - Sample Response:
         ```json
@@ -150,116 +150,138 @@ Get info about a Linode Instance.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-view__responses) for a list of returned fields
 
 
-- `disks` - A list of disks tied to this Linode Instance.
+- `disks` - The returned Disks.
 
     - Sample Response:
         ```json
         [
           {
-            "created": "2018-01-01T00:01:01",
-            "filesystem": "ext4",
-            "id": 25674,
-            "label": "Debian 9 Disk",
-            "size": 48640,
-            "status": "ready",
-            "updated": "2018-01-01T00:01:01"
+            "comments": "This is my main Config",
+            "devices": {
+              "sda": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdb": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdc": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdd": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sde": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdf": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdg": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdh": {
+                "disk_id": 124458,
+                "volume_id": null
+              }
+            },
+            "helpers": {
+              "devtmpfs_automount": false,
+              "distro": true,
+              "modules_dep": true,
+              "network": true,
+              "updatedb_disabled": true
+            },
+            "id": 23456,
+            "interfaces": [
+              {
+                "ipam_address": "10.0.0.1/24",
+                "label": "example-interface",
+                "purpose": "vlan"
+              }
+            ],
+            "kernel": "linode/latest-64bit",
+            "label": "My Config",
+            "memory_limit": 2048,
+            "root_device": "/dev/sda",
+            "run_level": "default",
+            "virt_mode": "paravirt"
           }
         ]
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#disk-view__responses) for a list of returned fields
 
 
-- `networking` - Networking information about this Linode Instance.
+- `networking` - The returned Networking Configuration.
 
     - Sample Response:
         ```json
-        
-        {
-          "ipv4": {
-            "private": [
-              {
-                "address": "192.168.133.234",
-                "gateway": null,
-                "linode_id": 123,
-                "prefix": 17,
-                "public": false,
-                "rdns": null,
-                "region": "us-east",
-                "subnet_mask": "255.255.128.0",
-                "type": "ipv4"
+        [
+          {
+            "comments": "This is my main Config",
+            "devices": {
+              "sda": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdb": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdc": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdd": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sde": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdf": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdg": {
+                "disk_id": 124458,
+                "volume_id": null
+              },
+              "sdh": {
+                "disk_id": 124458,
+                "volume_id": null
               }
-            ],
-            "public": [
-              {
-                "address": "97.107.143.141",
-                "gateway": "97.107.143.1",
-                "linode_id": 123,
-                "prefix": 24,
-                "public": true,
-                "rdns": "test.example.org",
-                "region": "us-east",
-                "subnet_mask": "255.255.255.0",
-                "type": "ipv4"
-              }
-            ],
-            "reserved": [
-              {
-                "address": "97.107.143.141",
-                "gateway": "97.107.143.1",
-                "linode_id": 123,
-                "prefix": 24,
-                "public": true,
-                "rdns": "test.example.org",
-                "region": "us-east",
-                "subnet_mask": "255.255.255.0",
-                "type": "ipv4"
-              }
-            ],
-            "shared": [
-              {
-                "address": "97.107.143.141",
-                "gateway": "97.107.143.1",
-                "linode_id": 123,
-                "prefix": 24,
-                "public": true,
-                "rdns": "test.example.org",
-                "region": "us-east",
-                "subnet_mask": "255.255.255.0",
-                "type": "ipv4"
-              }
-            ]
-          },
-          "ipv6": {
-            "global": {
-              "prefix": 124,
-              "range": "2600:3c01::2:5000:0",
-              "region": "us-east",
-              "route_target": "2600:3c01::2:5000:f"
             },
-            "link_local": {
-              "address": "fe80::f03c:91ff:fe24:3a2f",
-              "gateway": "fe80::1",
-              "linode_id": 123,
-              "prefix": 64,
-              "public": false,
-              "rdns": null,
-              "region": "us-east",
-              "subnet_mask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-              "type": "ipv6"
+            "helpers": {
+              "devtmpfs_automount": false,
+              "distro": true,
+              "modules_dep": true,
+              "network": true,
+              "updatedb_disabled": true
             },
-            "slaac": {
-              "address": "2600:3c03::f03c:91ff:fe24:3a2f",
-              "gateway": "fe80::1",
-              "linode_id": 123,
-              "prefix": 64,
-              "public": true,
-              "rdns": null,
-              "region": "us-east",
-              "subnet_mask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-              "type": "ipv6"
-            }
+            "id": 23456,
+            "interfaces": [
+              {
+                "ipam_address": "10.0.0.1/24",
+                "label": "example-interface",
+                "purpose": "vlan"
+              }
+            ],
+            "kernel": "linode/latest-64bit",
+            "label": "My Config",
+            "memory_limit": 2048,
+            "root_device": "/dev/sda",
+            "run_level": "default",
+            "virt_mode": "paravirt"
           }
-        }
+        ]
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses) for a list of returned fields
 

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -8,62 +8,13 @@ Get info about a Linode StackScript.
 
 ## Examples
 
-```yaml
-- name: Get info about a StackScript by label
-  linode.cloud.stackscript_info:
-    label: my-stackscript
-```
-
-```yaml
-- name: Get info about a StackScript by ID
-  linode.cloud.stackscript_info:
-    id: 12345
-```
-
 
 ## Parameters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript.  **(Conflicts With: `label`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript.  **(Conflicts With: `id`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.   |
 
 ## Return Values
-
-- `stackscript` - The StackScript in JSON serialized form.
-
-    - Sample Response:
-        ```json
-        {
-          "created": "2018-01-01T00:01:01",
-          "deployments_active": 1,
-          "deployments_total": 12,
-          "description": "This StackScript installs and configures MySQL",
-          "id": 10079,
-          "images": [
-            "linode/debian9",
-            "linode/debian8"
-          ],
-          "is_public": true,
-          "label": "a-stackscript",
-          "mine": true,
-          "rev_note": "Set up MySQL",
-          "script": "#!/bin/bash",
-          "updated": "2018-01-01T00:01:01",
-          "user_defined_fields": [
-            {
-              "default": null,
-              "example": "hunter2",
-              "label": "Enter the password",
-              "manyOf": "avalue,anothervalue,thirdvalue",
-              "name": "DB_PASSWORD",
-              "oneOf": "avalue,anothervalue,thirdvalue"
-            }
-          ],
-          "user_gravatar_id": "a445b305abda30ebc766bc7fda037c37",
-          "username": "myuser"
-        }
-        ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/stackscripts/#stackscript-view__response-samples) for a list of returned fields
-
 

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -8,6 +8,18 @@ Get info about a Linode StackScript.
 
 ## Examples
 
+```yaml
+- name: Get info about a StackScript by label
+  linode.cloud.stackscript_info:
+    label: my-stackscript
+```
+
+```yaml
+- name: Get info about a StackScript by ID
+  linode.cloud.stackscript_info:
+    id: 12345
+```
+
 
 ## Parameters
 
@@ -17,4 +29,40 @@ Get info about a Linode StackScript.
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.   |
 
 ## Return Values
+
+- `stackscript` - The returned StackScript.
+
+    - Sample Response:
+        ```json
+        {
+          "created": "2018-01-01T00:01:01",
+          "deployments_active": 1,
+          "deployments_total": 12,
+          "description": "This StackScript installs and configures MySQL",
+          "id": 10079,
+          "images": [
+            "linode/debian9",
+            "linode/debian8"
+          ],
+          "is_public": true,
+          "label": "a-stackscript",
+          "mine": true,
+          "rev_note": "Set up MySQL",
+          "script": "#!/bin/bash",
+          "updated": "2018-01-01T00:01:01",
+          "user_defined_fields": [
+            {
+              "default": null,
+              "example": "hunter2",
+              "label": "Enter the password",
+              "manyOf": "avalue,anothervalue,thirdvalue",
+              "name": "DB_PASSWORD",
+              "oneOf": "avalue,anothervalue,thirdvalue"
+            }
+          ],
+          "user_gravatar_id": "a445b305abda30ebc766bc7fda037c37",
+          "username": "myuser"
+        }
+        ```
+
 

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list SSH keys in their Linode profile."""
+
+from __future__ import absolute_import, division, print_function
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import LinodeClient
+
+
+@dataclass
+class ListModuleParent:
+    """
+    Represents a single parent resource ID for a list module.
+    This is intended to be used for nested resources (e.g. Instance Config)
+    """
+
+    field: str
+    display_name: str
+    type: FieldType
+
+
+@dataclass
+class InfoModuleResponse:
+    spec: SpecReturnValue
+    do_request: Callable[[LinodeClient, Dict[str, Any]], Any]
+
+
+@dataclass
+class InfoModuleParam:
+    display_name: str
+    type: FieldType
+
+
+@dataclass
+class InfoModuleAttr:
+    display_name: str
+    type: FieldType
+    get: Callable[[LinodeClient, Dict[str, Any]], Dict[str, Any]]
+
+
+class InfoModuleBase(LinodeModuleBase):
+    """A common module for listing API resources given a set of filters."""
+
+    display_name: str
+    response_field: str
+    response_sample: Dict[str, Any]
+
+    # Params correspond to path IDs (e.g. linode/instances/{param1})
+    # These are always required.
+    params: Dict[str, InfoModuleParam] = {}
+
+    attributes: Dict[str, InfoModuleAttr] = {}
+    examples: List[str] = []
+
+    def __init__(self) -> None:
+        self.module_arg_spec = self.spec.ansible_spec
+        self.results: Dict[str, Any] = {self.response_field: None}
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_one_of=[self.attributes.keys()],
+            mutually_exclusive=[self.attributes.keys()],
+        )
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for list module"""
+
+        result = None
+
+        for k, v in self.attributes.items():
+            if kwargs.get(k) is None:
+                continue
+
+            result = v.get(self.client, kwargs)
+            break
+
+        if result is None:
+            raise ValueError("Expected a result; got None")
+
+        self.results[self.response_field] = result
+
+        return self.results
+
+    @classmethod
+    @property
+    def spec(cls):
+        """
+        Returns the ansible-specdoc spec for this module.
+        """
+
+        options = {
+            "state": SpecField(
+                type=FieldType.string, required=False, doc_hide=True
+            ),
+            "label": SpecField(
+                type=FieldType.string, required=False, doc_hide=True
+            ),
+        }
+
+        for k, param in cls.params.items():
+            options[k] = SpecField(
+                type=param.type,
+                required=True,
+                description=f"The ID of the {cls.display_name} for this resource.",
+            )
+
+        for k, attr in cls.attributes.items():
+            options[k] = SpecField(
+                type=attr.type,
+                description=f"The {attr.display_name} of the {cls.display_name} to resolve.",
+            )
+
+        return SpecDocMeta(
+            description=[f"Get info about a Linode {cls.display_name}."],
+            requirements=global_requirements,
+            author=global_authors,
+            options=options,
+            examples=cls.examples,
+            return_values={},
+        )

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -156,7 +156,7 @@ class InfoModule(LinodeModuleBase):
             options[param.name] = SpecField(
                 type=param.type,
                 required=True,
-                description=f"The ID of the {self.primary_result.display_name} for this resource.",
+                description=f"The ID of the {param.display_name} for this resource.",
             )
 
         # Add attrs to spec

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -85,7 +85,7 @@ class InfoModuleResult:
     ] = None
 
 
-class InfoModuleBase(LinodeModuleBase):
+class InfoModule(LinodeModuleBase):
     """A common module for listing API resources given a set of filters."""
 
     def __init__(

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -305,3 +305,18 @@ def poll_condition(
         step=step,
         timeout=timeout,
     )
+
+
+def safe_find(
+    func: Callable[[Tuple[Filter]], List[Any]], *filters: Filter
+) -> Any:
+    """
+    Wraps a resource list function with error handling.
+    If no entries are returned, this function returns None rather than
+    raising an error.
+    """
+    try:
+        list_results = func(*filters)
+        return None if len(list_results) < 1 else list_results[0]
+    except Exception as exception:
+        raise Exception(f"failed to get resource: {exception}") from exception

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -5,157 +5,85 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModuleAttr,
+    InfoModuleBase,
+    InfoModuleResponse,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    create_filter_and,
     paginated_list_to_json,
 )
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import Instance
 
-linode_instance_info_spec = {
-    # We need to overwrite attributes to exclude them as requirements
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "id": SpecField(
-        type=FieldType.integer,
-        required=False,
-        conflicts_with=["label"],
-        description=[
-            "The unique ID of the instance.",
-            "Optional if `label` is defined.",
-        ],
-    ),
-    "label": SpecField(
-        type=FieldType.string,
-        required=False,
-        conflicts_with=["id"],
-        description=[
-            "The instance’s label.",
-            "Optional if `id` is defined.",
-        ],
-    ),
-}
 
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Instance."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=linode_instance_info_spec,
-    examples=docs.specdoc_examples,
-    return_values={
-        "instance": SpecReturnValue(
-            description="The instance description in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
-            type=FieldType.dict,
-            sample=docs_parent.result_instance_samples,
-        ),
-        "configs": SpecReturnValue(
-            description="A list of configs tied to this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#configuration-profile-view__responses",
-            type=FieldType.list,
-            sample=docs_parent.result_configs_samples,
-        ),
-        "disks": SpecReturnValue(
-            description="A list of disks tied to this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
-            type=FieldType.list,
-            sample=docs_parent.result_disks_samples,
-        ),
-        "networking": SpecReturnValue(
-            description="Networking information about this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#networking-information-list__responses",
-            type=FieldType.dict,
-            sample=docs_parent.result_networking_samples,
-        ),
-    },
-)
-
-linode_instance_valid_filters = ["id", "label"]
-
-
-class LinodeInstanceInfo(LinodeModuleBase):
+class Module(InfoModuleBase):
     """Module for getting info about a Linode Instance"""
 
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.required_one_of: List[str] = []
-        self.results: Dict[str, Any] = {
-            "instance": None,
-            "configs": None,
-            "disks": None,
-            "networking": None,
-        }
+    examples = docs.specdoc_examples
 
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
+    primary_response = InfoModuleResponse(
+        display_name="Instance",
+        field="instance",
+        field_type=FieldType.dict,
+        docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
+        samples=docs_parent.result_instance_samples,
+    )
 
-    def _get_matching_instance(self) -> Optional[Instance]:
-        params = self.module.params
+    secondary_responses = [
+        InfoModuleResponse(
+            field="configs",
+            field_type=FieldType.list,
+            display_name="Configs",
+            docs_url="https://www.linode.com/docs/api/linode-instances/#configuration-profile-view__responses",
+            samples=docs_parent.result_configs_samples,
+            get=lambda client, instance, params: paginated_list_to_json(
+                Instance(client, instance.get("id")).configs
+            ),
+        ),
+        InfoModuleResponse(
+            field="disks",
+            field_type=FieldType.list,
+            display_name="Disks",
+            docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
+            samples=docs_parent.result_configs_samples,
+            get=lambda client, instance, params: paginated_list_to_json(
+                Instance(client, instance.get("id")).disks
+            ),
+        ),
+        InfoModuleResponse(
+            field="networking",
+            field_type=FieldType.dict,
+            display_name="Networking Configuration",
+            docs_url="https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses",
+            samples=docs_parent.result_configs_samples,
+            get=lambda client, instance, params: client.get(
+                "/linode/instances/{0}/ips".format(instance.get("id"))
+            ),
+        ),
+    ]
 
-        filter_items = {
-            k: v
-            for k, v in params.items()
-            if k in linode_instance_valid_filters and v is not None
-        }
-
-        filter_statement = create_filter_and(Instance, filter_items)
-
-        try:
-            # Special case because ID is not filterable
-            if "id" in filter_items.keys():
-                result = Instance(self.client, params.get("id"))
-                result._api_get()  # Force lazy-loading
-
-                return result
-
-            return self.client.linode.instances(filter_statement)[0]
-        except IndexError:
-            return None
-        except Exception as exception:
-            return self.fail(msg="failed to get instance {0}".format(exception))
-
-    def _get_networking(self, inst: Instance) -> Dict[str, Any]:
-        return self.client.get("/linode/instances/{0}/ips".format(inst.id))
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for instance info module"""
-
-        instance = self._get_matching_instance()
-
-        if instance is None:
-            return self.fail("failed to get instance")
-
-        self.results["instance"] = instance._raw_json
-        self.results["configs"] = paginated_list_to_json(instance.configs)
-        self.results["disks"] = paginated_list_to_json(instance.disks)
-        self.results["networking"] = self._get_networking(instance)
-
-        return self.results
+    attributes = {
+        "id": InfoModuleAttr(
+            display_name="ID",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                Instance, params.get("id")
+            )._raw_json,
+        ),
+        "label": InfoModuleAttr(
+            display_name="label",
+            type=FieldType.string,
+            get=lambda client, params: client.linode.instances(
+                Instance.label == params.get("label")
+            )[0]._raw_json,
+        ),
+    }
 
 
-def main() -> None:
-    """Constructs and calls the Linode Instance info module"""
-    LinodeInstanceInfo()
-
+SPECDOC_META = Module.spec
 
 if __name__ == "__main__":
-    main()
+    Module()

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -10,7 +10,7 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.insta
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModuleAttr,
     InfoModuleBase,
-    InfoModuleResponse,
+    InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     paginated_list_to_json,
@@ -24,27 +24,28 @@ class Module(InfoModuleBase):
 
     examples = docs.specdoc_examples
 
-    primary_response = InfoModuleResponse(
+    primary_result = InfoModuleResult(
         display_name="Instance",
-        field="instance",
+        field_name="instance",
         field_type=FieldType.dict,
         docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
         samples=docs_parent.result_instance_samples,
     )
 
-    secondary_responses = [
-        InfoModuleResponse(
-            field="configs",
+    secondary_results = [
+        InfoModuleResult(
+            field_name="configs",
             field_type=FieldType.list,
             display_name="Configs",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#configuration-profile-view__responses",
+            docs_url="https://www.linode.com/docs/api/linode-instances/"
+            "#configuration-profile-view__responses",
             samples=docs_parent.result_configs_samples,
             get=lambda client, instance, params: paginated_list_to_json(
                 Instance(client, instance.get("id")).configs
             ),
         ),
-        InfoModuleResponse(
-            field="disks",
+        InfoModuleResult(
+            field_name="disks",
             field_type=FieldType.list,
             display_name="Disks",
             docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
@@ -53,11 +54,12 @@ class Module(InfoModuleBase):
                 Instance(client, instance.get("id")).disks
             ),
         ),
-        InfoModuleResponse(
-            field="networking",
+        InfoModuleResult(
+            field_name="networking",
             field_type=FieldType.dict,
             display_name="Networking Configuration",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses",
+            docs_url="https://www.linode.com/docs/api/linode-instances/"
+            "#networking-information-list__responses",
             samples=docs_parent.result_networking_samples,
             get=lambda client, instance, params: client.get(
                 "/linode/instances/{0}/ips".format(instance.get("id"))
@@ -65,22 +67,24 @@ class Module(InfoModuleBase):
         ),
     ]
 
-    attributes = {
-        "id": InfoModuleAttr(
+    attributes = [
+        InfoModuleAttr(
+            name="id",
             display_name="ID",
             type=FieldType.integer,
             get=lambda client, params: client.load(
                 Instance, params.get("id")
             )._raw_json,
         ),
-        "label": InfoModuleAttr(
+        InfoModuleAttr(
+            name="label",
             display_name="label",
             type=FieldType.string,
             get=lambda client, params: client.linode.instances(
                 Instance.label == params.get("label")
             )[0]._raw_json,
         ),
-    }
+    ]
 
 
 SPECDOC_META = Module.spec

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -18,21 +18,16 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_specdoc.objects import FieldType
 from linode_api4 import Instance
 
-
-class Module(InfoModuleBase):
-    """Module for getting info about a Linode Instance"""
-
-    examples = docs.specdoc_examples
-
-    primary_result = InfoModuleResult(
+module = InfoModuleBase(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
         display_name="Instance",
         field_name="instance",
         field_type=FieldType.dict,
         docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
         samples=docs_parent.result_instance_samples,
-    )
-
-    secondary_results = [
+    ),
+    secondary_results=[
         InfoModuleResult(
             field_name="configs",
             field_type=FieldType.list,
@@ -65,9 +60,8 @@ class Module(InfoModuleBase):
                 "/linode/instances/{0}/ips".format(instance.get("id"))
             ),
         ),
-    ]
-
-    attributes = [
+    ],
+    attributes=[
         InfoModuleAttr(
             name="id",
             display_name="ID",
@@ -84,10 +78,10 @@ class Module(InfoModuleBase):
                 Instance.label == params.get("label")
             )[0]._raw_json,
         ),
-    ]
+    ],
+)
 
-
-SPECDOC_META = Module.spec
+SPECDOC_META = module.spec
 
 if __name__ == "__main__":
-    Module()
+    module.run()

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import, division, print_function
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
-    InfoModuleAttr,
     InfoModule,
+    InfoModuleAttr,
     InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -14,6 +14,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     paginated_list_to_json,
+    safe_find,
 )
 from ansible_specdoc.objects import FieldType
 from linode_api4 import Instance
@@ -74,9 +75,9 @@ module = InfoModule(
             name="label",
             display_name="label",
             type=FieldType.string,
-            get=lambda client, params: client.linode.instances(
-                Instance.label == params.get("label")
-            )[0]._raw_json,
+            get=lambda client, params: safe_find(
+                client.linode.instances, Instance.label == params.get("label")
+            )._raw_json,
         ),
     ],
 )

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -9,7 +9,7 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.insta
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModuleAttr,
-    InfoModuleBase,
+    InfoModule,
     InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
@@ -18,7 +18,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 from ansible_specdoc.objects import FieldType
 from linode_api4 import Instance
 
-module = InfoModuleBase(
+module = InfoModule(
     examples=docs.specdoc_examples,
     primary_result=InfoModuleResult(
         display_name="Instance",

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -48,7 +48,7 @@ class Module(InfoModuleBase):
             field_type=FieldType.list,
             display_name="Disks",
             docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
-            samples=docs_parent.result_configs_samples,
+            samples=docs_parent.result_disks_samples,
             get=lambda client, instance, params: paginated_list_to_json(
                 Instance(client, instance.get("id")).disks
             ),
@@ -58,7 +58,7 @@ class Module(InfoModuleBase):
             field_type=FieldType.dict,
             display_name="Networking Configuration",
             docs_url="https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses",
-            samples=docs_parent.result_configs_samples,
+            samples=docs_parent.result_networking_samples,
             get=lambda client, instance, params: client.get(
                 "/linode/instances/{0}/ips".format(instance.get("id"))
             ),

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -5,120 +5,40 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Optional
-
-from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    stackscript as docs_parent,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModuleAttr,
+    InfoModuleBase,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    stackscript_info as docs,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    filter_null_values,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
 
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "id": SpecField(
-        type=FieldType.integer,
-        description=["The ID of the StackScript."],
-        conflicts_with=["label"],
-    ),
-    "label": SpecField(
-        type=FieldType.string,
-        description=["The label of the StackScript."],
-        conflicts_with=["id"],
-    ),
-}
 
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode StackScript."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
-    examples=docs.specdoc_examples,
-    return_values={
-        "stackscript": SpecReturnValue(
-            description="The StackScript in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/stackscripts/"
-            "#stackscript-view__response-samples",
-            type="dict",
-            sample=docs_parent.result_stackscript_samples,
-        )
-    },
-)
-
-
-class Module(LinodeModuleBase):
+class Module(InfoModuleBase):
     """Module for getting info about a Linode StackScript"""
 
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results = {"stackscript": None}
+    display_name = "StackScript"
+    response_field = "stackscript"
+    response_sample = {}
 
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=[("id", "label")],
-            mutually_exclusive=[("id", "label")],
-        )
-
-    def _get_stackscript_by_label(self, label: str) -> Optional[StackScript]:
-        try:
-            return self.client.linode.stackscripts(StackScript.label == label)[
-                0
-            ]
-        except IndexError:
-            return self.fail(
-                msg="failed to get stackscript with label {0}: "
-                "stackscript does not exist".format(label)
-            )
-        except Exception as exception:
-            return self.fail(
-                msg="failed to get stackscript {0}: {1}".format(
-                    label, exception
-                )
-            )
-
-    def _get_stackscript_by_id(self, stackscript_id: int) -> StackScript:
-        return self._get_resource_by_id(StackScript, stackscript_id)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for stackscript_info module"""
-
-        params = filter_null_values(self.module.params)
-
-        if "id" in params:
-            self.results["stackscript"] = self._get_stackscript_by_id(
-                params.get("id")
-            )._raw_json
-
-        if "label" in params:
-            self.results["stackscript"] = self._get_stackscript_by_label(
-                params.get("label")
-            )._raw_json
-
-        return self.results
+    attributes = {
+        "id": InfoModuleAttr(
+            display_name="ID",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                StackScript, params.get("id")
+            )._raw_json,
+        ),
+        "label": InfoModuleAttr(
+            display_name="label",
+            type=FieldType.string,
+            get=lambda client, params: client.linode.stackscripts(
+                StackScript.label == params.get("label")
+            )[0]._raw_json,
+        ),
+    }
 
 
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
+SPECDOC_META = Module.spec
 
 if __name__ == "__main__":
-    main()
+    Module()

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -5,9 +5,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModuleAttr,
     InfoModuleBase,
+    InfoModuleResponse,
 )
 from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
@@ -16,9 +19,14 @@ from linode_api4 import StackScript
 class Module(InfoModuleBase):
     """Module for getting info about a Linode StackScript"""
 
-    display_name = "StackScript"
-    response_field = "stackscript"
-    response_sample = {}
+    examples = docs.specdoc_examples
+
+    primary_response = InfoModuleResponse(
+        field="stackscript",
+        field_type=FieldType.dict,
+        display_name="StackScript",
+        samples=docs_parent.result_stackscript_samples,
+    )
 
     attributes = {
         "id": InfoModuleAttr(

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -10,13 +10,13 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stack
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModuleAttr,
-    InfoModuleBase,
+    InfoModule,
     InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
 
-module = InfoModuleBase(
+module = InfoModule(
     examples=docs.specdoc_examples,
     primary_result=InfoModuleResult(
         field_name="stackscript",

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -16,20 +16,15 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
 from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
 
-
-class Module(InfoModuleBase):
-    """Module for getting info about a Linode StackScript"""
-
-    examples = docs.specdoc_examples
-
-    primary_result = InfoModuleResult(
+module = InfoModuleBase(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
         field_name="stackscript",
         field_type=FieldType.dict,
         display_name="StackScript",
         samples=docs_parent.result_stackscript_samples,
-    )
-
-    attributes = [
+    ),
+    attributes=[
         InfoModuleAttr(
             name="id",
             display_name="ID",
@@ -46,10 +41,10 @@ class Module(InfoModuleBase):
                 StackScript.label == params.get("label")
             )[0]._raw_json,
         ),
-    ]
+    ],
+)
 
-
-SPECDOC_META = Module.spec
+SPECDOC_META = module.spec
 
 if __name__ == "__main__":
-    Module()
+    module.run()

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -5,12 +5,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+# pylint: disable=line-too-long
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModuleAttr,
     InfoModuleBase,
-    InfoModuleResponse,
+    InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
@@ -21,29 +22,31 @@ class Module(InfoModuleBase):
 
     examples = docs.specdoc_examples
 
-    primary_response = InfoModuleResponse(
-        field="stackscript",
+    primary_result = InfoModuleResult(
+        field_name="stackscript",
         field_type=FieldType.dict,
         display_name="StackScript",
         samples=docs_parent.result_stackscript_samples,
     )
 
-    attributes = {
-        "id": InfoModuleAttr(
+    attributes = [
+        InfoModuleAttr(
+            name="id",
             display_name="ID",
             type=FieldType.integer,
             get=lambda client, params: client.load(
                 StackScript, params.get("id")
             )._raw_json,
         ),
-        "label": InfoModuleAttr(
+        InfoModuleAttr(
+            name="label",
             display_name="label",
             type=FieldType.string,
             get=lambda client, params: client.linode.stackscripts(
                 StackScript.label == params.get("label")
             )[0]._raw_json,
         ),
-    }
+    ]
 
 
 SPECDOC_META = Module.spec

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -9,8 +9,8 @@ from __future__ import absolute_import, division, print_function
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
-    InfoModuleAttr,
     InfoModule,
+    InfoModuleAttr,
     InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -13,6 +13,9 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
     InfoModuleAttr,
     InfoModuleResult,
 )
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    safe_find,
+)
 from ansible_specdoc.objects import FieldType
 from linode_api4 import StackScript
 
@@ -37,9 +40,10 @@ module = InfoModule(
             name="label",
             display_name="label",
             type=FieldType.string,
-            get=lambda client, params: client.linode.stackscripts(
-                StackScript.label == params.get("label")
-            )[0]._raw_json,
+            get=lambda client, params: safe_find(
+                client.linode.stackscripts,
+                StackScript.label == params.get("label"),
+            )._raw_json,
         ),
     ],
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,6 @@ black>=23.1.0
 isort>=5.12.0
 autoflake>=2.0.1
 pytest>=7.3.1
+pytest-ansible>=4.1.0
+pytest-forked>=1.6.0
+pytest-xdist>=3.3.1

--- a/tests/unit/module_utils/test_linode_common_info.py
+++ b/tests/unit/module_utils/test_linode_common_info.py
@@ -1,0 +1,85 @@
+import unittest
+
+import pytest
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import InfoModule, InfoModuleResult, \
+    InfoModuleParam, InfoModuleAttr
+from ansible_specdoc.objects import FieldType
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_requirements, global_authors
+
+
+class TestLinodeInfoModule:
+
+    @pytest.fixture
+    def mock_module(self):
+        return InfoModule(
+            primary_result=InfoModuleResult(
+                field_name="foo",
+                field_type=FieldType.dict,
+                display_name="Foo",
+                docs_url="https://linode.com/",
+                samples=['{"foo": "bar"}', '{"foo": "foo"}']
+            ),
+            secondary_results=[
+                InfoModuleResult(
+                    field_name="bar",
+                    field_type=FieldType.dict,
+                    display_name="Bar",
+                    docs_url="https://foo.linode.com/",
+                    samples=['{"foo": "bar"}', '{"foo": "foo"}'],
+                    get=lambda *args: "wow"
+                ),
+            ],
+            params=[
+                InfoModuleParam(
+                    name="parent_id",
+                    display_name="Parent",
+                    type=FieldType.integer
+                )
+            ],
+            attributes=[
+                InfoModuleAttr(
+                    name="attr",
+                    display_name="Attr",
+                    type=FieldType.string,
+                    get=lambda *args: ["cool"]
+                )
+            ],
+            examples=["foo"]
+        )
+
+    def test_init(self, mock_module):
+        assert set(mock_module.results.keys()) == {"foo", "bar"}
+
+    def test_generate_spec(self, mock_module):
+        spec = mock_module.spec
+
+        assert spec.description == [
+            "Get info about a Linode Foo."
+        ]
+        assert spec.requirements == global_requirements
+        assert spec.author == global_authors
+
+        parent_id_field = spec.options.get("parent_id")
+        assert parent_id_field.type == FieldType.integer
+        assert parent_id_field.required
+        assert parent_id_field.description == "The ID of the Parent for this resource."
+
+        attr_field = spec.options.get("attr")
+        assert attr_field.type == FieldType.string
+        assert not attr_field.required
+        assert attr_field.description == "The Attr of the Foo to resolve."
+
+        foo_result = spec.return_values.get("foo")
+        assert foo_result.description == "The returned Foo."
+        assert foo_result.docs_url == "https://linode.com/"
+        assert foo_result.type == FieldType.dict
+        assert foo_result.sample == mock_module.primary_result.samples
+
+        bar_result = spec.return_values.get("bar")
+        assert bar_result.description == "The returned Bar."
+        assert bar_result.docs_url == "https://foo.linode.com/"
+        assert bar_result.type == FieldType.dict
+        assert bar_result.sample == mock_module.secondary_results[0].samples
+

--- a/tests/unit/module_utils/test_linode_database_shared.py
+++ b/tests/unit/module_utils/test_linode_database_shared.py
@@ -1,7 +1,7 @@
 import unittest
 
 from linode_api4 import ApiError
-from plugins.module_utils.linode_database_shared import validate_allow_list, validate_shared_db_input, call_protected_provisioning
+from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import validate_allow_list, validate_shared_db_input, call_protected_provisioning
 
 
 class LinodeDatabaseSharedTest(unittest.TestCase):

--- a/tests/unit/module_utils/test_linode_helper.py
+++ b/tests/unit/module_utils/test_linode_helper.py
@@ -1,5 +1,5 @@
 import unittest
-from plugins.module_utils.linode_helper import (
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     dict_select_spec,
     filter_null_values,
     drop_empty_strings,


### PR DESCRIPTION
## 📝 Description

This change adds a shared `InfoModuleBase` class that allows for the easy creation of info modules with very little boilerplate.

This change also switches from directly calling `pytest` to using the `ansible-test units` wrapper.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_basic" test
make TEST_ARGS="-v stackscript_info" test
```