### PR TITLE
fix: Account for implicit `disk_resize` event during disk creation

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -810,6 +810,13 @@ class LinodeInstance(LinodeModuleBase):
     def _create_disk_register(self, **kwargs: Any) -> None:
         size = kwargs.pop("size")
 
+        # Workaround for race condition on implicit events
+        # See: TPT-2738
+        self.client.polling.wait_for_entity_free(
+            entity_type="disks",
+            entity_id=self._instance.id,
+        )
+
         create_poller = self.client.polling.event_poller_create(
             "disks", "disk_create", entity_id=self._instance.id
         )

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -478,9 +478,9 @@ class LinodeLKECluster(LinodeModuleBase):
     def _populate_dashboard_url_poll(self, cluster: LKECluster) -> None:
         def condition() -> bool:
             try:
-                self.results["dashboard_url"] = (
-                    cluster.cluster_dashboard_url_view()
-                )
+                self.results[
+                    "dashboard_url"
+                ] = cluster.cluster_dashboard_url_view()
             except ApiError as error:
                 if error.status != 503:
                     raise error

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -478,9 +478,9 @@ class LinodeLKECluster(LinodeModuleBase):
     def _populate_dashboard_url_poll(self, cluster: LKECluster) -> None:
         def condition() -> bool:
             try:
-                self.results[
-                    "dashboard_url"
-                ] = cluster.cluster_dashboard_url_view()
+                self.results["dashboard_url"] = (
+                    cluster.cluster_dashboard_url_view()
+                )
             except ApiError as error:
                 if error.status != 503:
                     raise error

--- a/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
@@ -1,0 +1,77 @@
+- name: instance_config_disk_private
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+        file_content: 'H4sIAAAAAAAAA6vML1UozsgvzUlRKC1OVShJLSpKTMsvyuUCAMhLS4gZAAAA='
+
+    - name: Create temporary image file
+      tempfile:
+        state: file
+        suffix: .img.gz
+      register: source_file
+
+    - copy:
+        dest: '{{ source_file.path }}'
+        content: '{{ file_content | b64decode }}'
+
+    - name: Create a private image from the image file
+      linode.cloud.image:
+        label: 'ansible-test-{{ r }}'
+        source_file: '{{ source_file.path }}'
+        state: present
+      register: image_create
+
+    - assert:
+        that:
+          - image_create.image.status == 'available'
+
+    - name: Provision an instance consuming the new image
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        type: g6-nanode-1
+        region: us-mia
+        boot_config_label: boot-config
+        disks:
+          - label: boot
+            filesystem: raw
+            image: '{{ image_create.image.id }}'
+            size: 5000
+          - label: swap
+            filesystem: swap
+            size: 4000
+        configs:
+          - label: 'boot-config'
+            root_device: '/dev/sda'
+            run_level: 'default'
+            kernel: 'linode/direct-disk'
+            devices:
+              sda:
+                disk_label: boot
+              sdb:
+                disk_label: swap
+        state: present
+      register: instance_create
+
+    - assert:
+        that:
+          - instance_create.changed
+          - instance_create.disks | length == 2
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.instance:
+            label: '{{ instance_create.instance.label }}'
+            state: absent
+
+        - linode.cloud.image:
+            label: '{{ image_create.image.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+


### PR DESCRIPTION
## 📝 Description

This change adds logic to the disk creation/polling logic to account for any implicit events that could occur after the `disk_create` event. This is necessary for disk creations that trigger implicit `disk_resize` events (e.g. deploying from private images).

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make TEST_ARGS="instance_config_disk_private" test
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: Test disk polling
  hosts: localhost
  tasks:
    - set_fact:
        file_content: 'H4sIAAAAAAAAA6vML1UozsgvzUlRKC1OVShJLSpKTMsvyuUCAMhLS4gZAAAA='

    - name: Create temporary image file
      tempfile:
        state: file
        suffix: .img.gz
      register: source_file

    - copy:
        dest: '{{ source_file.path }}'
        content: '{{ file_content | b64decode }}'

    - name: Create a private image from the image file
      linode.cloud.image:
        label: 'ansible-test-{{ r }}'
        source_file: '{{ source_file.path }}'
        state: present
      register: image_create

    - name: Provision an instance consuming the new image
      linode.cloud.instance:
        label: 'ansible-test-{{ r }}'
        type: g6-nanode-1
        region: us-mia
        boot_config_label: boot-config
        disks:
          - label: boot
            filesystem: raw
            image: '{{ image_create.image.id }}'
            size: 5000
          - label: swap
            filesystem: swap
            size: 4000
        configs:
          - label: 'boot-config'
            root_device: '/dev/sda'
            run_level: 'default'
            kernel: 'linode/direct-disk'
            devices:
              sda:
                disk_label: boot
              sdb:
                disk_label: swap
        state: present
```

2. Ensure the playbook completes with no errors. (NOTE: The new instance is not intended to be booted)