### PR TITLE
new: Improve InfoModule attribute spec generation

### DIFF
--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -20,7 +20,7 @@ Get info about a Linode Account Availability.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `region` | <center>`str`</center> | <center>Optional</center> | The Region of the Account Availability to resolve.   |
+| `region` | <center>`str`</center> | <center>**Required**</center> | The Region of the Account Availability to resolve.   |
 
 ## Return Values
 

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -25,8 +25,8 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.   |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Instance to resolve.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Instance to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -25,8 +25,8 @@ Get info about a Linode StackScript.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.   |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 

--- a/docs/modules/type_info.md
+++ b/docs/modules/type_info.md
@@ -19,7 +19,7 @@ Get info about a Linode Type.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the Type to resolve.   |
+| `id` | <center>`str`</center> | <center>**Required**</center> | The ID of the Type to resolve.   |
 
 ## Return Values
 

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -25,8 +25,8 @@ Get info about a Linode VPC.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.   |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC to resolve.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 

--- a/docs/modules/vpc_subnet_info.md
+++ b/docs/modules/vpc_subnet_info.md
@@ -28,8 +28,8 @@ Get info about a Linode VPC Subnet.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC for this resource.   |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.   |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC Subnet to resolve.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC Subnet to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -176,6 +176,7 @@ class InfoModule(LinodeModuleBase):
         for attr in self.attributes:
             options[attr.name] = SpecField(
                 type=attr.type,
+                required=len(self.attributes) == 1,
                 description=f"The {attr.display_name} of the "
                 f"{self.primary_result.display_name} to resolve.",
             )

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -177,6 +177,9 @@ class InfoModule(LinodeModuleBase):
             options[attr.name] = SpecField(
                 type=attr.type,
                 required=len(self.attributes) == 1,
+                conflicts_with=[
+                    v.name for v in self.attributes if v.name != attr.name
+                ],
                 description=f"The {attr.display_name} of the "
                 f"{self.primary_result.display_name} to resolve.",
             )


### PR DESCRIPTION
## 📝 Description

This change makes the following improvements to the attribute spec generation in the InfoModule base class:
- Individual info module attributes are now treated as required.
- Info module attributes now are now marked as in-conflict with other attributes. 

## ✔️ How to Test

### Unit Testing

```
make unittest
```

### Manually Testing Required Individual Attributes

1. Inside of an ansible_linode sandbox environment, run the following playbook:

```yaml
---
- name: Required attribute testing
  hosts: localhost
  tasks:
    - name: Get info about a type without specifying an ID
      linode.cloud.type_info:
```

2. Observe the following error is raised:

```
missing required arguments: id
```

3. Update the playbook to include a type ID:

```yaml
---
- name: Required attribute testing
  hosts: localhost
  tasks:
    - name: Get info about a type without specifying an ID
      linode.cloud.type_info:
        id: g6-nanode-1
```

4. Observe the playbook passes as expected.
