### PR TITLE
new: Add support for specifying a firewall_id on instance creation

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -111,6 +111,7 @@ Manage Linode Instances, Configs, and Disks.
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of a Firewall this Linode to assign this Linode to.   |
 | `private_ip` | <center>`bool`</center> | <center>Optional</center> | If true, the created Linode will have private networking enabled.   |
 | `group` | <center>`str`</center> | <center>Optional</center> | The group that the instance should be marked under. Please note, that group labelling is deprecated but still supported. The encouraged method for marking instances is to use tags.  **(Updatable)** |
 | `boot_config_label` | <center>`str`</center> | <center>Optional</center> | The label of the config to boot from.   |

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -855,7 +855,7 @@ class LinodeInstance(LinodeModuleBase):
         if len(related_devices) < 1:
             self.fail(
                 msg="firewall_id can not be updated after Linode creation. "
-                "If you would like to update Firewall attachments, refer to 'firewall' "
+                "To update Firewall attachments, refer to the 'firewall' "
                 "and 'firewall_device' modules."
             )
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -32,7 +32,15 @@ from ansible_specdoc.objects import (
 )
 
 try:
-    from linode_api4 import Config, ConfigInterface, Disk, Instance, Volume
+    from linode_api4 import (
+        ApiError,
+        Config,
+        ConfigInterface,
+        Disk,
+        Firewall,
+        Instance,
+        Volume,
+    )
 except ImportError:
     # handled in module_utils.linode_common
     pass
@@ -339,6 +347,12 @@ linode_instance_spec = {
             "the StackScript used when creating the instance.",
             "Only valid when a stackscript_id is provided.",
             "See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).",
+        ],
+    ),
+    "firewall_id": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The ID of a Firewall this Linode to assign this Linode to."
         ],
     ),
     "state": SpecField(
@@ -693,7 +707,6 @@ class LinodeInstance(LinodeModuleBase):
 
         result = {"instance": None, "root_pass": ""}
 
-        # We want to retry on 408s
         response = self.client.linode.instance_create(ltype, region, **params)
 
         # Weird variable return type
@@ -809,6 +822,42 @@ class LinodeInstance(LinodeModuleBase):
                 self._instance.label, config.id
             )
         )
+
+    def _update_firewall(self) -> None:
+        """
+        Handles updates to the firewall_id field.
+        """
+        firewall_id = self.module.params.get("firewall_id")
+        # Nothing to do
+        if firewall_id is None:
+            return
+
+        # Resolve the expected firewall; fail if firewall doesn't exist
+        try:
+            firewall = self.client.load(Firewall, firewall_id)
+        except ApiError as err:
+            # Raise a readable error for missing Firewalls
+            if err.status == 404:
+                self.fail(
+                    msg=f"Could not find Linode Firewall with id {firewall_id}"
+                )
+
+            raise err
+
+        # Raise an error if the firewall_id assignment is not currently valid.
+        # This is necessary to avoid making a large number of requests to discover
+        # Firewalls and reconcile their devices.
+        related_devices = [
+            v
+            for v in firewall.devices
+            if v.entity.type == "linode" and v.entity.id == self._instance.id
+        ]
+        if len(related_devices) < 1:
+            self.fail(
+                msg="firewall_id can not be updated after Linode creation. "
+                "If you would like to update Firewall attachments, refer to 'firewall' "
+                "and 'firewall_device' modules."
+            )
 
     def _update_config(
         self, config: Config, config_params: Dict[str, Any]
@@ -1043,6 +1092,9 @@ class LinodeInstance(LinodeModuleBase):
 
         # Update interfaces
         self._update_interfaces()
+
+        # Handle updating on the target Firewall ID
+        self._update_firewall()
 
     def _handle_instance_boot(self) -> None:
         boot_status = self.module.params.get("booted")

--- a/tests/integration/targets/instance_firewall/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall/tasks/main.yaml
@@ -1,0 +1,55 @@
+- name: instance_firewall
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+        api_version: v4beta
+        label: 'ansible-test-{{ r }}'
+        devices: []
+        rules:
+          inbound_policy: DROP
+          outbound_policy: DROP
+        state: present
+      register: firewall_create
+
+    - name: Create a Linode instance attached to the Firewall
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        firewall_id: '{{ firewall_create.firewall.id }}'
+        wait: false
+        state: present
+      register: instance_create
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+        id: '{{ firewall_create.firewall.id }}'
+      register: firewall_info
+
+    - name: Assert instance is assigned to the firewall
+      assert:
+        that:
+          - firewall_info.devices[0].entity.id == instance_create.instance.id
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ instance_create.instance.label }}'
+            state: absent
+
+        - name: Delete a Linode firewall
+          linode.cloud.firewall:
+            label: '{{ firewall_create.firewall.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file }}'

--- a/tests/integration/targets/instance_firewall/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall/tasks/main.yaml
@@ -54,7 +54,7 @@
         wait: false
         state: present
       register: instance_update
-      failed_when: '"firewall_id can not be updated after Linode creation" in instance_update.msg'
+      failed_when: '"firewall_id can not be updated after Linode creation" not in instance_update.msg'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/instance_firewall/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall/tasks/main.yaml
@@ -14,6 +14,17 @@
         state: present
       register: firewall_create
 
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+        api_version: v4beta
+        label: 'ansible-test-{{ r }}-2'
+        devices: []
+        rules:
+          inbound_policy: DROP
+          outbound_policy: DROP
+        state: present
+      register: firewall_2_create
+
     - name: Create a Linode instance attached to the Firewall
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
@@ -34,6 +45,17 @@
         that:
           - firewall_info.devices[0].entity.id == instance_create.instance.id
 
+    - name: Attempt to update the firewall_id for the instance
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        type: g6-standard-1
+        firewall_id: '{{ firewall_2_create.firewall.id }}'
+        wait: false
+        state: present
+      register: instance_update
+      failed_when: '"firewall_id can not be updated after Linode creation" in instance_update.msg'
+
   always:
     - ignore_errors: yes
       block:
@@ -45,6 +67,11 @@
         - name: Delete a Linode firewall
           linode.cloud.firewall:
             label: '{{ firewall_create.firewall.label }}'
+            state: absent
+
+        - name: Delete a Linode firewall
+          linode.cloud.firewall:
+            label: '{{ firewall_2_create.firewall.label }}'
             state: absent
 
   environment:


### PR DESCRIPTION
## 📝 Description

This change adds support for specifying a `firewall_id` when creating an instance using the `linode.cloud.instance` module.

NOTE: This feature has not yet been enabled in the API.

## ✔️ How to Test
```
make TEST_ARGS="-v instance_firewall" test
```