### PR TITLE
fix: Add `tags` to instance module spec

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -127,6 +127,7 @@ Manage Linode Instances, Configs, and Disks.
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an instance to have status "running".  **(Default: `240`)** |
 | [`additional_ipv4` (sub-options)](#additional_ipv4) | <center>`list`</center> | <center>Optional</center> | Additional ipv4 addresses to allocate.   |
 | `rebooted` | <center>`bool`</center> | <center>Optional</center> | If true, the Linode Instance will be rebooted. NOTE: The instance will only be rebooted if it was previously in a running state. To ensure your Linode will always be rebooted, consider also setting the `booted` field.  **(Default: `False`)** |
+| `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to this object. Tags are for organizational purposes only.  **(Updatable)** |
 
 ### configs
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -471,6 +471,15 @@ linode_instance_spec = {
         ],
         default=False,
     ),
+    "tags": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        description=[
+            "An array of tags applied to this object.",
+            "Tags are for organizational purposes only."
+        ],
+        editable=True,
+    )
 }
 
 SPECDOC_META = SpecDocMeta(

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -476,10 +476,10 @@ linode_instance_spec = {
         element_type=FieldType.string,
         description=[
             "An array of tags applied to this object.",
-            "Tags are for organizational purposes only."
+            "Tags are for organizational purposes only.",
         ],
         editable=True,
-    )
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(


### PR DESCRIPTION
## 📝 Description

The `tags` was missing in the instance module spec. Add it to the spec field. 

## ✔️ How to Test

`make TEST_ARGS="-v instance_basic" test`                                                     

**Manual test:** 
Inside of a collection sandbox environment (e.g. dx-devenv), run the following playbook:

```
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a Linode instance
      linode.cloud.instance:
        label: ansible-sbx-linode
        type: g6-nanode-1
        region: us-southeast
        image: linode/alpine3.16
        root_pass: v3rys3curep4ssword!!!!
        tags: ["example tag"]
        state: present
      register: instance

    - name: Output info about the instance
      debug:
        msg: |
          Instance Info:
            ID: {{ instance.instance.id }}
            Tags: {{ instance.instance.tags }}
```
