### PR TITLE
new: Introduce `ListModule` class to simplify list module implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Name | Description |
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|
 [linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Linode events.|
 [linode.cloud.firewall_list](./docs/modules/firewall_list.md)|List and filter on Firewalls.|
-[linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Linode images.|
+[linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
 [linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Linode Instances.|
 [linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|List and filter on Linode Instance Types.|
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List Kubernetes versions available for deployment to a Kubernetes cluster.|

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -1,6 +1,6 @@
 # image_list
 
-List and filter on Linode images.
+List and filter on Images.
 
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -34,21 +34,21 @@ List and filter on Linode images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Images in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Images by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Images.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Images to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/images/#images-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://www.linode.com/docs/api/images/#images-list__responses).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `images` - The returned images.
+- `images` - The returned Images.
 
     - Sample Response:
         ```json
@@ -71,6 +71,6 @@ List and filter on Linode images.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#images-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#images-list__responses) for a list of returned fields
 
 

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list SSH keys in their Linode profile."""
+
+from __future__ import absolute_import, division, print_function
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    construct_api_filter,
+    get_all_paginated,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+
+
+@dataclass
+class ListModuleParam:
+    """
+    Represents a single parent resource ID for a list module.
+    This is intended to be used for nested resources (e.g. Instance Config).
+    """
+
+    name: str
+    display_name: str
+    type: FieldType
+
+
+class ListModule(
+    LinodeModuleBase
+):  # pylint: disable=too-many-instance-attributes
+    """A common module for listing API resources given a set of filters."""
+
+    def __init__(
+        self,
+        result_display_name: str,
+        result_field_name: str,
+        endpoint_template: str,
+        result_docs_url: str = "",
+        params: List[ListModuleParam] = None,
+        examples: List[str] = None,
+        result_samples: List[str] = None,
+    ) -> None:
+        self.result_display_name = result_display_name
+        self.result_field_name = result_field_name
+        self.endpoint_template = endpoint_template
+
+        self.result_docs_url = result_docs_url
+        self.params = params or []
+        self.examples = examples or []
+        self.result_samples = result_samples or []
+
+        self.module_arg_spec = self.spec.ansible_spec
+        self.results: Dict[str, Any] = {self.result_field_name: []}
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for list module"""
+
+        filter_dict = construct_api_filter(self.module.params)
+
+        self.results[self.result_field_name] = get_all_paginated(
+            self.client,
+            self.endpoint_template.format(**self.module.params),
+            filter_dict,
+            num_results=self.module.params["count"],
+        )
+        return self.results
+
+    @property
+    def spec(self):
+        """
+        Returns the ansible-specdoc spec for this module.
+        """
+        spec_filter = {
+            "name": SpecField(
+                type=FieldType.string,
+                required=True,
+                description=[
+                    "The name of the field to filter on.",
+                    f"Valid filterable fields can be found [here]({self.result_docs_url}).",
+                ],
+            ),
+            "values": SpecField(
+                type=FieldType.list,
+                element_type=FieldType.string,
+                required=True,
+                description=[
+                    "A list of values to allow for this field.",
+                    "Fields will pass this filter if at least one of these values matches.",
+                ],
+            ),
+        }
+
+        options = {
+            # Disable the default values
+            "state": SpecField(
+                type=FieldType.string, required=False, doc_hide=True
+            ),
+            "label": SpecField(
+                type=FieldType.string, required=False, doc_hide=True
+            ),
+            "order": SpecField(
+                type=FieldType.string,
+                description=[
+                    f"The order to list {self.result_display_name}s in."
+                ],
+                default="asc",
+                choices=["desc", "asc"],
+            ),
+            "order_by": SpecField(
+                type=FieldType.string,
+                description=[
+                    f"The attribute to order {self.result_display_name}s by."
+                ],
+            ),
+            "filters": SpecField(
+                type=FieldType.list,
+                element_type=FieldType.dict,
+                suboptions=spec_filter,
+                description=[
+                    f"A list of filters to apply to the resulting {self.result_display_name}s."
+                ],
+            ),
+            "count": SpecField(
+                type=FieldType.integer,
+                description=[
+                    f"The number of {self.result_display_name}s to return.",
+                    "If undefined, all results will be returned.",
+                ],
+            ),
+        }
+
+        # Add the parent fields to the spec
+        for param in self.params:
+            options[param.name] = SpecField(
+                type=param.type,
+                description=[
+                    f"The parent {param.display_name} for this {self.result_display_name}."
+                ],
+                required=True,
+            )
+
+        return SpecDocMeta(
+            description=[f"List and filter on {self.result_display_name}s."],
+            requirements=global_requirements,
+            author=global_authors,
+            options=options,
+            examples=self.examples,
+            return_values={
+                self.result_field_name: SpecReturnValue(
+                    description=f"The returned {self.result_display_name}s.",
+                    docs_url=self.result_docs_url,
+                    type=FieldType.list,
+                    elements=FieldType.dict,
+                    sample=self.result_samples,
+                )
+            },
+        )
+
+    def run(self):
+        """
+        This method executes the module.
+        """
+
+        super().__init__(module_arg_spec=self.module_arg_spec)

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -5,121 +5,21 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/images/#images-list__responses",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list events in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string, description=["The attribute to order events by."]
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting events."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode images."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Image",
+    result_field_name="images",
+    endpoint_template="/images",
+    result_docs_url="https://www.linode.com/docs/api/images/#images-list__responses",
+    result_samples=docs.result_images_samples,
     examples=docs.specdoc_examples,
-    return_values={
-        "images": SpecReturnValue(
-            description="The returned images.",
-            docs_url="https://www.linode.com/docs/api/images/#images-list__response-samples",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_images_samples,
-        )
-    },
 )
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode images"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"images": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for event list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["images"] = get_all_paginated(
-            self.client,
-            "/images",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
+SPECDOC_META = module.spec
 
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

This PR adds a new `ListModule` class that significantly reduces the amount of boilerplate required in list module implementations.

Depends on #409 

[Relevant Changes](https://github.com/linode/ansible_linode/pull/410/files/6d8013a9087b574fa7dd83e8746f73097838150a..0e5e9e4ab24507c86c300072b5e415efe8b3c877)

## ✔️ How to Test

```
make TEST_ARGS="-v image_list" test
```
