### PR TITLE
fix: Domain record deletion example in documentation

### DIFF
--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -22,9 +22,19 @@ NOTE: Domain records are identified by their name, target, and type.
 
 ```yaml
 - name: Delete a domain record
-  linode.cloud.domain:
+  linode.cloud.domain_record:
     domain: my-domain.com
     name: my-subdomain
+    type: 'A'
+    target: '127.0.0.1'
+    state: absent
+```
+
+```yaml
+- name: Delete the record by record_id
+  linode.cloud.domain_record:            
+    domain: my-domain.com
+    record_id: 5678
     state: absent
 ```
 

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -478,9 +478,9 @@ class LinodeLKECluster(LinodeModuleBase):
     def _populate_dashboard_url_poll(self, cluster: LKECluster) -> None:
         def condition() -> bool:
             try:
-                self.results["dashboard_url"] = (
-                    cluster.cluster_dashboard_url_view()
-                )
+                self.results[
+                    "dashboard_url"
+                ] = cluster.cluster_dashboard_url_view()
             except ApiError as error:
                 if error.status != 503:
                     raise error


### PR DESCRIPTION
## 📝 Description

Fix the error in domain_record documentation.

Addressed issue #462 

## ✔️ How to Test

To verify that the example is correct, we can perform a manual test.

1. Inside of an `ansible_linode` sandbox environment, run the following playbook:
```
- name: domain_record
  block:
    - name: Create a domain
      linode.cloud.domain:
        domain: 'example.com'
        soa_email: 'email@example.com'
        type: 'master'
        state: present
      register: domain_create

    - name: Create a domain record
      linode.cloud.domain_record:
        domain: '{{ domain_create.domain.domain }}'
        name: 'sub'
        type: 'A'
        target: '127.0.0.1'
        ttl_sec: 3600
        weight: 55
        state: present
      register: record_create

    - name: Delete the record
      linode.cloud.domain_record:            
        domain: '{{ domain_create.domain.domain }}'
        name: 'sub'
        type: 'A'
        target: '127.0.0.1'
        state: absent
```
2. Observe the playbook passes as expected and the domain record has been deleted.
3. Modify the play book a bit to delete the domain record by the `record_id`
```
    - name: Delete the record
      linode.cloud.domain_record:            
        domain: '{{ domain_create.domain.domain }}'
        record_id: '{{ record_create.record.id }}'
        state: absent
```
