### PR TITLE
new: Add `account_availability_info` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modules for retrieving information about existing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)| Get info about a Linode Account Availability.|
+[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|Get info about a Linode Account Availability.|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Modules for retrieving information about existing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
+[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)| Get info about a Linode Account Availability.        |
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modules for retrieving information about existing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)| Get info about a Linode Account Availability.        |
+[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)| Get info about a Linode Account Availability.|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`trailing\_separator`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :emphasis:`False`\  to omit the \ :literal:`separator`\  after the host variable when the value is an empty string.
+        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`default\_value`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
 
 
 

--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -12,25 +12,28 @@ Get info about a Linode Account Availability.
 - name: Get info about the current Linode account availability
   linode.cloud.account_info: 
     region: us-east
+
 ```
+
 
 ## Parameters
 
-| Field    | Type | Required                  | Description                              |
-|----------|------|---------------------------|------------------------------------------|
-| `region` | <center>`str`</center> | <center>Required</center> | The region ID of the availability entry. |
-
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `region` | <center>`str`</center> | <center>Optional</center> | The Region of the Account Availability to resolve.   |
 
 ## Return Values
 
-- `account_availability` - The returned Account Availability info.
+- `account_availability` - The returned Account Availability.
 
     - Sample Response:
         ```json
+        
         {
           "region": "us-east",
           "unavailable": ["Linode"]
         }
+        
         ```
     - See the [Linode API response documentation](TBD) for a list of returned fields
 

--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -1,0 +1,37 @@
+# account_availability_info
+
+Get info about a Linode Account Availability.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Get info about the current Linode account availability
+  linode.cloud.account_info: 
+    region: us-east
+```
+
+## Parameters
+
+| Field    | Type | Required                  | Description                              |
+|----------|------|---------------------------|------------------------------------------|
+| `region` | <center>`str`</center> | <center>Required</center> | The region ID of the availability entry. |
+
+
+## Return Values
+
+- `account_availability` - The returned Account Availability info.
+
+    - Sample Response:
+        ```json
+        {
+          "region": "us-east",
+          "unavailable": ["Linode"]
+        }
+        ```
+    - See the [Linode API response documentation](TBD) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/account_availability_info.py
+++ b/plugins/module_utils/doc_fragments/account_availability_info.py
@@ -1,0 +1,15 @@
+"""Documentation fragments for the account_availability module"""
+
+result_account_availability_samples = ['''
+{
+  "region": "us-east",
+  "unavailable": ["Linode"]
+}
+''']
+
+
+specdoc_examples = ['''
+- name: Get info about the current Linode account availability
+  linode.cloud.account_info: 
+    region: us-east
+''']

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Account Availability info."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_availability_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import AccountAvailability
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="Account Availability",
+        field_name="account_availability",
+        field_type=FieldType.dict,
+        docs_url="TBD",
+        samples=docs.result_account_availability_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            name="region",
+            display_name="Region",
+            type=FieldType.string,
+            get=lambda client, params: client.load(
+                AccountAvailability, params.get("region")
+            )._raw_json,
+        ),
+    ],
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    account_availability_info as docs
+    account_availability_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -5,7 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_availability_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    account_availability_info as docs
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleAttr,

--- a/tests/integration/targets/account_availability_info/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_info/tasks/main.yaml
@@ -1,0 +1,17 @@
+- name: account_availability_info
+  block:
+    - name: Get info about the current account availability
+      linode.cloud.account_availability_info:
+        region: 'us-east'
+      register: account_availability
+
+    - assert:
+        that:
+          - account_availability.account_availability.region == "us-east"
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/account_availability_info/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_info/tasks/main.yaml
@@ -2,7 +2,7 @@
   block:
     - name: Get info about the current account availability
       linode.cloud.account_availability_info:
-        region: 'us-east'
+        region: us-east
       register: account_availability
 
     - assert:


### PR DESCRIPTION
## 📝 Description

Add the `account_availability_info` module for user to get information about resource availability in a region to their account.

## ✔️ How to Test

To run the test, you'll need to install python sdk from [proj/dc-get-well](https://github.com/linode/linode_api4-python/tree/proj/dc-get-well) branch, and test it in Alpha.

`make TEST_ARGS="-v account_availability_info" test`

**Manual test:**

1. Inside of a collection sandbox environment (e.g. dx-devenv), run the following playbook:

```
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Get account availability information
      linode.cloud.account_availability_info:
        region: us-east
      register: account_availability

    - name: Output info about the accout availability
      debug:
        msg: |
          Account Availability Info:
            Region: {{ account_availability.account_availability.region }}
            Unavailable: {{ account_availability.account_availability.unavailable }}
```