### PR TITLE
new: adding `firewall_id` field to nodebalancers

### DIFF
--- a/docs/modules/firewall_device.md
+++ b/docs/modules/firewall_device.md
@@ -41,7 +41,7 @@ Manage Linode Firewall Devices.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `firewall_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Firewall that contains this device.   |
 | `entity_id` | <center>`int`</center> | <center>**Required**</center> | The ID for this Firewall Device. This will be the ID of the Linode Entity.   |
-| `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode.  **(Choices: `linode`)** |
+| `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode and nodebalancer.  **(Choices: `linode`, `nodebalancer`)** |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 
 ## Return Values

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -41,6 +41,7 @@ Manage a Linode NodeBalancer.
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 | `client_conn_throttle` | <center>`int`</center> | <center>Optional</center> | Throttle connections per second. Set to 0 (zero) to disable throttling.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | The ID of the Region to create this NodeBalancer in.   |
+| `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of the Firewall to assign this NodeBalancer to.   |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 
 ### configs

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -39,9 +39,9 @@ MODULE_SPEC = {
         type=FieldType.string,
         required=True,
         description=[
-            "The type of Linode Entity. Currently only supports linode."
+            "The type of Linode Entity. Currently only supports linode and nodebalancer."
         ],
-        choices=["linode"],
+        choices=["linode", "nodebalancer"],
     ),
     "label": SpecField(
         type=FieldType.string,

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -239,6 +239,10 @@ linode_nodebalancer_spec = {
         type=FieldType.string,
         description=["The ID of the Region to create this NodeBalancer in."],
     ),
+    "firewall_id": SpecField(
+        type=FieldType.integer,
+        description=["The ID of the Firewall to assign this NodeBalancer to."],
+    ),
     "state": SpecField(
         type=FieldType.string,
         description=["The desired state of the target."],
@@ -342,9 +346,10 @@ class LinodeNodeBalancer(LinodeModuleBase):
         params = self.module.params
         label = params.get("label")
         region = params.get("region")
+        firewall_id = params.get("firewall_id")
 
         try:
-            return self.client.nodebalancer_create(region, label=label)
+            return self.client.nodebalancer_create(region, label=label, firewall_id=firewall_id)
         except Exception as exception:
             return self.fail(
                 msg="failed to create nodebalancer: {0}".format(exception)

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -12,6 +12,13 @@
         state: present
       register: inst
 
+    - name: Create Nodebalancer
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-nb-{{ r }}'
+        region: us-east
+        state: present
+      register: nb
+
     - name: Create a Linode Firewall
       linode.cloud.firewall:
         api_version: v4beta
@@ -39,6 +46,20 @@
         that:
           - fw_device.changed
 
+    - name: Add Nodebalancer Device to Linode Firewall
+      linode.cloud.firewall_device:
+        api_version: v4beta
+        firewall_id: '{{ fw.firewall.id }}'
+        entity_id: '{{ nb.node_balancer.id }}'
+        entity_type: 'nodebalancer'
+        state: present
+      register: fw_device_nb
+
+    - name: Assert firewall device added
+      assert:
+        that:
+          - fw_device_nb.changed
+
     - name: Add Existing Device to Linode Firewall
       linode.cloud.firewall_device:
         api_version: v4beta
@@ -61,11 +82,17 @@
             entity_id: '{{ inst.instance.id }}'
             entity_type: 'linode'
             state: absent
-
+        - linode.cloud.firewall_device:
+            firewall_id: '{{ fw.firewall.id }}'
+            entity_id: '{{ nb.node_balancer.id }}'
+            entity_type: 'nodebalancer'
+            state: absent
+        - linode.cloud.nodebalancer:
+            label: '{{ nb.node_balancer.label }}'
+            state: absent
         - linode.cloud.instance:
             label: '{{ inst.instance.label }}'
             state: absent
-
         - linode.cloud.firewall:
             label: '{{ fw.firewall.label }}'
             state: absent

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -1,0 +1,61 @@
+- name: nodebalancer_firewall
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Firewall
+      linode.cloud.firewall:
+        api_version: v4beta
+        label: 'ansible-test-fw-{{ r }}'
+        devices: []
+        rules:
+          inbound: []
+          inbound_policy: DROP
+          outbound: []
+          outbound_policy: DROP
+        state: present
+      register: firewall
+
+    - name: Create Nodebalancer
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-nb-{{ r }}'
+        region: us-east
+        firewall_id: '{{ firewall.firewall.id }}'
+        state: present
+      register: nodebalancer
+
+    - name: Assert empty NodeBalancer is created
+      assert:
+        that:
+          - nodebalancer.changed
+          - nodebalancer.configs|length == 0
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the empty NodeBalancer
+          linode.cloud.nodebalancer:
+            label: '{{ nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_nodebalancer
+
+        - name: Delete a Linode Firewall
+          linode.cloud.firewall:
+            api_version: v4beta
+            label: '{{ firewall.firewall.label }}'
+            state: absent
+          register: delete_firewall
+
+        - name: Assert firewall and nodebalancer deleted
+          assert:
+            that:
+              - delete_nodebalancer.changed
+              - delete_nodebalancer.node_balancer.id == delete_nodebalancer.node_balancer.id
+              - delete_firewall.changed
+              - delete_firewall.firewall.id == delete_firewall.firewall.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Adding `firewall_id` field to creating nodebalancers.

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

`make TEST_ARGS='-v nodebalancer_firewall' test`
