### PR TITLE
Cleanup VPC interface workaround

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -818,10 +818,6 @@ class LinodeInstance(LinodeModuleBase):
         if self._compare_interfaces(param_interfaces, remote_interfaces):
             return
 
-        # TODO: Remove when related bug is fixed
-        config.interfaces = []
-        config.save()
-
         config.interfaces = [ConfigInterface(**v) for v in param_interfaces]
 
         config.save()
@@ -934,13 +930,6 @@ class LinodeInstance(LinodeModuleBase):
                 )
 
         if should_update:
-            # TODO: Hack to work around know bug; remove before release
-            old_interfaces = config.interfaces
-            config.interfaces = []
-            config.save()
-
-            config.interfaces = old_interfaces
-
             config.save()
 
     def _update_configs(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ disable = [
     "missing-timeout",
     "use-sequence-for-iteration",
     "broad-exception-raised",
-    "fixme" # Temporary "TODO" ignore
 ]
 py-version = "3.8"
 extension-pkg-whitelist = "math"


### PR DESCRIPTION
## 📝 Description

The bug has been fixed apparently, so we don't need the workaround previously implemented.

## ✔️ How to Test

`make test TEST_ARGS="-v instance_config_vpc"`
`make test TEST_ARGS="-v instance_interfaces_vpc"`