### PR TITLE
new: add vpc fields to ip_info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install: build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
 deps:
-	pip install --upgrade -r requirements.txt -r requirements-dev.txt
+	pip install -r requirements.txt -r requirements-dev.txt --upgrade
 
 lint:
 	pylint plugins

--- a/docs/modules/ip_info.md
+++ b/docs/modules/ip_info.md
@@ -36,7 +36,12 @@ Get info about a Linode IP.
           "rdns": "test.example.org",
           "region": "us-east",
           "subnet_mask": "255.255.255.0",
-          "type": "ipv4"
+          "type": "ipv4",
+          "vpc_nat_1_1": {
+            "vpc_id": 242,
+            "subnet_id": 194,
+            "address": "139.144.244.36",
+          }
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#ip-address-view__responses) for a list of returned fields

--- a/docs/modules/ip_rdns.md
+++ b/docs/modules/ip_rdns.md
@@ -49,7 +49,12 @@ Manage a Linode IP address's rDNS.
           "rdns": "test.example.org",
           "region": "us-east",
           "subnet_mask": "255.255.255.0",
-          "type": "ipv4"
+          "type": "ipv4",
+          "vpc_nat_1_1": {
+            "vpc_id": 242,
+            "subnet_id": 194,
+            "address": "139.144.244.36",
+          }
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#ip-address-rdns-update) for a list of returned fields

--- a/plugins/module_utils/doc_fragments/ip_info.py
+++ b/plugins/module_utils/doc_fragments/ip_info.py
@@ -14,5 +14,10 @@ result_ip_samples = ['''{
   "rdns": "test.example.org",
   "region": "us-east",
   "subnet_mask": "255.255.255.0",
-  "type": "ipv4"
+  "type": "ipv4",
+  "vpc_nat_1_1": {
+    "vpc_id": 242,
+    "subnet_id": 194,
+    "address": "139.144.244.36",
+  }
 }''']

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -3,6 +3,7 @@
 
 """This module allows users to retrieve information about a Linode IP address."""
 
+
 from __future__ import absolute_import, division, print_function
 
 from typing import Any, Optional
@@ -69,16 +70,13 @@ class Module(LinodeModuleBase):
 
     def _get_ip(self, address: str) -> IPAddress:
         try:
-            ip_addr = IPAddress(self.client, address)
-
-            ip_addr._api_get()
-
-            return ip_addr
+            return self.client.load(IPAddress, address)
         except Exception as exception:
             self.fail(
                 msg="failed to get IP address {0}: {1}".format(
                     address, exception
-                )
+                ),
+                exception=exception,
             )
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -70,7 +70,9 @@ class Module(LinodeModuleBase):
 
     def _get_ip(self, address: str) -> IPAddress:
         try:
-            return self.client.load(IPAddress, address)
+            ip_addr = IPAddress(self.client, address)
+            ip_addr._api_get()
+            return ip_addr
         except Exception as exception:
             self.fail(
                 msg="failed to get IP address {0}: {1}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # linode-api4>=5.9.0
 git+https://github.com/linode/linode_api4-python@proj/vpc
 polling>=0.3.2
-types-requests==2.31.0.2
+types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -63,4 +63,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/api_request_extra/tasks/main.yaml
+++ b/tests/integration/targets/api_request_extra/tasks/main.yaml
@@ -48,4 +48,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -25,4 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -95,4 +95,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -72,4 +72,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -245,4 +245,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -60,4 +60,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -43,4 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -283,4 +283,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -102,6 +102,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -91,4 +91,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -64,4 +64,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -887,4 +887,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -94,4 +94,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -43,4 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -39,4 +39,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -98,4 +98,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -156,4 +156,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -59,4 +59,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -224,4 +224,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -113,4 +113,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_config_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vpc/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a VPC
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         description: test description
         state: present
       register: create_vpc
@@ -22,7 +22,7 @@
     - name: Create a Linode instance with interface
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         type: g6-standard-1
         disks:
           - label: test-disk
@@ -58,10 +58,23 @@
           - create_instance.configs[0].interfaces[0].ipv4.nat_1_1 == create_instance.instance.ipv4[0]
           - create_instance.configs[0].interfaces[0].ipv4.vpc == '10.0.0.3'
 
+    - name: Get ip_info about the instance's vpc ip
+      linode.cloud.ip_info:
+        address: '{{ create_instance.instance.ipv4[0] }}'
+      register: ip_info
+
+    - name: Assert ip_info matches vpc settings
+      assert:
+        that:
+          - ip_info.ip.address == create_instance.instance.ipv4[0]
+          - ip_info.ip.vpc_nat_1_1.address == '10.0.0.3'
+          - ip_info.ip.vpc_nat_1_1.vpc_id == create_vpc.vpc.id
+          - ip_info.ip.vpc_nat_1_1.subnet_id == create_subnet.subnet.id
+
     - name: Update the config interfaces
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         type: g6-standard-1
         disks:
           - label: test-disk
@@ -103,7 +116,7 @@
     - name: Don't change the config interfaces
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         type: g6-standard-1
         disks:
           - label: test-disk
@@ -158,4 +171,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -89,8 +89,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-<<<<<<< HEAD
-=======
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 >>>>>>> 3ee3aabf6b1a20187f78b4f2371ab8902cc76b7e

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -63,4 +63,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -41,4 +41,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/instance_reboot/tasks/main.yaml
+++ b/tests/integration/targets/instance_reboot/tasks/main.yaml
@@ -55,4 +55,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -27,5 +27,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -26,4 +26,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -61,6 +61,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -21,7 +21,6 @@
     - assert:
         that:
           - ip_info.ip.address == instance_create.instance.ipv4[0]
-          - ip_info.ip.vpc_nat_1_1
 
   always:
     - ignore_errors: true
@@ -35,4 +34,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -35,3 +35,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -21,6 +21,7 @@
     - assert:
         that:
           - ip_info.ip.address == instance_create.instance.ipv4[0]
+          - ip_info.ip.vpc_nat_1_1
 
   always:
     - ignore_errors: true

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -52,4 +52,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+
+

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -93,4 +93,4 @@
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -53,4 +53,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -149,4 +149,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -67,4 +67,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -98,5 +98,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -13,4 +13,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -137,4 +137,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -84,4 +84,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -112,4 +112,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -59,5 +59,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -58,4 +58,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -126,4 +126,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -325,4 +325,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -114,4 +114,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -126,4 +126,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -25,5 +25,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -104,4 +104,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -86,4 +86,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -13,4 +13,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -25,4 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -44,4 +44,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ssh_key_list/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_list/tasks/main.yaml
@@ -83,4 +83,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -60,4 +60,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -54,4 +54,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -42,4 +42,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -40,4 +40,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -44,4 +44,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -54,4 +54,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -21,4 +21,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -42,4 +42,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -89,4 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -37,4 +37,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -59,4 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -53,4 +53,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -278,4 +278,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -59,4 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a VPC
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         description: test description
         state: present
       register: create_vpc
@@ -16,13 +16,13 @@
         that:
           - create_vpc.changed
           - create_vpc.vpc.label == 'ansible-test-{{ r }}'
-          - create_vpc.vpc.region == 'us-east'
+          - create_vpc.vpc.region == 'us-mia'
           - create_vpc.vpc.description == 'test description'
 
     - name: Create a VPC with invalid label
       linode.cloud.vpc:
           label: 'test-vpc!!'
-          region: us-east
+          region: us-mia
           description: test description
           state: present
       register: invalid_label
@@ -31,7 +31,7 @@
     - name: Update the VPC
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         description: test description updated
         state: present
       register: update_vpc
@@ -46,7 +46,7 @@
     - name: Update the VPC with invalid label
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}!'
-        region: us-east
+        region: us-mia
         description: test description updated
         state: present
       register: modify_vpc
@@ -55,7 +55,7 @@
     - name: Don't update the VPC
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         description: test description updated
         state: present
       register: no_update_vpc
@@ -115,4 +115,4 @@
     LINODE_API_VERSION: '{{ api_version }}'
 
     # Temporary testing override; remove before merge to dev
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a VPC
       linode.cloud.vpc:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-mia
         description: test description
         state: present
       register: create_vpc
@@ -16,7 +16,7 @@
         that:
           - create_vpc.changed
           - create_vpc.vpc.label == 'ansible-test-{{ r }}'
-          - create_vpc.vpc.region == 'us-east'
+          - create_vpc.vpc.region == 'us-mia'
           - create_vpc.vpc.description == 'test description'
 
     - name: Create a subnet
@@ -100,4 +100,4 @@
     LINODE_API_VERSION: '{{ api_version }}'
 
     # Temporary testing override; remove before merge to dev
-    REQUESTS_CA_BUNDLE: '{{ ca_file }}'
+    REQUESTS_CA_BUNDLE: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

adding `vpc_nat_1_1` field to `ip_info`

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

`make TEST_ARGS='-v ip_info' test`
