### PR TITLE
new: Support overriding the CA file for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ COLLECTIONS_PATH ?= ~/.ansible/collections
 DOCS_PATH ?= docs
 COLLECTION_VERSION ?=
 
+TEST_API_URL ?= https://api.linode.com/
+TEST_API_VERSION ?= v4beta
+TEST_API_CA ?=
+
 TEST_ARGS := -v
-TEST_API_URL := https://api.linode.com/
-TEST_API_VERSION := v4beta
 INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 
 clean:
@@ -79,3 +81,4 @@ endif
 	@echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)
 	@echo "api_url: $(TEST_API_URL)" >> $(INTEGRATION_CONFIG)
 	@echo "api_version: $(TEST_API_VERSION)" >> $(INTEGRATION_CONFIG)
+	@echo "ca_file: $(TEST_API_CA)" >> $(INTEGRATION_CONFIG)

--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -63,3 +63,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/api_request_extra/tasks/main.yaml
+++ b/tests/integration/targets/api_request_extra/tasks/main.yaml
@@ -46,3 +46,6 @@
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -25,3 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -95,3 +95,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -74,4 +74,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -72,3 +72,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -245,3 +245,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -247,4 +247,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -60,3 +60,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -62,4 +62,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -43,3 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -283,3 +283,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -104,3 +104,4 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
+

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -102,3 +102,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -91,3 +91,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -66,4 +66,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -64,3 +64,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -887,3 +887,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -889,4 +889,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -94,3 +94,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -43,3 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -39,3 +39,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -41,4 +41,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -96,3 +96,6 @@
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -156,3 +156,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -158,4 +158,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -59,3 +59,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -61,4 +61,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -224,3 +224,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -113,3 +113,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -89,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -90,3 +90,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -65,4 +65,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -63,3 +63,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -41,3 +41,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -43,4 +43,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_reboot/tasks/main.yaml
+++ b/tests/integration/targets/instance_reboot/tasks/main.yaml
@@ -53,3 +53,6 @@
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -27,3 +27,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -29,4 +29,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -26,3 +26,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -27,3 +27,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -63,4 +63,4 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA
+

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -61,3 +61,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -34,3 +34,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -36,4 +36,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -54,4 +54,4 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA
+

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -52,3 +52,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -93,3 +93,4 @@
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -55,4 +55,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -53,3 +53,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -149,3 +149,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -151,4 +151,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -67,3 +67,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -98,3 +98,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -99,3 +99,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -15,4 +15,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -13,3 +13,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -137,3 +137,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -84,3 +84,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -112,3 +112,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -114,4 +114,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -59,3 +59,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -58,3 +58,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -128,4 +128,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -126,3 +126,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -325,3 +325,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -114,3 +114,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -126,3 +126,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -27,4 +27,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -25,3 +25,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -104,3 +104,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -86,3 +86,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -15,4 +15,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -13,3 +13,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -26,5 +26,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -25,3 +25,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -44,3 +44,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -45,5 +45,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/ssh_key_list/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_list/tasks/main.yaml
@@ -77,3 +77,10 @@
             ua_prefix: '{{ ua_prefix }}'
             path: "profile/sshkeys/{{ create_ssh_key2.body.id }}"
             method: DELETE
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -60,3 +60,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -54,3 +54,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -55,5 +55,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -42,3 +42,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -40,3 +40,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -41,5 +41,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -44,3 +44,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -45,3 +45,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -55,3 +55,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
+

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -54,3 +54,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -21,3 +21,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -44,4 +44,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
 
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -42,3 +42,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -89,3 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -37,3 +37,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -59,3 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -53,3 +53,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -278,3 +278,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -279,5 +279,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -59,3 +59,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file }}'
+
+    LINODA_CA: LINODE_CA

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -60,5 +60,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file }}'
-
-    LINODA_CA: LINODE_CA


### PR DESCRIPTION
## 📝 Description

This change adds support for overriding the CA file when running E2E tests. This is useful for testing the Ansible Collection in alternate environments where a custom cert is needed.

## ✔️ How to Test

1. Pull down a CA file

```
wget https://us-east-1.linodeobjects.com/linode-internal-ca/cacert.pem
```

2. Point the `TEST_API_CA` environment variable at the downloaded cert.

```
export TEST_API_CA=$PWD/cacert.pem
```

3. Export environment variables to point at an alternate environment.

```
export LINODE_TOKEN=MYALTERNATETOKEN
export TEST_API_URL=foo.linode.com
```

4. Run the test suite.  

```
make test
```
