### PR TITLE
test: integration tod workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: .ansible/collections/ansible_collections/linode/cloud
+          fetch-depth: 0
+          submodules: 'recursive'
 
       - name: update packages
         run: sudo apt-get update -y
@@ -51,59 +53,17 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
-          pwd
-          ls -a tests/output/junit/
-          cat tests/output/junit/*.xml
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
-
-      - name: Upload test report as artifact
-        id: upload-artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report-dir
-          path: tests/output/
-
-      - name: Test Execution Status Handler
-        run: |
-          if [[ "$EXIT_STATUS" != 0 ]]; then
-            echo "Test execution contains failure(s), check Run Integration tests step above"
-            exit $EXIT_STATUS 
-          else
-            echo "Tests passed!"
-          fi
-
-  process-upload-report:
-    runs-on: ubuntu-latest
-    needs:
-      - run-tests
-    if: ${{ needs.run-tests.outputs.upload-artifact == 'success' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Download test report
-        uses: actions/download-artifact@v4
-        with:
-          name: test-report-dir
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install Python dependencies
-        run: pip3 install requests wheel boto3
 
       - name: Set release version env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Merge all test xmls in output directory
         run: |
+          pwd
+          ls
           python tod_scripts/merge_ansible_results.py
 
       - name: Add additional information to XML report
@@ -122,3 +82,13 @@ jobs:
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+      - name: Test Execution Status Handler
+        run: |
+          if [[ "$EXIT_STATUS" != 0 ]]; then
+            echo "Test execution contains failure(s), check Run Integration tests step above"
+            exit $EXIT_STATUS 
+          else
+            echo "Tests passed!"
+          fi
+

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,9 +51,8 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
-          ls -a
           pwd
-          ls tests
+          ls tests/output/junit
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
@@ -63,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-report-dir
-          path: tests/output
+          path: tests/output/junit/
 
       - name: Test Execution Status Handler
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/dev')
     env:
       EXIT_STATUS: 0
     defaults:
@@ -50,6 +51,9 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
+          ls -a
+          pwd
+          ls tests
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
@@ -68,11 +72,13 @@ jobs:
           else
             echo "Tests passed!"
           fi
+        continue-on-error: true
 
   process-upload-report:
     runs-on: ubuntu-latest
     needs:
       - run-tests
+    if: ${{ needs.run-tests.outputs.upload-artifact == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: run tests
         run: |
-          if ! make testall > test_output.txt; then
+          if ! ansible-test integration -v api_request_basic > test_output.txt; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
@@ -59,6 +59,7 @@ jobs:
           ANSIBLE_CALLBACKS_ENABLED: "junit"
 
       - name: Upload test report as artifact
+        id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
           name: test-report-dir

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      EXIT_STATUS: 0
     defaults:
       run:
         working-directory: .ansible/collections/ansible_collections/linode/cloud
@@ -43,7 +45,74 @@ jobs:
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
       - name: run tests
-        run: make testall
+        run: |
+          if ! make testall > test_output.txt; then
+            echo "EXIT_STATUS=1" >> $GITHUB_ENV
+          fi
+          cat test_output.txt
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+          ANSIBLE_CALLBACKS_ENABLED: "junit"
 
+      - name: Upload test report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-dir
+          path: tests/output
+
+      - name: Test Execution Status Handler
+        run: |
+          if [[ "$EXIT_STATUS" != 0 ]]; then
+            echo "Test execution contains failure(s), check Run Integration tests step above"
+            exit $EXIT_STATUS 
+          else
+            echo "Tests passed!"
+          fi
+
+  process-upload-report:
+    runs-on: ubuntu-latest
+    needs:
+      - run-tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        with:
+          name: test-report-dir
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip3 install requests wheel boto3
+
+      - name: Set release version env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Merge all test xmls in output directory
+        run: |
+          python tod_scripts/merge_ansible_results.py
+
+      - name: Add additional information to XML report
+        run: |
+          filename=$(ls | grep -E '^[0-9]{12}_ansible_merged\.xml$') 
+          python tod_scripts/add_to_xml_test_report.py \
+          --branch_name "${{ env.RELEASE_VERSION }}" \
+          --gha_run_id "$GITHUB_RUN_ID" \
+          --gha_run_number "$GITHUB_RUN_NUMBER" \
+          --xmlfile "${filename}"
+
+      - name: Upload test results to the bucket
+        run: |
+          filename=$(ls | grep -E '^[0-9]{12}_ansible_merged\.xml$')
+          python3 tod_scripts/test_report_upload_script.py "${filename}"
+        env:
+          LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
+          LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,8 +51,8 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
-          pwd
-          ls tests/output/junit
+          mkdir -p junit
+          cp tests/output/junit/* junit/
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-report-dir
-          path: tests/output/junit/
+          path: junit/
 
       - name: Test Execution Status Handler
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,8 +51,6 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
-          mkdir -p junit
-          cp tests/output/junit/* junit/
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
@@ -62,7 +60,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-report-dir
-          path: junit/
+          run: |
+            pwd
+            ls -a tests/output/junit/
+            cat tests/output/junit/*.xml
+          path: tests/output/
 
       - name: Test Execution Status Handler
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,6 +51,9 @@ jobs:
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat test_output.txt
+          pwd
+          ls -a tests/output/junit/
+          cat tests/output/junit/*.xml
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
@@ -60,10 +63,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-report-dir
-          run: |
-            pwd
-            ls -a tests/output/junit/
-            cat tests/output/junit/*.xml
           path: tests/output/
 
       - name: Test Execution Status Handler
@@ -74,7 +73,6 @@ jobs:
           else
             echo "Tests passed!"
           fi
-        continue-on-error: true
 
   process-upload-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/dev')
     env:
       EXIT_STATUS: 0
     defaults:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tod_scripts"]
+	path = tod_scripts
+	url = https://github.com/linode/TOD-test-report-uploader.git


### PR DESCRIPTION
## 📝 Description

This PR generates junit xml files after test execution and combines all the xml output into file for TOD. In this process, reports are processed so that unnecessary system output are dropped for better readability

- Setting `export ANSIBLE_CALLBACKS_ENABLED=junit` generates output after ansible test execution in tests folder. This will generate one corresponding file for each test suite
![image](https://github.com/linode/ansible_linode/assets/126618609/8c1c6db5-105f-4407-bc5e-870c6a03aeb6)

- XML files that are generated are merged by script below in `tod_scripts`. While pushing all files separately to TOD works, it makes the entries really messy since it will create separate entry for each file that is pushed
https://github.com/linode/TOD-test-report-uploader/blob/main/merge_ansible_results.py

- TOD snippet of how test results look like
http://198.19.5.79:7272/builds/65cabd73d8f7260001752e03?team=DX-Test-02-10&buildName=Release%20Builds1&bld_id=65cabd73d8f7260001752e03

## ✔️ How to Test

Here is the example run on my forked repo verifying merging of the test report and push to TOD object storage - https://github.com/ykim-1/ansible_linode/actions/runs/7882439521/job/21507649213. 
Ignore one test failure, this was used to verify if the build can be marked as 'x' when test execution fails

