### PR TITLE
fix: Resolve issue that causes `make unittest` and `make install` to fail

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,5 @@ black>=23.1.0
 isort>=5.12.0
 autoflake>=2.0.1
 pytest>=7.3.1
-pytest-ansible>=4.1.0
 pytest-forked>=1.6.0
 pytest-xdist>=3.3.1

--- a/template/galaxy.template.yml
+++ b/template/galaxy.template.yml
@@ -26,3 +26,4 @@ build_ignore:
   - 'tests'
   - 'scripts'
   - 'venv'
+  - 'collections'


### PR DESCRIPTION
## 📝 Description

This change resolves two issues that caused the `make unittest` and `make install` targets to fail on certain machines:
- The PyTest Ansible plugin (pytest-ansible) package was being explicitly installed but is now provided directly in the [`ansible` package](https://github.com/ansible/ansible/tree/devel/test/lib/ansible_test/_util/target/pytest/plugins), causing a conflict.
- The `collections` symlink was not being ignored in the `galaxy.yml` file, leading to an error when attempting to resolve the link during install
    - ` Unexpected Exception, this is probably a bug: "linkname 'collections/ansible_collections/linode/cloud/../../../../Makefile' not found"`

## ✔️ How to Test

1. Clone a fresh copy of this PR.
```bash
mkdir -p testproject/ansible_collections/linode
cd testproject/ansible_collections/linode
git clone --branch fix/install-unit-test-errors git@github.com:lgarber-akamai/ansible_linode.git cloud
cd cloud
```

2. Install the project dependencies.

```
make deps
```

3. Attempt to run unit tests on the collection.
```bash
make unittest
```

4. Attempt to install the collection.
```bash
make install
```

5. Observe that none of the previous steps failed.
