### PR TITLE
Support specifying a custom CA path

### DIFF
--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -80,6 +80,10 @@ LINODE_COMMON_ARGS = {
         "doc_hide": True,
         "fallback": (env_fallback, ["LINODE_UA_PREFIX"]),
     },
+    "ca_path": {
+        "type": "str",
+        "description": "A path to a custom certificate authority that allows for alternate API testing.",
+    }
 }
 
 LINODE_TAG_ARGS = {
@@ -241,6 +245,7 @@ class LinodeModuleBase:
             api_token = self.module.params["api_token"]
             api_version = self.module.params["api_version"]
             api_url = self.module.params["api_url"]
+            ca_path = self.module.params["ca_path"]
 
             user_agent = COLLECTION_USER_AGENT
 
@@ -256,6 +261,7 @@ class LinodeModuleBase:
                 retry_rate_limit_interval=RETRY_INTERVAL_SECONDS,
                 retry_max=MAX_RETRIES,
                 retry_statuses=RETRY_STATUSES,
+                ca_path=ca_path
             )
 
         return self._client


### PR DESCRIPTION
## 📝 Description

Users can now specify a custom CA file by passing in its path through a ca_path argument for each module.
