### PR TITLE
new: Return firewalls from nodebalancer and nodebalancer_info modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ The Python module dependencies are not installed by `ansible-galaxy`.  They can
 be manually installed using pip:
 
 ```shell
-pip install -r https://raw.githubusercontent.com/linode/ansible_linode/main/requirements.txt
+pip install --upgrade -r https://raw.githubusercontent.com/linode/ansible_linode/main/requirements.txt
 ```
+
+> :warning: **NOTE:** Python dependencies should always be reinstalled when upgrading collection versions
 
 ## Usage
 Once the Linode Ansible collection is installed, it can be referenced by its [Fully Qualified Collection Namespace (FQCN)](https://github.com/ansible-collections/overview#terminology): `linode.cloud.module_name`.

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -160,7 +160,7 @@ Manage a Linode NodeBalancer.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
 
 
-- `firewalls` - A list of firewalls the NodeBalancer is attached to.
+- `firewalls` - A list IDs for firewalls attached to this NodeBalancer.
 
     - Sample Response:
         ```json

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -160,3 +160,15 @@ Manage a Linode NodeBalancer.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
 
 
+- `firewalls` - A list of firewalls the NodeBalancer is attached to.
+
+    - Sample Response:
+        ```json
+        [
+          1234,
+          5678
+        ]
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#firewalls-list) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -113,3 +113,15 @@ Get info about a Linode NodeBalancer.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
 
 
+- `firewalls` - A list of firewalls the NodeBalancer is attached to.
+
+    - Sample Response:
+        ```json
+        [
+          1234,
+          5678
+        ]
+        ```
+    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#firewalls-list) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -113,7 +113,7 @@ Get info about a Linode NodeBalancer.
     - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
 
 
-- `firewalls` - A list of firewalls the NodeBalancer is attached to.
+- `firewalls` - A list IDs for firewalls attached to this NodeBalancer.
 
     - Sample Response:
         ```json

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -81,3 +81,8 @@ result_nodes_samples = ['''[
     "weight": 50
   }
 ]''']
+
+result_firewalls_samples = ['''[
+  1234,
+  5678
+]''']

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -290,7 +290,7 @@ SPECDOC_META = SpecDocMeta(
             sample=docs.result_nodes_samples,
         ),
         "firewalls": SpecReturnValue(
-            description="A list of firewalls the NodeBalancer is attached to.",
+            description="A list IDs for firewalls attached to this NodeBalancer.",
             docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
             type=FieldType.list,
             elements=FieldType.integer,

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -289,6 +289,13 @@ SPECDOC_META = SpecDocMeta(
             type=FieldType.list,
             sample=docs.result_nodes_samples,
         ),
+        "firewalls": SpecReturnValue(
+            description="A list of firewalls the NodeBalancer is attached to.",
+            docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
+            type=FieldType.list,
+            elements=FieldType.integer,
+            sample=docs.result_firewalls_samples,
+        ),
     },
 )
 
@@ -307,6 +314,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
             "node_balancer": None,
             "configs": [],
             "nodes": [],
+            "firewalls": [],
         }
 
         self._node_balancer: Optional[NodeBalancer] = None
@@ -616,6 +624,13 @@ class LinodeNodeBalancer(LinodeModuleBase):
             for node in config.nodes:
                 node._api_get()
                 cast(list, self.results["nodes"]).append(node._raw_json)
+
+        # NOTE: Only the Firewall IDs are used here to reduce the
+        # number of API requests made by this module and to simplify
+        # the module result.
+        self.results["firewalls"] = [
+            v.id for v in self._node_balancer.firewalls()
+        ]
 
         return self.results
 

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -80,7 +80,7 @@ SPECDOC_META = SpecDocMeta(
             sample=docs_parent.result_nodes_samples,
         ),
         "firewalls": SpecReturnValue(
-            description="A list of firewalls the NodeBalancer is attached to.",
+            description="A list IDs for firewalls attached to this NodeBalancer.",
             docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
             type=FieldType.list,
             elements=FieldType.integer,

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -79,6 +79,13 @@ SPECDOC_META = SpecDocMeta(
             type=FieldType.list,
             sample=docs_parent.result_nodes_samples,
         ),
+        "firewalls": SpecReturnValue(
+            description="A list of firewalls the NodeBalancer is attached to.",
+            docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
+            type=FieldType.list,
+            elements=FieldType.integer,
+            sample=docs_parent.result_firewalls_samples,
+        ),
     },
 )
 
@@ -91,7 +98,12 @@ class LinodeNodeBalancerInfo(LinodeModuleBase):
     def __init__(self) -> None:
         self.module_arg_spec = SPECDOC_META.ansible_spec
         self.required_one_of: List[str] = []
-        self.results: dict = {"node_balancer": None, "configs": [], "nodes": []}
+        self.results: dict = {
+            "node_balancer": None,
+            "configs": [],
+            "nodes": [],
+            "firewalls": [],
+        }
 
         super().__init__(
             module_arg_spec=self.module_arg_spec,
@@ -154,6 +166,11 @@ class LinodeNodeBalancerInfo(LinodeModuleBase):
                 node._api_get()
 
                 self.results["nodes"].append(node._raw_json)
+
+        # NOTE: Only the Firewall IDs are used here to reduce the
+        # number of API requests made by this module and to simplify
+        # the module result.
+        self.results["firewalls"] = [v.id for v in node_balancer.firewalls()]
 
         return self.results
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -65,8 +65,10 @@ The Python module dependencies are not installed by `ansible-galaxy`.  They can
 be manually installed using pip:
 
 ```shell
-pip install -r https://raw.githubusercontent.com/linode/ansible_linode/{{collection_version}}/requirements.txt
+pip install --upgrade -r https://raw.githubusercontent.com/linode/ansible_linode/{{collection_version}}/requirements.txt
 ```
+
+> :warning: **NOTE:** Python dependencies should always be reinstalled when upgrading collection versions
 
 ## Usage
 Once the Linode Ansible collection is installed, it can be referenced by its [Fully Qualified Collection Namespace (FQCN)](https://github.com/ansible-collections/overview#terminology): `linode.cloud.module_name`.

--- a/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_firewall/tasks/main.yaml
@@ -29,6 +29,19 @@
         that:
           - nodebalancer.changed
           - nodebalancer.configs|length == 0
+          - nodebalancer.firewalls|length == 1
+          - nodebalancer.firewalls[0] == firewall.firewall.id
+
+    - name: Get info about the NodeBalancer
+      linode.cloud.nodebalancer_info:
+        id: '{{ nodebalancer.node_balancer.id }}'
+      register: nodebalancer_info
+
+    - name: Ensure the attached firewalls are returned
+      assert:
+        that:
+          - nodebalancer_info.firewalls|length == 1
+          - nodebalancer_info.firewalls[0] == firewall.firewall.id
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

This change adds a new `firewalls` field returned by the `nodebalancer` and `nodebalancer_info` modules, allowing users to easily access which firewalls are attached to a NodeBalancer.

## ✔️ How to Test

The following test steps assume you have pulled down this change locally.

### Integration Tests

```bash
make TEST_ARGS="-v nodebalancer_firewall" test
```

### Manual Testing

1. In a collection sandbox environment (e.g. dx-devenv) run the following playbook:

```yaml
---
- name: NodeBalancer firewalls testing
  hosts: localhost
  tasks:
    - name: Create a Firewall
      linode.cloud.firewall:
        label: 'test-firewall'
        devices: []
        rules:
          inbound: []
          inbound_policy: DROP
          outbound: []
          outbound_policy: DROP
        state: present
      register: create_firewall

    - name: Create a NodeBalancer
      linode.cloud.nodebalancer:
        label: 'test-nodebalancer'
        region: us-ord
        firewall_id: '{{ create_firewall.firewall.id }}'
        state: present
      register: create_nodebalancer

    - name: Get info about the NodeBalancer
      linode.cloud.nodebalancer_info:
        label: 'test-nodebalancer'
      register: info_nodebalancer

    - debug:
        var: create_nodebalancer.firewalls

    - debug:
        var: info_nodebalancer.firewalls
```

2. Observe that the debug outputs both output a single ID matching the ID of the newly created firewall.

