### PR TITLE
fix: Use `--upgrade` in `make deps` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install: build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
 deps:
-	pip install -r requirements.txt -r requirements-dev.txt
+	pip install -r requirements.txt -r requirements-dev.txt --upgrade
 
 lint:
 	pylint plugins


### PR DESCRIPTION
## 📝 Description

This change adds the `--upgrade` argument to the pip install command in `make deps`, which will allow Python to upgrade existing dependencies.

## ✔️ How to Test

1. Pull down this change
2. Run `make deps`
3. Observe `--upgrade` in the run pip install command