### PR TITLE
doc: Add disclaimer to documentation for modules that consume beta endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Name | Description |
 [linode.cloud.instance](./docs/modules/instance.md)|Manage Linode Instances, Configs, and Disks.|
 [linode.cloud.ip_assign](./docs/modules/ip_assign.md)|Assign IPs to Linodes in a given Region.|
 [linode.cloud.ip_rdns](./docs/modules/ip_rdns.md)|Manage a Linode IP address's rDNS.|
-[linode.cloud.ip_share](./docs/modules/ip_share.md)|Manage the Linode shared IPs.|
+[linode.cloud.ip_share](./docs/modules/ip_share.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
 [linode.cloud.lke_cluster](./docs/modules/lke_cluster.md)|Manage Linode LKE clusters.|
 [linode.cloud.lke_node_pool](./docs/modules/lke_node_pool.md)|Manage Linode LKE cluster node pools.|
 [linode.cloud.nodebalancer](./docs/modules/nodebalancer.md)|Manage a Linode NodeBalancer.|
@@ -54,7 +54,7 @@ Modules for retrieving information about existing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|Get info about a Linode Account Availability.|
+[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
@@ -86,7 +86,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilitys.|
+[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Name | Description |
 [linode.cloud.instance](./docs/modules/instance.md)|Manage Linode Instances, Configs, and Disks.|
 [linode.cloud.ip_assign](./docs/modules/ip_assign.md)|Assign IPs to Linodes in a given Region.|
 [linode.cloud.ip_rdns](./docs/modules/ip_rdns.md)|Manage a Linode IP address's rDNS.|
-[linode.cloud.ip_share](./docs/modules/ip_share.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
+[linode.cloud.ip_share](./docs/modules/ip_share.md)|Manage the Linode shared IPs.|
 [linode.cloud.lke_cluster](./docs/modules/lke_cluster.md)|Manage Linode LKE clusters.|
 [linode.cloud.lke_node_pool](./docs/modules/lke_node_pool.md)|Manage Linode LKE cluster node pools.|
 [linode.cloud.nodebalancer](./docs/modules/nodebalancer.md)|Manage a Linode NodeBalancer.|
@@ -54,7 +54,7 @@ Modules for retrieving information about existing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
+[linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|Get info about a Linode Account Availability.|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
@@ -86,7 +86,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**|
+[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilitys.|
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|

--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -1,5 +1,7 @@
 # account_availability_info
 
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 Get info about a Linode Account Availability.
 
 - [Examples](#examples)
@@ -11,6 +13,7 @@ Get info about a Linode Account Availability.
 ```yaml
 - name: Get info about the current Linode account availability
   linode.cloud.account_info: 
+    api_version: v4beta
     region: us-east
 
 ```

--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -2,7 +2,7 @@
 
 Get info about a Linode Account Availability.
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -1,8 +1,8 @@
 # account_availability_info
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
-
 Get info about a Linode Account Availability.
+
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,8 +1,8 @@
 # account_availability_list
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
-
 List and filter on Account Availabilitys.
+
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -2,7 +2,7 @@
 
 List and filter on Account Availabilitys.
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,5 +1,7 @@
 # account_availability_list
 
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 List and filter on Account Availabilitys.
 
 - [Examples](#examples)
@@ -10,7 +12,8 @@ List and filter on Account Availabilitys.
 
 ```yaml
 - name: List all of the region resource availabilities to the account
-  linode.cloud.account_availability_list: {}
+  linode.cloud.account_availability_list:
+    api_version: v4beta
 ```
 
 

--- a/docs/modules/ip_share.md
+++ b/docs/modules/ip_share.md
@@ -1,5 +1,7 @@
 # ip_share
 
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 Manage the Linode shared IPs.
 
 - [Examples](#examples)
@@ -11,6 +13,7 @@ Manage the Linode shared IPs.
 ```yaml
 - name: Configure the Linode shared IPs.
   linode.cloud.ip_share:
+    api_version: v4beta
     linode_id: 12345
     ips: ["192.0.2.1", "2001:db8:3c4d:15::"]
 ```

--- a/docs/modules/ip_share.md
+++ b/docs/modules/ip_share.md
@@ -2,7 +2,7 @@
 
 Manage the Linode shared IPs.
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/ip_share.md
+++ b/docs/modules/ip_share.md
@@ -1,8 +1,8 @@
 # ip_share
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
-
 Manage the Linode shared IPs.
+
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -2,7 +2,7 @@
 
 Get info about a Linode VLAN.
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -13,6 +13,7 @@ Get info about a Linode VLAN.
 ```yaml
 - name: Get info about a VLAN by label
   linode.cloud.vlan_info:
+    api_version: v4beta
     label: example-vlan
 ```
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -2,6 +2,8 @@
 
 Get info about a Linode VLAN.
 
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 - [Examples](#examples)
 - [Parameters](#parameters)
 - [Return Values](#return-values)

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -2,6 +2,8 @@
 
 List and filter on Linode VLANs.
 
+> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 - [Examples](#examples)
 - [Parameters](#parameters)
 - [Return Values](#return-values)

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -12,12 +12,14 @@ List and filter on Linode VLANs.
 
 ```yaml
 - name: List all of the VLANs for the current Linode Account
-  linode.cloud.vlan_list: {}
+  linode.cloud.vlan_list:
+    api_version: v4beta
 ```
 
 ```yaml
 - name: List all VLANs in the us-southeast region
   linode.cloud.vlan_list:
+    api_version: v4beta
     filters:
       - name: region
         values: us-southeast

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -2,7 +2,7 @@
 
 List and filter on Linode VLANs.
 
-> :warning: **This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/plugins/module_utils/doc_fragments/account_availability_info.py
+++ b/plugins/module_utils/doc_fragments/account_availability_info.py
@@ -11,5 +11,6 @@ result_account_availability_samples = ['''
 specdoc_examples = ['''
 - name: Get info about the current Linode account availability
   linode.cloud.account_info: 
+    api_version: v4beta
     region: us-east
 ''']

--- a/plugins/module_utils/doc_fragments/account_availability_list.py
+++ b/plugins/module_utils/doc_fragments/account_availability_list.py
@@ -2,7 +2,8 @@
 
 specdoc_examples = ['''
 - name: List all of the region resource availabilities to the account
-  linode.cloud.account_availability_list: {}''']
+  linode.cloud.account_availability_list:
+    api_version: v4beta''']
 
 result_account_availabilities_samples = ['''[
     {

--- a/plugins/module_utils/doc_fragments/ip_share.py
+++ b/plugins/module_utils/doc_fragments/ip_share.py
@@ -2,6 +2,7 @@
 specdoc_examples = ['''
 - name: Configure the Linode shared IPs.
   linode.cloud.ip_share:
+    api_version: v4beta
     linode_id: 12345
     ips: ["192.0.2.1", "2001:db8:3c4d:15::"]''']
 

--- a/plugins/module_utils/doc_fragments/vlan_info.py
+++ b/plugins/module_utils/doc_fragments/vlan_info.py
@@ -3,6 +3,7 @@
 specdoc_examples = ['''
 - name: Get info about a VLAN by label
   linode.cloud.vlan_info:
+    api_version: v4beta
     label: example-vlan''']
 
 result_vlan_samples = ['''{

--- a/plugins/module_utils/doc_fragments/vlan_list.py
+++ b/plugins/module_utils/doc_fragments/vlan_list.py
@@ -2,9 +2,11 @@
 
 specdoc_examples = ['''
 - name: List all of the VLANs for the current Linode Account
-  linode.cloud.vlan_list: {}''', '''
+  linode.cloud.vlan_list:
+    api_version: v4beta''', '''
 - name: List all VLANs in the us-southeast region
   linode.cloud.vlan_list:
+    api_version: v4beta
     filters:
       - name: region
         values: us-southeast

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -12,6 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    beta_disclaimer,
     global_authors,
     global_requirements,
 )
@@ -95,12 +96,14 @@ class InfoModule(LinodeModuleBase):
         params: List[InfoModuleParam] = None,
         attributes: List[InfoModuleAttr] = None,
         examples: List[str] = None,
+        requires_beta: bool = False,
     ) -> None:
         self.primary_result = primary_result
         self.secondary_results = secondary_results or []
         self.params = params or []
         self.attributes = attributes or []
         self.examples = examples or []
+        self.requires_beta = requires_beta
 
         self.module_arg_spec = self.spec.ansible_spec
         self.results: Dict[str, Any] = {
@@ -195,10 +198,15 @@ class InfoModule(LinodeModuleBase):
             for v in [self.primary_result] + self.secondary_results
         }
 
+        description = [
+            f"Get info about a Linode {self.primary_result.display_name}."
+        ]
+
+        if self.requires_beta:
+            description.insert(0, beta_disclaimer)
+
         return SpecDocMeta(
-            description=[
-                f"Get info about a Linode {self.primary_result.display_name}."
-            ],
+            description=description,
             requirements=global_requirements,
             author=global_authors,
             options=options,

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -203,7 +203,7 @@ class InfoModule(LinodeModuleBase):
         ]
 
         if self.requires_beta:
-            description.insert(0, beta_disclaimer)
+            description.append(beta_disclaimer)
 
         return SpecDocMeta(
             description=description,

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -12,7 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    beta_disclaimer,
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -203,7 +203,7 @@ class InfoModule(LinodeModuleBase):
         ]
 
         if self.requires_beta:
-            description.append(beta_disclaimer)
+            description.append(BETA_DISCLAIMER)
 
         return SpecDocMeta(
             description=description,

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -159,7 +159,7 @@ class ListModule(
         description = [f"List and filter on {self.result_display_name}s."]
 
         if self.requires_beta:
-            description.insert(0, beta_disclaimer)
+            description.append(beta_disclaimer)
 
         return SpecDocMeta(
             description=description,

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -12,7 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    beta_disclaimer,
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -159,7 +159,7 @@ class ListModule(
         description = [f"List and filter on {self.result_display_name}s."]
 
         if self.requires_beta:
-            description.append(beta_disclaimer)
+            description.append(BETA_DISCLAIMER)
 
         return SpecDocMeta(
             description=description,

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -12,6 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    beta_disclaimer,
     global_authors,
     global_requirements,
 )
@@ -53,6 +54,7 @@ class ListModule(
         params: List[ListModuleParam] = None,
         examples: List[str] = None,
         result_samples: List[str] = None,
+        requires_beta: bool = False,
     ) -> None:
         self.result_display_name = result_display_name
         self.result_field_name = result_field_name
@@ -62,6 +64,7 @@ class ListModule(
         self.params = params or []
         self.examples = examples or []
         self.result_samples = result_samples or []
+        self.requires_beta = requires_beta
 
         self.module_arg_spec = self.spec.ansible_spec
         self.results: Dict[str, Any] = {self.result_field_name: []}
@@ -153,8 +156,13 @@ class ListModule(
                 required=True,
             )
 
+        description = [f"List and filter on {self.result_display_name}s."]
+
+        if self.requires_beta:
+            description.insert(0, beta_disclaimer)
+
         return SpecDocMeta(
-            description=[f"List and filter on {self.result_display_name}s."],
+            description=description,
             requirements=global_requirements,
             author=global_authors,
             options=options,

--- a/plugins/module_utils/linode_docs.py
+++ b/plugins/module_utils/linode_docs.py
@@ -11,6 +11,6 @@ global_authors = [
 global_requirements = ["python >= 3"]
 
 beta_disclaimer = (
-    "> :warning: **This module makes use of beta endpoints and requires the `api_version` "
+    "**:warning: This module makes use of beta endpoints and requires the `api_version` "
     "field be explicitly set to `v4beta`.**"
 )

--- a/plugins/module_utils/linode_docs.py
+++ b/plugins/module_utils/linode_docs.py
@@ -9,3 +9,8 @@ global_authors = [
 ]
 
 global_requirements = ["python >= 3"]
+
+beta_disclaimer = (
+    "> :warning: **This module makes use of beta endpoints and requires the `api_version` "
+    "field be explicitly set to `v4beta`.**"
+)

--- a/plugins/module_utils/linode_docs.py
+++ b/plugins/module_utils/linode_docs.py
@@ -10,7 +10,7 @@ global_authors = [
 
 global_requirements = ["python >= 3"]
 
-beta_disclaimer = (
+BETA_DISCLAIMER = (
     "**:warning: This module makes use of beta endpoints and requires the `api_version` "
     "field be explicitly set to `v4beta`.**"
 )

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -35,6 +35,7 @@ module = InfoModule(
             )._raw_json,
         ),
     ],
+    requires_beta=True,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -19,6 +19,7 @@ module = ListModule(
     result_docs_url="TBD",
     result_samples=docs.result_account_availabilities_samples,
     examples=docs.specdoc_examples,
+    requires_beta=True,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -12,7 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    beta_disclaimer,
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -47,7 +47,7 @@ ip_share_spec = {
 SPECDOC_META = SpecDocMeta(
     description=[
         "Manage the Linode shared IPs.",
-        beta_disclaimer,
+        BETA_DISCLAIMER,
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -46,8 +46,8 @@ ip_share_spec = {
 
 SPECDOC_META = SpecDocMeta(
     description=[
-        beta_disclaimer,
         "Manage the Linode shared IPs.",
+        beta_disclaimer,
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -12,6 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    beta_disclaimer,
     global_authors,
     global_requirements,
 )
@@ -44,7 +45,10 @@ ip_share_spec = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["Manage the Linode shared IPs."],
+    description=[
+        beta_disclaimer,
+        "Manage the Linode shared IPs.",
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=ip_share_spec,

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -12,6 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    beta_disclaimer,
     global_authors,
     global_requirements,
 )
@@ -32,7 +33,10 @@ linode_vlan_info_spec = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode VLAN."],
+    description=[
+        "Get info about a Linode VLAN.",
+        beta_disclaimer,
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=linode_vlan_info_spec,

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -12,7 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    beta_disclaimer,
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -35,7 +35,7 @@ linode_vlan_info_spec = {
 SPECDOC_META = SpecDocMeta(
     description=[
         "Get info about a Linode VLAN.",
-        beta_disclaimer,
+        BETA_DISCLAIMER,
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -12,7 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    beta_disclaimer,
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -79,7 +79,7 @@ spec = {
 SPECDOC_META = SpecDocMeta(
     description=[
         "List and filter on Linode VLANs.",
-        beta_disclaimer,
+        BETA_DISCLAIMER,
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -12,6 +12,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    beta_disclaimer,
     global_authors,
     global_requirements,
 )
@@ -76,7 +77,10 @@ spec = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode VLANs."],
+    description=[
+        "List and filter on Linode VLANs.",
+        beta_disclaimer,
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=spec,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ disable = [
     "duplicate-code",
     "too-many-lines",
     "too-many-branches",
+    "too-many-instance-attributes",
     "anomalous-backslash-in-string",
     "too-many-locals",
     "consider-using-f-string",


### PR DESCRIPTION
## 📝 Description

This change adds a disclaimer to the documentation for modules that consume beta (`v4beta`) endpoints. I intentionally opted not to add `api_version` validation logic to prevent any testing/edge case issues.

**NOTE: We do not implicitly override the API version because the default behavior for beta usage should be opt-out.**

## 📷 Preview

<img width="1066" alt="ansible_linode_docs_modules_ip_share_md_at_doc_beta-endpoints_·_lgarber-akamai_ansible_linode" src="https://github.com/linode/ansible_linode/assets/114949949/e59e2e76-8356-4aa4-97b3-002b7ac55f67">
