### PR TITLE
test: replace legacy compute regions in integration tests

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       tests:
         description: 'The tests to run.'
-        required: true
+        required: false
       sha:
         description: 'The hash value of the commit.'
         required: true

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`trailing\_separator`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :emphasis:`False`\  to omit the \ :literal:`separator`\  after the host variable when the value is an empty string.
+        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`default\_value`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
 
 
 

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -5,7 +5,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.17
         state: present
@@ -14,7 +14,7 @@
     - name: Create another Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}-2'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.17
         state: present

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.17
         state: present
@@ -15,7 +15,7 @@
     - name: Create Nodebalancer
       linode.cloud.nodebalancer:
         label: 'ansible-test-nb-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
       register: nb
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -5,7 +5,7 @@
     - name: Create a Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.17
         state: present

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create an instance to image
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.16
         state: present

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance without set backup to be enabled
       linode.cloud.instance:
         label: 'ansible-test-not-set-backup-{{ r }}'
-        region: us-central
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
         wait: false

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance without a root password
       linode.cloud.instance:
         label: 'ansible-test-nopass-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         private_ip: true
@@ -24,7 +24,7 @@
     - name: Create a Linode instance with additional ips and without a root password
       linode.cloud.instance:
         label: 'ansible-test-additional-ips-nopass-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         private_ip: true
@@ -44,7 +44,7 @@
     - name: Update the instance region and type (recreate disallowed)
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-southeast
+        region: us-ord
         group: funny
         type: g6-standard-2
         image: linode/ubuntu20.04
@@ -57,7 +57,7 @@
     - name: Attempt to add additional ips to an instance
       linode.cloud.instance:
         label: '{{ create_additional_ips.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         private_ip: true
@@ -73,7 +73,7 @@
     - name: Attempt to remove additional ips from an instance
       linode.cloud.instance:
         label: '{{ create_additional_ips.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         private_ip: true
@@ -86,7 +86,7 @@
     - name: Update the instance
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-east
+        region: us-ord
         group: funny
         type: g6-standard-1
         image: linode/ubuntu20.04
@@ -108,7 +108,7 @@
       assert:
         that:
           - info_id.instance.ipv4|length > 1
-          - info_id.instance.region == 'us-east'
+          - info_id.instance.region == 'us-ord'
           - info_id.configs|length == 1
           - info_id.networking.ipv4.public[0].address != None
 
@@ -121,7 +121,7 @@
       assert:
         that:
           - info_label.instance.ipv4|length > 1
-          - info_label.instance.region == 'us-east'
+          - info_label.instance.region == 'us-ord'
           - info_label.configs|length == 1
 
   always:

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a booted Linode instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123
@@ -25,7 +25,7 @@
     - name: Power off the instance
       linode.cloud.instance:
         label: '{{create.instance.label}}'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance with explicit disks and config
       linode.cloud.instance:
         label: 'ansible-test-dc-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: false
         disks:
@@ -55,7 +55,7 @@
     - name: Keep the config unchanged
       linode.cloud.instance:
         label: 'ansible-test-dc-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: false
         disks:
@@ -88,7 +88,7 @@
     - name: Update the config
       linode.cloud.instance:
         label: 'ansible-test-dc-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: false
         disks:
@@ -123,7 +123,7 @@
     - name: Delete the config and resize the disk
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: false
         disks:
@@ -142,7 +142,7 @@
     - name: Try to update the disk
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: false
         disks:
@@ -156,7 +156,7 @@
     - name: Try to use conflicting params
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.17
         booted: false
@@ -170,7 +170,7 @@
     - name: Boot the instance with a new config and disk
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         booted: true
         disks:

--- a/tests/integration/targets/instance_firewall/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall/tasks/main.yaml
@@ -28,7 +28,7 @@
     - name: Create a Linode instance attached to the Firewall
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         firewall_id: '{{ firewall_create.firewall.id }}'
         wait: false
@@ -48,7 +48,7 @@
     - name: Attempt to update the firewall_id for the instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         firewall_id: '{{ firewall_2_create.firewall.id }}'
         wait: false

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance with interface
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}-i'
-        region: us-southeast
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         interfaces:
@@ -29,7 +29,7 @@
     - name: Update the instance interfaces
       linode.cloud.instance:
         label: '{{ create_interface.instance.label }}'
-        region: us-southeast
+        region: us-ord
         group: funny
         type: g6-standard-1
         image: linode/ubuntu20.04
@@ -52,7 +52,7 @@
     - name: Update the instance interfaces
       linode.cloud.instance:
         label: '{{ create_interface.instance.label }}'
-        region: us-southeast
+        region: us-ord
         group: funny
         type: g6-standard-1
         image: linode/ubuntu20.04

--- a/tests/integration/targets/instance_inventory/playbooks/setup_instance.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/setup_instance.yml
@@ -11,7 +11,7 @@
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
         type: g6-nanode-1
-        region: us-east
+        region: us-ord
         tags:
           - ansible-inventory-node
         state: present

--- a/tests/integration/targets/instance_inventory/playbooks/teardown.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/teardown.yml
@@ -11,7 +11,7 @@
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
         type: g6-nanode-1
-        region: us-east
+        region: us-ord
         tags:
           - ansible-inventory-node
         state: absent

--- a/tests/integration/targets/instance_inventory/templates/filter.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/filter.instance.yml
@@ -5,4 +5,4 @@ types:
 tags:
   - ansible-inventory-node
 regions:
-  - us-east
+  - us-ord

--- a/tests/integration/targets/instance_inventory/templates/templatetoken.instance.yml
+++ b/tests/integration/targets/instance_inventory/templates/templatetoken.instance.yml
@@ -5,4 +5,4 @@ types:
 tags:
   - ansible-inventory-node
 regions:
-  - us-east
+  - us-ord

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance without a root password
       linode.cloud.instance:
         label: 'ansible-test-nopass-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         private_ip: true
@@ -35,13 +35,13 @@
         order: desc
         filters:
           - name: region
-            values: us-east
+            values: us-ord
       register: filter
 
     - assert:
         that:
           - filter.instances | length >= 1
-          - filter.instances[0].region == 'us-east'
+          - filter.instances[0].region == 'us-ord'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a Linode instance with an immediate timeout
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         wait: yes

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create an instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.16
         wait: no

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create an instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-central
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
         wait: no

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -8,7 +8,7 @@
     - name: Create an instance to get IPs.
       linode.cloud.instance:
         label: 'ansible-test-{{ r1 }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.16
         wait: false
@@ -18,7 +18,7 @@
     - name: Create an instance to be shared with IPs.
       linode.cloud.instance:
         label: 'ansible-test-{{ r2 }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.16
         wait: false

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create an instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/alpine3.16
         wait: no

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -21,7 +21,7 @@
     - name: Create a database
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{engine_id}}'
         type: g6-standard-1
         allow_list:
@@ -35,7 +35,7 @@
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
           - db_create.database.version == '{{ engine_version }}'
-          - db_create.database.region == 'us-east'
+          - db_create.database.region == 'us-ord'
           - db_create.database.type == 'g6-standard-1'
 
     - name: Get info about the database by ID
@@ -54,7 +54,7 @@
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'mysql'
           - by_label.database.version == '{{ engine_version }}'
-          - by_label.database.region == 'us-east'
+          - by_label.database.region == 'us-ord'
           - by_label.database.type == 'g6-standard-1'
           - by_label.ssl_cert != None
           - by_label.credentials != None
@@ -63,7 +63,7 @@
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'mysql'
           - by_id.database.version == '{{ engine_version }}'
-          - by_id.database.region == 'us-east'
+          - by_id.database.region == 'us-ord'
           - by_id.database.type == 'g6-standard-1'
           - by_id.ssl_cert != None
           - by_id.credentials != None
@@ -73,7 +73,7 @@
     - name: Update the database
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
@@ -115,7 +115,7 @@
     - name: Update the database
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -21,7 +21,7 @@
     - name: Validation check
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
@@ -33,7 +33,7 @@
     - name: Create a database
       linode.cloud.database_mysql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: "{{ engine_id }}"
         type: g6-standard-1
         allow_list:
@@ -57,7 +57,7 @@
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'mysql'
           - db_create.database.version == '{{ engine_version }}'
-          - db_create.database.region == 'us-east'
+          - db_create.database.region == 'us-ord'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3
           - db_create.database.encrypted == true

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: create empty nodebalancer
       linode.cloud.nodebalancer:
         label: 'ansible-test-empty-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
       register: create_empty_nodebalancer
 
@@ -19,7 +19,7 @@
     - name: update empty nodebalancer
       linode.cloud.nodebalancer:
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         client_conn_throttle: 6
         state: present
       register: update_empty_nodebalancer
@@ -39,7 +39,7 @@
     - name: Add NodeBalancer config
       linode.cloud.nodebalancer:
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         client_conn_throttle: 6
         state: present
         configs:
@@ -56,7 +56,7 @@
     - name: Update NodeBalancer config
       linode.cloud.nodebalancer:
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         client_conn_throttle: 6
         state: present
         configs:
@@ -76,7 +76,7 @@
     - name: Recreate NodeBalancer config
       linode.cloud.nodebalancer:
         label: '{{ create_empty_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         client_conn_throttle: 6
         state: present
         configs:

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -19,7 +19,7 @@
     - name: Create Nodebalancer
       linode.cloud.nodebalancer:
         label: 'ansible-test-nb-{{ r }}'
-        region: us-east
+        region: us-ord
         firewall_id: '{{ firewall.firewall.id }}'
         state: present
       register: nodebalancer

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: create empty nodebalancer
       linode.cloud.nodebalancer:
         label: 'ansible-test-empty-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
       register: create
 
@@ -30,13 +30,13 @@
         order: desc
         filters:
           - name: region
-            values: us-east
+            values: us-ord
       register: filter
 
     - assert:
         that:
           - filter.nodebalancers | length >= 1
-          - filter.nodebalancers[0].region == 'us-east'
+          - filter.nodebalancers[0].region == 'us-ord'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -5,7 +5,7 @@
 
     - linode.cloud.nodebalancer:
         label: 'ansible-nb-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 80
@@ -73,7 +73,7 @@
     - name: Create a populated NodeBalancer
       linode.cloud.nodebalancer:
         label: 'ansible-nb-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 80

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -7,7 +7,7 @@
     - name: Create node1
       linode.cloud.instance:
         label: 'ansible-test-node1-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123
@@ -25,7 +25,7 @@
     - name: Create node2
       linode.cloud.instance:
         label: 'ansible-test-node2-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123
@@ -62,7 +62,7 @@
     - name: Create a populated NodeBalancer
       linode.cloud.nodebalancer:
         label: 'ansible-nb-populated-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 80
@@ -92,7 +92,7 @@
       assert:
         that:
           - create_populated_nodebalancer.changed
-          - create_populated_nodebalancer.node_balancer.region == 'us-east'
+          - create_populated_nodebalancer.node_balancer.region == 'us-ord'
           - create_populated_nodebalancer.configs|length == 1
           - create_populated_nodebalancer.configs[0].port == 80
           - create_populated_nodebalancer.configs[0].protocol == 'http'
@@ -113,7 +113,7 @@
     - name: Update the NodeBalancer config
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 81 # Port changed
@@ -135,7 +135,7 @@
     - name: Attempt to update with no differences
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 81
@@ -155,7 +155,7 @@
     - name: Add node to NodeBalancer
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 81
@@ -178,7 +178,7 @@
     - name: Add node from different region to NodeBalancer
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 81
@@ -199,7 +199,7 @@
     - name: Add additional config and node to NodeBalancer
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 81
@@ -230,7 +230,7 @@
     - name: Remove a config from the NodeBalancer
       linode.cloud.nodebalancer:
         label: '{{ create_populated_nodebalancer.node_balancer.label }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 80

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create node
       linode.cloud.instance:
         label: 'ansible-test-node-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123
@@ -25,7 +25,7 @@
     - name: Create a populated NodeBalancer
       linode.cloud.nodebalancer:
         label: 'ansible-nb-populated-{{ r }}'
-        region: us-east
+        region: us-ord
         state: present
         configs:
           - port: 80
@@ -54,7 +54,7 @@
       assert:
         that:
           - create_populated_nodebalancer.changed
-          - create_populated_nodebalancer.node_balancer.region == 'us-east'
+          - create_populated_nodebalancer.node_balancer.region == 'us-ord'
           - create_populated_nodebalancer.configs|length == 1
           - create_populated_nodebalancer.configs[0].port == 80
           - create_populated_nodebalancer.configs[0].protocol == 'http'

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -3,27 +3,27 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Get info about clusters in us-east
+    - name: Get info about clusters in us-ord
       linode.cloud.object_cluster_info:
-        region: us-east
+        region: us-ord
       register: info_by_region
 
     - name: Assert cluster information is valid
       assert:
         that:
-          - info_by_region.clusters[0].id == 'us-east-1'
-          - info_by_region.clusters[0].region == 'us-east'
+          - info_by_region.clusters[0].id == 'us-ord-1'
+          - info_by_region.clusters[0].region == 'us-ord'
 
-    - name: Get info about cluster id us-east-1
+    - name: Get info about cluster id us-ord-1
       linode.cloud.object_cluster_info:
-        id: us-east-1
+        id: us-ord-1
       register: info_by_id
 
     - name: Assert cluster information is valid
       assert:
         that:
-          - info_by_id.clusters[0].id == 'us-east-1'
-          - info_by_id.clusters[0].region == 'us-east'
+          - info_by_id.clusters[0].id == 'us-ord-1'
+          - info_by_id.clusters[0].region == 'us-ord'
 
     - name: Create a Linode key
       linode.cloud.object_keys:
@@ -55,10 +55,10 @@
       linode.cloud.object_keys:
         label: 'test-ansible-key-access-{{ r }}'
         access:
-          - cluster: us-east-1
+          - cluster: us-ord-1
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_write
-          - cluster: us-east-1
+          - cluster: us-ord-1
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_only
         state: present
@@ -69,10 +69,10 @@
         that:
           - create_access.changed
           - 'not "REDACTED" in create_access.key.secret_key'
-          - create_access.key.bucket_access[0].cluster == 'us-east-1'
+          - create_access.key.bucket_access[0].cluster == 'us-ord-1'
           - create_access.key.bucket_access[0].bucket_name == create_bucket.name
           - create_access.key.bucket_access[0].permissions == 'read_write'
-          - create_access.key.bucket_access[1].cluster == 'us-east-1'
+          - create_access.key.bucket_access[1].cluster == 'us-ord-1'
           - create_access.key.bucket_access[1].bucket_name == create_bucket.name
           - create_access.key.bucket_access[1].permissions == 'read_only'
 

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -12,13 +12,13 @@
       linode.cloud.object_cluster_list:
         filters:
           - name: region
-            values: us-east
+            values: us-ord
       register: filter
 
     - assert:
         that:
           - filter.clusters | length >= 1
-          - filter.clusters[0].region == 'us-east'
+          - filter.clusters[0].region == 'us-ord'
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -21,7 +21,7 @@
     - name: Create a database
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
@@ -35,7 +35,7 @@
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
           - db_create.database.version == '{{ engine_version }}'
-          - db_create.database.region == 'us-east'
+          - db_create.database.region == 'us-ord'
           - db_create.database.type == 'g6-standard-1'
 
     - name: Get info about the database by ID
@@ -54,19 +54,19 @@
           - by_label.database.allow_list[0] == '0.0.0.0/0'
           - by_label.database.engine == 'postgresql'
           - by_label.database.version == '{{ engine_version }}'
-          - by_label.database.region == 'us-east'
+          - by_label.database.region == 'us-ord'
           - by_label.database.type == 'g6-standard-1'
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'postgresql'
           - by_id.database.version == '{{ engine_version }}'
-          - by_id.database.region == 'us-east'
+          - by_id.database.region == 'us-ord'
           - by_id.database.type == 'g6-standard-1'
 
     - name: Update the database
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
@@ -82,7 +82,7 @@
     - name: Update the database
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -21,7 +21,7 @@
     - name: Validation check
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
@@ -33,7 +33,7 @@
     - name: Create a database
       linode.cloud.database_postgresql:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         engine: '{{ engine_id }}'
         type: g6-standard-1
         allow_list:
@@ -58,7 +58,7 @@
           - db_create.database.allow_list[0] == '0.0.0.0/0'
           - db_create.database.engine == 'postgresql'
           - db_create.database.version == '{{ engine_version }}'
-          - db_create.database.region == 'us-east'
+          - db_create.database.region == 'us-ord'
           - db_create.database.type == 'g6-standard-1'
           - db_create.database.cluster_size == 3
           - db_create.database.encrypted == true

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create Linode instance
       linode.cloud.instance:
         label: 'ansible-test-inst-{{ r }}'
-        region: us-east
+        region: us-ord
         type: g6-standard-1
         image: linode/ubuntu20.04
         root_pass: Fn$$oobar123
@@ -21,7 +21,7 @@
     - name: Create a volume with an instance
       linode.cloud.volume:
         label: 'ansible-test-attached-{{ r }}'
-        region: us-east
+        region: us-ord
         size: 30
         linode_id: '{{ create_inst.instance.id }}'
         state: present
@@ -47,7 +47,7 @@
     - name: Create a volume without an instance
       linode.cloud.volume:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         size: 42
         state: present
       register: create_volume_noinst

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a volume
       linode.cloud.volume:
         label: 'ansible-test-{{ r }}'
-        region: us-east
+        region: us-ord
         size: 42
         state: present
       register: create
@@ -31,13 +31,13 @@
         order: desc
         filters:
           - name: region
-            values: us-east
+            values: us-ord
       register: filter
     
     - assert:
         that:
           - filter.volumes | length >= 1
-          - filter.volumes[0].region == 'us-east'
+          - filter.volumes[0].region == 'us-ord'
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

Regions have been updated:
Legacy Compute sites are in Atlanta, Dallas, Frankfurt, Fremont, London, Mumbai, Newark, Singapore, Sydney, Tokyo, and Toronto

New Core Compute sites are in Amsterdam, Chennai, Chicago, Jakarta, Los Angeles, Madrid (coming soon!), Miami, Milan, Osaka, Paris, São Paulo, Seattle, Stockholm, and Washington, DC (and the list will continue to grow).

All integration test runs provision infrastructure only in New Core Compute sites (not Legacy Compute sites). For this repository, replacing all legacy regions with Chicago and Miami region

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**