### PR TITLE
fix: Explicitly handle `None` values for E2E testing CA file

### DIFF
--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -63,4 +63,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/api_request_extra/tasks/main.yaml
+++ b/tests/integration/targets/api_request_extra/tasks/main.yaml
@@ -48,4 +48,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -25,4 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -95,4 +95,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -72,5 +72,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -245,5 +245,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -60,5 +60,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -43,4 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -283,4 +283,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -102,6 +102,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -91,4 +91,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -64,5 +64,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -887,5 +887,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -94,4 +94,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -43,4 +43,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -39,5 +39,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -98,4 +98,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -156,5 +156,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -59,5 +59,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -224,4 +224,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -113,4 +113,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -89,5 +89,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -63,5 +63,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -41,5 +41,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_reboot/tasks/main.yaml
+++ b/tests/integration/targets/instance_reboot/tasks/main.yaml
@@ -55,4 +55,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -27,5 +27,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -26,5 +26,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -61,6 +61,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -34,5 +34,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -52,6 +52,6 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 
 

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -93,4 +93,4 @@
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -53,5 +53,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -149,5 +149,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -67,4 +67,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -98,5 +98,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -13,5 +13,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -137,4 +137,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -84,4 +84,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -112,5 +112,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -59,5 +59,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -58,4 +58,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -126,5 +126,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -325,4 +325,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -114,5 +114,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -126,4 +126,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -25,5 +25,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -104,4 +104,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -86,4 +86,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -13,5 +13,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -25,4 +25,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -44,4 +44,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/ssh_key_list/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_list/tasks/main.yaml
@@ -83,4 +83,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -60,4 +60,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -54,4 +54,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -42,4 +42,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/token_basic/tasks/main.yaml
+++ b/tests/integration/targets/token_basic/tasks/main.yaml
@@ -40,4 +40,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -44,5 +44,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -54,5 +54,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -21,4 +21,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -42,5 +42,5 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'
 

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -89,4 +89,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -37,4 +37,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -59,4 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -53,4 +53,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -278,4 +278,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -59,4 +59,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused cert file resolution errors when the `TEST_API_CA` environment variable was not exported. 

This issue is resolved by explicitly using an empty string if the environment variable is `None` rather than formatting `None` as a string. 

## ✔️ How to Test

```
unset TEST_API_CA
make test
```
