### PR TITLE
test: fix failures caused by jinja2 templating in assertions

### DIFF
--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -73,9 +73,12 @@
       register: ip_unshared
 
     - name: Assert shared IPs configured.
-      assert:
+      set_fact:
+        ip_shared_address: "{{ instance_create.instance.ipv4[0] }}"
+
+    - assert:
         that:
-          - ip_shared.ips[0] == '{{ instance_create.instance.ipv4[0]}}'
+          - ip_shared.ips[0] == ip_shared_address
           - ip_already_shared.changed == false
           - ip_unshared.ips == []
           

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -42,11 +42,14 @@
         state: present
       register: nb_node
 
+    - set_fact:
+        inst_ipv4_address: "{{ inst.instance.ipv4[1] }}:80"
+
     - assert:
         that:
           - nb_node.changed
           - nb_node.node.label == 'cool'
-          - nb_node.node.address == '{{ inst.instance.ipv4[1] }}:80'
+          - nb_node.node.address == inst_ipv4_address
           - nb_node.node.mode == 'accept'
           - nb_node.node.weight == 10
 
@@ -66,7 +69,7 @@
         that:
           - nb_node_update.changed
           - nb_node_update.node.label == 'cool'
-          - nb_node_update.node.address == '{{ inst.instance.ipv4[1] }}:80'
+          - nb_node_update.node.address == inst_ipv4_address
           - nb_node_update.node.mode == 'reject'
           - nb_node_update.node.weight == 15
 


### PR DESCRIPTION
## 📝 Description

Some existing tests are failing:
 * [https://github.com/linode/ansible_linode/actions/runs/7189234896/job/19580390406]
 * [https://github.com/linode/ansible_linode/actions/runs/7189237086/job/19580397184]
 
 This PR fixes the failures caused by jinja2 templating issue

## ✔️ How to Test

make TEST_ARGS="-v nodebalancer_node" test 
 make TEST_ARGS="-v ip_share" test 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**