### PR TITLE
fix/doc: Bump image/Kubernetes versions in tests and examples; fix LKE cluster update issue; fix broken examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The `LINODE_API_URL` environment variable pr the `api_url` module option can be 
         label: my-linode
         type: g6-nanode-1
         region: us-east
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: verysecurepassword!!!
         state: present
 ```

--- a/docs/modules/database_list.md
+++ b/docs/modules/database_list.md
@@ -72,7 +72,7 @@ List and filter on Linode Managed Databases.
                  "hour_of_day": 0,
                  "week_of_month": null
               },
-              "version": "8.0.26"
+              "version": "8.0.30"
            }
         ]
         ```

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -69,7 +69,7 @@ List and filter on Linode events.
               "rate":null,
               "read":true,
               "secondary_entity":{
-                 "id":"linode/debian9",
+                 "id":"linode/debian11",
                  "label":"linode1234",
                  "type":"linode",
                  "url":"/v4/linode/instances/1234"

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -14,7 +14,7 @@ Manage Linode Instances, Configs, and Disks.
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    image: linode/ubuntu20.04
+    image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     private_ip: false
     authorized_keys:
@@ -34,7 +34,7 @@ Manage Linode Instances, Configs, and Disks.
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    image: linode/ubuntu20.04
+    image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     private_ip: false
     authorized_keys:
@@ -61,7 +61,7 @@ Manage Linode Instances, Configs, and Disks.
     state: present
     disks:
       - label: boot
-        image: linode/ubuntu18.04
+        image: linode/ubuntu22.04
         size: 3000
         root_pass: ans1ble-test!
       - label: swap
@@ -299,7 +299,7 @@ Manage Linode Instances, Configs, and Disks.
           "has_user_data": true,
           "hypervisor": "kvm",
           "id": 123,
-          "image": "linode/debian10",
+          "image": "linode/debian11",
           "ipv4": [
             "203.0.113.1",
             "192.0.2.1"

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -55,7 +55,7 @@ Get info about a Linode Instance.
           "has_user_data": true,
           "hypervisor": "kvm",
           "id": 123,
-          "image": "linode/debian10",
+          "image": "linode/debian11",
           "ipv4": [
             "203.0.113.1",
             "192.0.2.1"

--- a/docs/modules/instance_list.md
+++ b/docs/modules/instance_list.md
@@ -67,7 +67,7 @@ List and filter on Linode Instances.
               "host_uuid": "example-uuid",
               "hypervisor": "kvm",
               "id": 123,
-              "image": "linode/debian10",
+              "image": "linode/debian11",
               "ipv4": [
                 "203.0.113.1",
                 "192.0.2.1"

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -13,7 +13,7 @@ Manage Linode LKE clusters.
   linode.cloud.lke_cluster:
     label: 'my-cluster'
     region: us-southeast
-    k8s_version: 1.23
+    k8s_version: 1.28
     node_pools:
       - type: g6-standard-1
         count: 3
@@ -27,7 +27,7 @@ Manage Linode LKE clusters.
   linode.cloud.lke_cluster:
     label: 'my-cluster'
     region: us-southeast
-    k8s_version: 1.23
+    k8s_version: 1.28
     node_pools:
       - type: g6-standard-1
         count: 2
@@ -87,7 +87,7 @@ Manage Linode LKE clusters.
           },
           "created": "2019-09-12T21:25:30Z",
           "id": 1234,
-          "k8s_version": "1.23",
+          "k8s_version": "1.28",
           "label": "lkecluster12345",
           "region": "us-central",
           "tags": [

--- a/docs/modules/lke_cluster_info.md
+++ b/docs/modules/lke_cluster_info.md
@@ -40,7 +40,7 @@ Get info about a Linode LKE cluster.
           },
           "created": "2019-09-12T21:25:30Z",
           "id": 1234,
-          "k8s_version": "1.23",
+          "k8s_version": "1.28",
           "label": "lkecluster12345",
           "region": "us-central",
           "tags": [

--- a/docs/modules/stackscript.md
+++ b/docs/modules/stackscript.md
@@ -12,7 +12,7 @@ Manage a Linode StackScript.
 - name: Create a basic StackScript
   linode.cloud.stackscript:
     label: my-stackscript
-    images: ['linode/ubuntu20.04']
+    images: ['linode/ubuntu22.04']
     description: Install a system package
     script: |
         #!/bin/bash
@@ -54,8 +54,8 @@ Manage a Linode StackScript.
           "description": "This StackScript installs and configures MySQL",
           "id": 10079,
           "images": [
-            "linode/debian9",
-            "linode/debian8"
+            "linode/debian11",
+            "linode/debian10"
           ],
           "is_public": true,
           "label": "a-stackscript",

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -41,8 +41,8 @@ Get info about a Linode StackScript.
           "description": "This StackScript installs and configures MySQL",
           "id": 10079,
           "images": [
-            "linode/debian9",
-            "linode/debian8"
+            "linode/debian11",
+            "linode/debian10"
           ],
           "is_public": true,
           "label": "a-stackscript",

--- a/docs/modules/stackscript_list.md
+++ b/docs/modules/stackscript_list.md
@@ -60,8 +60,8 @@ List and filter on Linode stackscripts.
                 "description": "This StackScript installs and configures MySQL\n",
                 "id": 10079,
                 "images": [
-                    "linode/debian9",
-                    "linode/debian8"
+                    "linode/debian11",
+                    "linode/debian10"
                 ],
                 "is_public": true,
                 "label": "a-stackscript",

--- a/examples/mysql_adminer/README.md
+++ b/examples/mysql_adminer/README.md
@@ -13,6 +13,7 @@ While in the `mysql_adminer` directory, run the following:
 
 ```bash
 export LINODE_TOKEN=mytoken
+export ANSIBLE_HOST_KEY_CHECKING=False
 ansible-playbook deploy.yml
 ```
 

--- a/examples/mysql_adminer/roles/configure_adminer/tasks/main.yml
+++ b/examples/mysql_adminer/roles/configure_adminer/tasks/main.yml
@@ -8,6 +8,8 @@
   pip:
     name: docker-py
     state: present
+  environment:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
 
 - name: Start and enable docker
   sysvinit:

--- a/examples/mysql_adminer/roles/configure_mysql/tasks/configure_mysql.yml
+++ b/examples/mysql_adminer/roles/configure_mysql/tasks/configure_mysql.yml
@@ -8,6 +8,8 @@
   pip:
     name: docker-py
     state: present
+  environment:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
 
 - name: Start and enable docker
   sysvinit:

--- a/examples/mysql_adminer/roles/configure_mysql/tasks/volume_mount.yml
+++ b/examples/mysql_adminer/roles/configure_mysql/tasks/volume_mount.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Wait for the volume to be available
+  wait_for:
+    path: "{{ var_vol_mountpoint }}"
+    state: present
+
 - name: Create a ext4 filesystem on the attached volume
   filesystem:
     fstype: ext4

--- a/examples/mysql_adminer/roles/infra/tasks/instances.yml
+++ b/examples/mysql_adminer/roles/infra/tasks/instances.yml
@@ -3,7 +3,7 @@
     label: "{{resource_prefix}}-mysql"
     type: g6-standard-2
     region: "{{ region }}"
-    image: linode/alpine3.14
+    image: linode/alpine3.19
     private_ip: true
     authorized_keys:
       - "{{ key_pair.public_key }}"
@@ -23,7 +23,7 @@
     label: "{{resource_prefix}}-adminer"
     type: g6-nanode-1
     region: "{{ region }}"
-    image: linode/alpine3.14
+    image: linode/alpine3.19
     private_ip: true
     authorized_keys:
       - "{{ key_pair.public_key }}"

--- a/examples/obj_static_site/README.md
+++ b/examples/obj_static_site/README.md
@@ -14,6 +14,7 @@ While in the `obj_static_site` directory, run the following:
 
 ```bash
 export LINODE_TOKEN=mytoken
+export ANSIBLE_HOST_KEY_CHECKING=False
 ansible-playbook deploy.yml
 ```
 

--- a/examples/simple_website/README.md
+++ b/examples/simple_website/README.md
@@ -13,6 +13,7 @@ While in the `simple_website` directory, run the following:
 
 ```bash
 export LINODE_TOKEN=mytoken
+export ANSIBLE_HOST_KEY_CHECKING=False
 ansible-playbook deploy.yml
 ```
 

--- a/examples/simple_website/roles/infra/tasks/main.yml
+++ b/examples/simple_website/roles/infra/tasks/main.yml
@@ -8,7 +8,7 @@
     label: "{{resource_prefix}}-{{item}}"
     type: g6-nanode-1
     region: us-east
-    image: linode/alpine3.14
+    image: linode/alpine3.19
     private_ip: true
     booted: true
     authorized_keys:

--- a/examples/simple_website/roles/website/tasks/main.yml
+++ b/examples/simple_website/roles/website/tasks/main.yml
@@ -8,6 +8,8 @@
   pip:
     name: docker-py
     state: present
+  environment:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
 
 - name: Start and enable docker
   sysvinit:

--- a/plugins/module_utils/doc_fragments/database_list.py
+++ b/plugins/module_utils/doc_fragments/database_list.py
@@ -37,6 +37,6 @@ result_images_samples = ['''[
          "hour_of_day": 0,
          "week_of_month": null
       },
-      "version": "8.0.26"
+      "version": "8.0.30"
    }
 ]''']

--- a/plugins/module_utils/doc_fragments/event_list.py
+++ b/plugins/module_utils/doc_fragments/event_list.py
@@ -31,7 +31,7 @@ result_events_samples = ['''[
       "rate":null,
       "read":true,
       "secondary_entity":{
-         "id":"linode/debian9",
+         "id":"linode/debian11",
          "label":"linode1234",
          "type":"linode",
          "url":"/v4/linode/instances/1234"

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -6,7 +6,7 @@ specdoc_examples = ['''
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    image: linode/ubuntu20.04
+    image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     private_ip: false
     authorized_keys:
@@ -23,7 +23,7 @@ specdoc_examples = ['''
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    image: linode/ubuntu20.04
+    image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     private_ip: false
     authorized_keys:
@@ -47,7 +47,7 @@ specdoc_examples = ['''
     state: present
     disks:
       - label: boot
-        image: linode/ubuntu18.04
+        image: linode/ubuntu22.04
         size: 3000
         root_pass: ans1ble-test!
       - label: swap
@@ -98,7 +98,7 @@ result_instance_samples = ['''{
   "has_user_data": true,
   "hypervisor": "kvm",
   "id": 123,
-  "image": "linode/debian10",
+  "image": "linode/debian11",
   "ipv4": [
     "203.0.113.1",
     "192.0.2.1"

--- a/plugins/module_utils/doc_fragments/instance_list.py
+++ b/plugins/module_utils/doc_fragments/instance_list.py
@@ -32,7 +32,7 @@ result_images_samples = ['''[
       "host_uuid": "example-uuid",
       "hypervisor": "kvm",
       "id": 123,
-      "image": "linode/debian10",
+      "image": "linode/debian11",
       "ipv4": [
         "203.0.113.1",
         "192.0.2.1"

--- a/plugins/module_utils/doc_fragments/lke_cluster.py
+++ b/plugins/module_utils/doc_fragments/lke_cluster.py
@@ -5,7 +5,7 @@ examples = ['''
   linode.cloud.lke_cluster:
     label: 'my-cluster'
     region: us-southeast
-    k8s_version: 1.23
+    k8s_version: 1.28
     node_pools:
       - type: g6-standard-1
         count: 3
@@ -16,7 +16,7 @@ examples = ['''
   linode.cloud.lke_cluster:
     label: 'my-cluster'
     region: us-southeast
-    k8s_version: 1.23
+    k8s_version: 1.28
     node_pools:
       - type: g6-standard-1
         count: 2
@@ -36,7 +36,7 @@ result_cluster = ['''{
   },
   "created": "2019-09-12T21:25:30Z",
   "id": 1234,
-  "k8s_version": "1.23",
+  "k8s_version": "1.28",
   "label": "lkecluster12345",
   "region": "us-central",
   "tags": [

--- a/plugins/module_utils/doc_fragments/stackscript.py
+++ b/plugins/module_utils/doc_fragments/stackscript.py
@@ -4,7 +4,7 @@ specdoc_examples = ['''
 - name: Create a basic StackScript
   linode.cloud.stackscript:
     label: my-stackscript
-    images: ['linode/ubuntu20.04']
+    images: ['linode/ubuntu22.04']
     description: Install a system package
     script: |
         #!/bin/bash
@@ -23,8 +23,8 @@ result_stackscript_samples = ['''{
   "description": "This StackScript installs and configures MySQL",
   "id": 10079,
   "images": [
-    "linode/debian9",
-    "linode/debian8"
+    "linode/debian11",
+    "linode/debian10"
   ],
   "is_public": true,
   "label": "a-stackscript",

--- a/plugins/module_utils/doc_fragments/stackscript_list.py
+++ b/plugins/module_utils/doc_fragments/stackscript_list.py
@@ -22,8 +22,8 @@ result_stackscripts_samples = ['''[
         "description": "This StackScript installs and configures MySQL\\n",
         "id": 10079,
         "images": [
-            "linode/debian9",
-            "linode/debian8"
+            "linode/debian11",
+            "linode/debian10"
         ],
         "is_public": true,
         "label": "a-stackscript",

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -89,7 +89,7 @@ The `LINODE_API_URL` environment variable pr the `api_url` module option can be 
         label: my-linode
         type: g6-nanode-1
         region: us-east
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: verysecurepassword!!!
         state: present
 ```

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: create_instance
 
@@ -16,7 +16,7 @@
         label: 'ansible-test-{{ r }}-2'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: create_instance_2
 

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: inst
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: create_instance
 

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         state: present
       register: instance_create
 

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -24,7 +24,7 @@
     - assert:
         that:
           - filter.images | length == 1
-          - filter.images[0].id == 'linode/alpine3.16'
+          - filter.images[0].id == 'linode/alpine3.19'
 
     - name: Resolve an empty list of images
       linode.cloud.image_list:

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-nopass-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         wait: false
         state: present
@@ -26,7 +26,7 @@
         label: 'ansible-test-additional-ips-nopass-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         wait: false
         state: present
@@ -47,7 +47,7 @@
         region: us-ord
         group: funny
         type: g6-standard-2
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         state: present
       register: invalid_update
@@ -59,7 +59,7 @@
         label: '{{ create_additional_ips.instance.label }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         wait: false
         state: present
@@ -75,7 +75,7 @@
         label: '{{ create_additional_ips.instance.label }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         wait: false
         state: present
@@ -89,7 +89,7 @@
         region: us-ord
         group: funny
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         state: present
       register: update

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         booted: true
@@ -27,7 +27,7 @@
         label: '{{create.instance.label}}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         booted: false

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -158,7 +158,7 @@
         label: '{{ create.instance.label }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         booted: false
         disks:
           - label: test-disk
@@ -179,7 +179,7 @@
 
           - label: boot-disk
             size: 4096
-            image: linode/alpine3.17
+            image: linode/alpine3.19
 
         configs:
           - label: boot-config

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}-i'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         interfaces:
           - purpose: vlan
             label: really-cool-vlan
@@ -32,7 +32,7 @@
         region: us-ord
         group: funny
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         interfaces:
           - purpose: vlan
@@ -55,7 +55,7 @@
         region: us-ord
         group: funny
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         interfaces:
           - purpose: vlan

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-nopass-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         private_ip: true
         wait: false
         state: present

--- a/tests/integration/targets/instance_reboot/tasks/main.yaml
+++ b/tests/integration/targets/instance_reboot/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         rebooted: true

--- a/tests/integration/targets/instance_region_migration/tasks/main.yaml
+++ b/tests/integration/targets/instance_region_migration/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-nanode-1
-        image: linode/ubuntu23.10
+        image: linode/ubuntu22.04
         state: present
       register: create
 
@@ -20,7 +20,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-iad
         type: g6-nanode-1
-        image: linode/ubuntu23.10
+        image: linode/ubuntu22.04
         migration_type: warm
         state: present
       register: migrated

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         wait: yes
         wait_timeout: 0
         booted: yes

--- a/tests/integration/targets/instance_type_change/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_change/tasks/main.yaml
@@ -7,7 +7,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-nanode-1
-        image: linode/ubuntu23.10
+        image: linode/ubuntu22.04
         state: present
       register: create
 
@@ -27,7 +27,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-standard-1
-        image: linode/ubuntu23.10
+        image: linode/ubuntu22.04
         auto_disk_resize: true
         state: present
       register: resize_disks
@@ -43,7 +43,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-standard-2
-        image: linode/ubuntu23.10
+        image: linode/ubuntu22.04
         migration_type: warm
         state: present
       register: resize_disks

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: create_instance
 
@@ -17,7 +17,7 @@
         label: 'ansible-test-{{ r }}-2'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.17
+        image: linode/alpine3.19
         state: present
       register: create_instance_2
 

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         wait: no
         state: present
       register: instance_create

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -10,7 +10,7 @@
         label: 'ansible-test-{{ r1 }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         wait: false
         state: present
       register: instance_create
@@ -20,7 +20,7 @@
         label: 'ansible-test-{{ r2 }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         wait: false
         state: present
       register: instance_create_shared

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         wait: no
         state: present
       register: instance_create

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -5,16 +5,22 @@
 
     - name: Resolve the latest K8s version
       linode.cloud.lke_version_list: {}
-      register: lke_versions
+      register: get_lke_versions
 
     - set_fact:
-        kube_version: '{{ lke_versions.lke_versions[0].id }}'
+        lke_versions: '{{ get_lke_versions.lke_versions|sort(attribute="id") }}'
+
+    - set_fact:
+        old_kube_version: '{{ lke_versions[0].id }}'
+
+        # Sometimes only one LKE version is available for provisioning
+        kube_version: '{{ lke_versions[1].id if lke_versions|length > 1 else lke_versions[0].id }}'
 
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:
         label: 'ansible-test-{{ r }}'
         region: us-southeast
-        k8s_version: '{{ kube_version }}'
+        k8s_version: '{{ old_kube_version }}'
         node_pools:
           - type: g6-standard-1
             count: 3
@@ -30,7 +36,7 @@
 
     - assert:
         that:
-          - create_cluster.cluster.k8s_version == kube_version
+          - create_cluster.cluster.k8s_version == old_kube_version
           - create_cluster.cluster.region == 'us-southeast'
           - create_cluster.node_pools[0].type == 'g6-standard-1'
           - create_cluster.node_pools[0].count == 3
@@ -42,7 +48,7 @@
       linode.cloud.lke_cluster:
         label: '{{ create_cluster.cluster.label }}'
         region: us-southeast
-        k8s_version: '{{ kube_version }}'
+        k8s_version: '{{ old_kube_version }}'
         skip_polling: true
         node_pools:
           - type: g6-standard-1
@@ -56,7 +62,7 @@
 
     - assert:
         that:
-          - update_pools.cluster.k8s_version == kube_version
+          - update_pools.cluster.k8s_version == old_kube_version
           - update_pools.cluster.region == 'us-southeast'
 
           - update_pools.node_pools | length == 3

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -9,7 +9,7 @@
         label: 'ansible-test-node1-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         state: present
@@ -27,7 +27,7 @@
         label: 'ansible-test-node2-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         state: present
@@ -45,7 +45,7 @@
         label: 'ansible-test-node3-{{ r }}'
         region: us-central
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         state: present

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-node-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
         state: present

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -13,7 +13,7 @@
     - name: Create a basic stackscript
       linode.cloud.stackscript:
         label: 'ansible-test-{{ r }}'
-        images: ['linode/alpine3.15']
+        images: ['linode/alpine3.19']
         script: |
           #!/bin/bash
           # <UDF name="package" label="System Package to Install" example="nginx" default="">
@@ -31,7 +31,7 @@
     - name: Update a basic stackscript
       linode.cloud.stackscript:
         label: 'ansible-test-{{ r }}'
-        images: ['linode/alpine3.14']
+        images: ['linode/alpine3.19']
         script: |
           #!/bin/bash
           # <UDF name="package2" label="System Package to Install" example="nginx" default="">

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a basic stackscript
       linode.cloud.stackscript:
         label: 'ansible-test-{{ r }}'
-        images: ['linode/alpine3.15']
+        images: ['linode/alpine3.19']
         script: |
           #!/bin/bash
           # <UDF name="package" label="System Package to Install" example="nginx" default="">

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -6,7 +6,7 @@
     - name: Create a basic stackscript
       linode.cloud.stackscript:
         label: 'ansible-test-{{ r }}'
-        images: ['linode/alpine3.15']
+        images: ['linode/alpine3.19']
         script: |
           #!/bin/bash
           # <UDF name="package" label="System Package to Install" example="nginx" default="">

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}-i'
         region: us-southeast
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         interfaces:
           - purpose: vlan
             label: really-cool-vlan

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-{{ r }}-i'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.16
+        image: linode/alpine3.19
         interfaces:
           - purpose: vlan
             label: really-cool-vlan

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -8,7 +8,7 @@
         label: 'ansible-test-inst-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu20.04
+        image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         state: present
       register: create_inst


### PR DESCRIPTION
## 📝 Description

This PR makes the following repo-wide improvements:
- Outdated image and Kubernetes versions have been bumped in both tests and code samples
  -  NOTE: Ubuntu 22.04 and Debian 11 have been picked rather than their newer counterparts because they both have support for cloud-init
- Broken LKE version + HA update logic has been fixed
- Example playbooks have been updated with some minor fixes and newer image versions

## ✔️ How to Test

The following test steps assume you have pulled this PR locally and have run `make install`.

### Integration Testing

```bash
make testint
```

### Testing Example Playbooks

The following test steps assume you have run exported the following environment variables:

```bash
export LINODE_TOKEN=...
export ANSIBLE_HOST_KEY_CHECKING=False
```

#### MySQL + Adminer

```bash
cd examples/mysql_adminer && ansible-playbook deploy.yml
```

#### OBJ Static Site

```
cd examples/obj_static_site && ansible-playbook deploy.yml
```

#### Simple Website

```
cd examples/simple_website && ansible-playbook deploy.yml
```
