### PR TITLE
fix: Set default for `LINODE_CA` in instance_firewall test

### DIFF
--- a/tests/integration/targets/instance_firewall/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall/tasks/main.yaml
@@ -79,4 +79,4 @@
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
-    LINODE_CA: '{{ ca_file }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This change addresses an oversight that caused the `instance_firewall` test to always fail without an explicit CA file.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_firewall" test
```
