### PR TITLE
new: Add `account_availability_list` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 
 Name | Description |
 --- | ------------ |
+[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilitys.|
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`trailing\_separator`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :emphasis:`False`\  to omit the \ :literal:`separator`\  after the host variable when the value is an empty string.
+        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`default\_value`\ .
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
 
 
 

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,6 +1,6 @@
 # account_availability_list
 
-List and filter on Account Availability.
+List and filter on Account Availabilitys.
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,0 +1,49 @@
+# account_availability_list
+
+List Account Availabilities. No filters can be sent to API currently. Only count is definable.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the region resource availabilities to the account
+  linode.cloud.account_availability_list: {}
+```
+
+```yaml
+- name: List 5 regions' availabilities to the Linode Account
+  linode.cloud.account_availability_list:
+    count: 5
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                                 |
+|-----------|------|----------|---------------------------------------------------------------------------------------------|
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Account Availabilities to return. If undefined, all results will be returned. |
+
+
+## Return Values
+
+- `account_availabilities` - The returned Account Availabilities.
+
+    - Sample Response:
+        ```json
+        [
+            {
+              "region": "ap-west",
+              "unavailable": ["Linode"]
+            },
+            {
+              "region": "ca-central",
+              "unavailable": ["Linode", "Block Storage"]
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](TBD) for a list of returned fields
+
+

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,6 +1,6 @@
 # account_availability_list
 
-List Account Availabilities. No filter can be sent to the API currently. Only count is definable.
+List and filter on Account Availability.
 
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -13,23 +13,26 @@ List Account Availabilities. No filter can be sent to the API currently. Only co
   linode.cloud.account_availability_list: {}
 ```
 
-```yaml
-- name: List 5 regions' availabilities to the Linode Account
-  linode.cloud.account_availability_list:
-    count: 5
-```
-
 
 ## Parameters
 
-| Field     | Type | Required | Description                                                                                 |
-|-----------|------|----------|---------------------------------------------------------------------------------------------|
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of Account Availabilities to return. If undefined, all results will be returned. |
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Account Availabilitys in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Account Availabilitys by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Account Availabilitys.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Account Availabilitys to return. If undefined, all results will be returned.   |
 
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](TBD).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `account_availabilities` - The returned Account Availabilities.
+- `account_availabilities` - The returned Account Availabilitys.
 
     - Sample Response:
         ```json

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,6 +1,6 @@
 # account_availability_list
 
-List Account Availabilities. No filters can be sent to API currently. Only count is definable.
+List Account Availabilities. No filter can be sent to the API currently. Only count is definable.
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/plugins/module_utils/doc_fragments/account_availability_list.py
+++ b/plugins/module_utils/doc_fragments/account_availability_list.py
@@ -1,0 +1,16 @@
+"""Documentation fragments for the account_availability_list module"""
+
+specdoc_examples = ['''
+- name: List all of the region resource availabilities to the account
+  linode.cloud.account_availability_list: {}''']
+
+result_account_availabilities_samples = ['''[
+    {
+      "region": "ap-west",
+      "unavailable": ["Linode"]
+    },
+    {
+      "region": "ca-central",
+      "unavailable": ["Linode", "Block Storage"]
+    }
+]''']

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -5,7 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_availability_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    account_availability_list as docs
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModule,
 )

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Account Availabilities."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_availability_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Account Availability",
+    result_field_name="account_availabilities",
+    endpoint_template="/account/availability",
+    result_docs_url="TBD",
+    result_samples=docs.result_account_availabilities_samples,
+    examples=docs.specdoc_examples,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    account_availability_list as docs
+    account_availability_list as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModule,

--- a/tests/integration/targets/account_availability_list/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_list/tasks/main.yaml
@@ -1,0 +1,16 @@
+- name: account_availability_list
+  block:
+    - linode.cloud.account_availability_list:
+        count: 5
+      register: no_filter
+
+    - assert:
+        that:
+          - no_filter.account_availabilities | length == 5
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Add a new list module `account_availability_list` to show a list of region availabilities to the account. This module is currently not filterable because the API doesn't support filtering.

## ✔️ How to Test

To test again Alpha, you probably need to overwrite the following variables:

```
TEST_API_URL=alpha/api-url
TEST_API_CA=your-local-ca-file
LINODE_TOKEN=alpha-linode-token
```

`make TEST_ARGS="-v account_availability_list" test`