### PR TITLE
test: update outdated failing tests

### DIFF
--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -41,9 +41,22 @@
           - create_additional_ips.instance.ipv4|length == 3
           - create_additional_ips.networking.ipv4.public[0].address != None
 
-    - name: Update the instance region and type (recreate disallowed)
+    - name: Update the instance region and type
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
+        region: us-ord
+        group: funny
+        type: g6-standard-2
+        image: linode/ubuntu22.04
+        private_ip: true
+        state: present
+      register: invalid_update
+      failed_when:
+        - invalid_update.changed == false
+
+    - name: Update label with invalid string
+      linode.cloud.instance:
+        label: '!!Invalid!!'
         region: us-ord
         group: funny
         type: g6-standard-2

--- a/tests/integration/targets/instance_config_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vpc/tasks/main.yaml
@@ -19,6 +19,10 @@
         state: present
       register: create_subnet
 
+    - name: Assert subnet information
+      debug:
+        msg: "{{ create_subnet.subnet.id }}"
+
     - name: Create a Linode instance with interface
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
@@ -110,7 +114,7 @@
           - update_instance.configs[0].interfaces[1].subnet_id == create_subnet.subnet.id
           - update_instance.configs[0].interfaces[1].vpc_id == create_vpc.vpc.id
           - update_instance.configs[0].interfaces[1].ip_ranges[0] == '10.0.0.7/32'
-          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == ""
+          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == None
           - update_instance.configs[0].interfaces[1].ipv4.vpc == '10.0.0.4'
 
     - name: Don't change the config interfaces

--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -49,6 +49,7 @@
           - create_instance.configs[0].interfaces[0].ipv4.nat_1_1 == create_instance.instance.ipv4[0]
           - create_instance.configs[0].interfaces[0].ipv4.vpc == '10.0.0.3'
 
+
     - name: Update the instance interfaces
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
@@ -66,8 +67,6 @@
         wait: false
         state: present
       register: update_instance
-    
-    
 
     - name: Assert instance updated
       assert:
@@ -81,9 +80,9 @@
           - update_instance.configs[0].interfaces[1].subnet_id == create_subnet.subnet.id
           - update_instance.configs[0].interfaces[1].vpc_id == create_vpc.vpc.id
           - update_instance.configs[0].interfaces[1].ip_ranges[0] == '10.0.0.7/32'
-          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == ""
+          - update_instance.configs[0].interfaces[1].ipv4.nat_1_1 == None
           - update_instance.configs[0].interfaces[1].ipv4.vpc == '10.0.0.4'
-    
+
     - name: Get information about the Subnet by ID
       linode.cloud.vpc_subnet_info:
         vpc_id: '{{ create_vpc.vpc.id }}'

--- a/tests/integration/targets/instance_region_migration/tasks/main.yaml
+++ b/tests/integration/targets/instance_region_migration/tasks/main.yaml
@@ -21,7 +21,7 @@
         region: us-iad
         type: g6-nanode-1
         image: linode/ubuntu22.04
-        migration_type: warm
+        migration_type: cold
         state: present
       register: migrated
 


### PR DESCRIPTION
## 📝 Description

Updating some of failing tests from GH executions from 348-350

## ✔️ How to Test

make TEST_ARGS="-v instance_region_migration" test
make TEST_ARGS="-v instance_config_vpc" test
 make TEST_ARGS="-v instance_interfaces_vpc" test
  make TEST_ARGS="-v instance_basic" test

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**