### PR TITLE
new: Add `type_info` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Name | Description |
 [linode.cloud.ssh_key_info](./docs/modules/ssh_key_info.md)|Get info about the Linode SSH public key.|
 [linode.cloud.stackscript_info](./docs/modules/stackscript_info.md)|Get info about a Linode StackScript.|
 [linode.cloud.token_info](./docs/modules/token_info.md)|Get info about a Linode Personal Access Token.|
+[linode.cloud.type_info](./docs/modules/type_info.md)|Get info about a Linode Type.|
 [linode.cloud.user_info](./docs/modules/user_info.md)|Get info about a Linode User.|
 [linode.cloud.vlan_info](./docs/modules/vlan_info.md)|Get info about a Linode VLAN.|
 [linode.cloud.volume_info](./docs/modules/volume_info.md)|Get info about a Linode Volume.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`trailing\_separator`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :emphasis:`False`\  to omit the \ :literal:`separator`\  after the host variable when the value is an empty string.
+        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`default\_value`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
 
 
 

--- a/docs/modules/type_info.md
+++ b/docs/modules/type_info.md
@@ -1,0 +1,58 @@
+# type_info
+
+Get info about a Linode Type.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Get info about a Linode type by ID
+  linode.cloud.type_info:
+    id: g6-standard-2
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the Type to resolve.   |
+
+## Return Values
+
+- `type` - The returned Type.
+
+    - Sample Response:
+        ```json
+        
+        {
+            "addons": {
+                "backups": {
+                    "price": {
+                        "hourly": 0.008,
+                        "monthly": 5
+                    }
+                }
+            },
+            "class": "standard",
+            "disk": 81920,
+            "gpus": 0,
+            "id": "g6-standard-2",
+            "label": "Linode 4GB",
+            "memory": 4096,
+            "network_out": 1000,
+            "price": {
+                "hourly": 0.03,
+                "monthly": 20
+            },
+            "successor": null,
+            "transfer": 4000,
+            "vcpus": 2
+        }
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-types/#type-view) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/type_info.py
+++ b/plugins/module_utils/doc_fragments/type_info.py
@@ -1,0 +1,32 @@
+"""Documentation fragments for the vpc_info module"""
+
+specdoc_examples = ['''
+- name: Get info about a Linode type by ID
+  linode.cloud.type_info:
+    id: g6-standard-2''']
+
+result_type_samples = ['''
+{
+    "addons": {
+        "backups": {
+            "price": {
+                "hourly": 0.008,
+                "monthly": 5
+            }
+        }
+    },
+    "class": "standard",
+    "disk": 81920,
+    "gpus": 0,
+    "id": "g6-standard-2",
+    "label": "Linode 4GB",
+    "memory": 4096,
+    "network_out": 1000,
+    "price": {
+        "hourly": 0.03,
+        "monthly": 20
+    },
+    "successor": null,
+    "transfer": 4000,
+    "vcpus": 2
+}''']

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode Type."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Dict
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.type_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import LinodeClient, Type
+
+
+def _get_by_id(client: LinodeClient, params: Dict[str, Any]):
+    """
+    This function is intended to be passed into the ID get attribute.
+
+    NOTE: This is not implemented as a lambda because Type currently does not work with
+    client.load().
+    """
+    inst_type = Type(client, params.get("id"))
+    inst_type._api_get()
+    return inst_type._raw_json
+
+
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="type",
+        field_type=FieldType.dict,
+        display_name="Type",
+        docs_url="https://www.linode.com/docs/api/linode-types/#type-view",
+        samples=docs.result_type_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            display_name="ID",
+            name="id",
+            type=FieldType.string,
+            get=_get_by_id,
+        )
+    ],
+    examples=docs.specdoc_examples,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -17,7 +17,7 @@ from ansible_specdoc.objects import FieldType
 from linode_api4 import LinodeClient, Type
 
 
-def _get_by_id(client: LinodeClient, params: Dict[str, Any]):
+def _get_by_id(client: LinodeClient, params: Dict[str, Any]) -> None:
     """
     This function is intended to be passed into the ID get attribute.
 

--- a/tests/integration/targets/type_info/tasks/main.yaml
+++ b/tests/integration/targets/type_info/tasks/main.yaml
@@ -1,0 +1,20 @@
+- name: type_info
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Get info about a type by ID
+      linode.cloud.type_info:
+        id: g6-standard-2
+      register: type_info
+
+    - assert:
+        that:
+          - type_info.type.class == "standard"
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This PR adds a `type_info` module that allows users to get information about a Linode type by ID.

## ✔️ How to Test

E2E Testing:

```
make TEST_ARGS="-v type_info" test
```

Manual Testing:

1. Inside of a collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: type_info example
  hosts: localhost
  tasks:
    - name: Get info about the g6-standard-4 type
      linode.cloud.type_info:
        id: g6-standard-4
      register: type_info

    - name: Output info about the instance
      debug:
        msg: |
          Type Info:
            ID: {{ type_info.type.id }}
            Label: {{ type_info.type.label }}
            Class: {{ type_info.type.class }}
```