### PR TITLE
new: Add `child_account_info` and `child_account_list` modules; add user_type to user response examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Name | Description |
 --- | ------------ |
 [linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|Get info about a Linode Account Availability.|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
+[linode.cloud.child_account_info](./docs/modules/child_account_info.md)|Get info about a Linode Child Account.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
 [linode.cloud.domain_info](./docs/modules/domain_info.md)|Get info about a Linode Domain.|
@@ -87,6 +88,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 Name | Description |
 --- | ------------ |
 [linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilitys.|
+[linode.cloud.child_account_list](./docs/modules/child_account_list.md)|List and filter on Child Accounts.|
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|

--- a/docs/modules/child_account_info.md
+++ b/docs/modules/child_account_info.md
@@ -1,0 +1,61 @@
+# child_account_info
+
+Get info about a Linode Child Account.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: Get info about a Child Account by EUUID
+  linode.cloud.child_account_info:
+    euuid: "FFFFFFFF-FFFF-FFFF-FFFFFFFFFFFFFFFF"
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `euuid` | <center>`int`</center> | <center>**Required**</center> | The EUUID of the Child Account to resolve.   |
+
+## Return Values
+
+- `child_account` - The returned Child Account.
+
+    - Sample Response:
+        ```json
+        {
+            "active_since": "2018-01-01T00:01:01",
+            "address_1": "123 Main Street",
+            "address_2": "Suite A",
+            "balance": 200,
+            "balance_uninvoiced": 145,
+            "billing_source": "external",
+            "capabilities": [
+                "Linodes",
+                "NodeBalancers",
+                "Block Storage",
+                "Object Storage"
+            ],
+            "city": "Philadelphia",
+            "company": "Linode LLC",
+            "country": "US",
+            "credit_card": {
+                "expiry": "11/2022",
+                "last_four": 1111
+            },
+            "email": "john.smith@linode.com",
+            "euuid": "E1AF5EEC-526F-487D-B317EBEB34C87D71",
+            "first_name": "John",
+            "last_name": "Smith",
+            "phone": "215-555-1212",
+            "state": "PA",
+            "tax_id": "ATU99999999",
+            "zip": "19102-1234"
+        }
+        ```
+
+

--- a/docs/modules/child_account_info.md
+++ b/docs/modules/child_account_info.md
@@ -19,7 +19,7 @@ Get info about a Linode Child Account.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `euuid` | <center>`int`</center> | <center>**Required**</center> | The EUUID of the Child Account to resolve.   |
+| `euuid` | <center>`str`</center> | <center>**Required**</center> | The EUUID of the Child Account to resolve.   |
 
 ## Return Values
 

--- a/docs/modules/child_account_list.md
+++ b/docs/modules/child_account_list.md
@@ -1,0 +1,70 @@
+# child_account_list
+
+List and filter on Child Accounts.
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+```yaml
+- name: List all of the Child Accounts under the current Account
+  linode.cloud.child_account_list: {}
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Child Accounts in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Child Accounts by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Child Accounts.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Child Accounts to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `child_accounts` - The returned Child Accounts.
+
+    - Sample Response:
+        ```json
+        {
+            "active_since": "2018-01-01T00:01:01",
+            "address_1": "123 Main Street",
+            "address_2": "Suite A",
+            "balance": 200,
+            "balance_uninvoiced": 145,
+            "billing_source": "external",
+            "capabilities": [
+                "Linodes",
+                "NodeBalancers",
+                "Block Storage",
+                "Object Storage"
+            ],
+            "city": "Philadelphia",
+            "company": "Linode LLC",
+            "country": "US",
+            "credit_card": {
+                "expiry": "11/2022",
+                "last_four": 1111
+            },
+            "email": "john.smith@linode.com",
+            "euuid": "E1AF5EEC-526F-487D-B317EBEB34C87D71",
+            "first_name": "John",
+            "last_name": "Smith",
+            "phone": "215-555-1212",
+            "state": "PA",
+            "tax_id": "ATU99999999",
+            "zip": "19102-1234"
+        }
+        ```
+
+

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -91,6 +91,7 @@ Manage a Linode User.
         {
           "email": "example_user@linode.com",
           "restricted": true,
+          "user_type": "default",
           "ssh_keys": [
             "home-pc",
             "laptop"

--- a/docs/modules/user_info.md
+++ b/docs/modules/user_info.md
@@ -30,6 +30,7 @@ Get info about a Linode User.
         {
           "email": "example_user@linode.com",
           "restricted": true,
+          "user_type": "default",
           "ssh_keys": [
             "home-pc",
             "laptop"

--- a/docs/modules/user_list.md
+++ b/docs/modules/user_list.md
@@ -31,6 +31,7 @@ List Users.
           {
             "email": "example_user@linode.com",
             "restricted": true,
+            "user_type": "default",
             "ssh_keys": [
               "home-pc",
               "laptop"

--- a/plugins/module_utils/doc_fragments/child_account_info.py
+++ b/plugins/module_utils/doc_fragments/child_account_info.py
@@ -1,0 +1,37 @@
+"""Documentation fragments for the vpc_info module"""
+
+result_child_account_samples = ['''{
+    "active_since": "2018-01-01T00:01:01",
+    "address_1": "123 Main Street",
+    "address_2": "Suite A",
+    "balance": 200,
+    "balance_uninvoiced": 145,
+    "billing_source": "external",
+    "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage",
+        "Object Storage"
+    ],
+    "city": "Philadelphia",
+    "company": "Linode LLC",
+    "country": "US",
+    "credit_card": {
+        "expiry": "11/2022",
+        "last_four": 1111
+    },
+    "email": "john.smith@linode.com",
+    "euuid": "E1AF5EEC-526F-487D-B317EBEB34C87D71",
+    "first_name": "John",
+    "last_name": "Smith",
+    "phone": "215-555-1212",
+    "state": "PA",
+    "tax_id": "ATU99999999",
+    "zip": "19102-1234"
+}''']
+
+
+specdoc_examples = ['''
+- name: Get info about a Child Account by EUUID
+  linode.cloud.child_account_info:
+    euuid: "FFFFFFFF-FFFF-FFFF-FFFFFFFFFFFFFFFF"''']

--- a/plugins/module_utils/doc_fragments/child_account_list.py
+++ b/plugins/module_utils/doc_fragments/child_account_list.py
@@ -1,0 +1,35 @@
+"""Documentation fragments for the vpc_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Child Accounts under the current Account
+  linode.cloud.child_account_list: {}''']
+
+result_child_accounts_samples = ['''{
+    "active_since": "2018-01-01T00:01:01",
+    "address_1": "123 Main Street",
+    "address_2": "Suite A",
+    "balance": 200,
+    "balance_uninvoiced": 145,
+    "billing_source": "external",
+    "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage",
+        "Object Storage"
+    ],
+    "city": "Philadelphia",
+    "company": "Linode LLC",
+    "country": "US",
+    "credit_card": {
+        "expiry": "11/2022",
+        "last_four": 1111
+    },
+    "email": "john.smith@linode.com",
+    "euuid": "E1AF5EEC-526F-487D-B317EBEB34C87D71",
+    "first_name": "John",
+    "last_name": "Smith",
+    "phone": "215-555-1212",
+    "state": "PA",
+    "tax_id": "ATU99999999",
+    "zip": "19102-1234"
+}''']

--- a/plugins/module_utils/doc_fragments/user.py
+++ b/plugins/module_utils/doc_fragments/user.py
@@ -27,6 +27,7 @@ specdoc_examples = ['''
 result_user_samples = ['''{
   "email": "example_user@linode.com",
   "restricted": true,
+  "user_type": "default",
   "ssh_keys": [
     "home-pc",
     "laptop"

--- a/plugins/module_utils/doc_fragments/user_info.py
+++ b/plugins/module_utils/doc_fragments/user_info.py
@@ -8,6 +8,7 @@ specdoc_examples = ['''
 result_user_samples = ['''{
   "email": "example_user@linode.com",
   "restricted": true,
+  "user_type": "default",
   "ssh_keys": [
     "home-pc",
     "laptop"

--- a/plugins/module_utils/doc_fragments/user_list.py
+++ b/plugins/module_utils/doc_fragments/user_list.py
@@ -8,6 +8,7 @@ result_users_samples = ['''[
   {
     "email": "example_user@linode.com",
     "restricted": true,
+    "user_type": "default",
     "ssh_keys": [
       "home-pc",
       "laptop"

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -5,7 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.child_account_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    child_account_info as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleAttr,

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode Child Account."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.child_account_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import ChildAccount
+
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="child_account",
+        field_type=FieldType.dict,
+        display_name="Child Account",
+        docs_url="",
+        samples=docs.result_child_account_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            display_name="EUUID",
+            name="euuid",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                ChildAccount,
+                params.get("euuid"),
+            )._raw_json,
+        ),
+    ],
+    examples=docs.specdoc_examples,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -26,7 +26,7 @@ module = InfoModule(
         InfoModuleAttr(
             display_name="EUUID",
             name="euuid",
-            type=FieldType.integer,
+            type=FieldType.string,
             get=lambda client, params: client.load(
                 ChildAccount,
                 params.get("euuid"),

--- a/plugins/modules/child_account_list.py
+++ b/plugins/modules/child_account_list.py
@@ -5,7 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.child_account_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    child_account_list as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModule,
 )

--- a/plugins/modules/child_account_list.py
+++ b/plugins/modules/child_account_list.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all the functionality for listing Linode Account Children."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.child_account_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Child Account",
+    result_field_name="child_accounts",
+    endpoint_template="/account/child-accounts",
+    result_docs_url="",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_child_accounts_samples,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-linode-api4>=5.13.1
+# TODO: Revert before merging to dev
+# linode-api4>=5.13.1
+git+https://github.com/linode/linode_api4-python@proj/parent-child
+
+
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/child_accounts/tasks/main.yaml
+++ b/tests/integration/targets/child_accounts/tasks/main.yaml
@@ -1,0 +1,31 @@
+- name: child_accounts
+  tags:
+    - never
+    - parent_child
+  block:
+    - name: List all children under the current account
+      linode.cloud.child_account_list: {}
+      register: children
+
+    - assert:
+        that:
+          - children.child_accounts | length > 0
+          - children.child_accounts[0].email is not none
+          - children.child_accounts[0].euuid is not none
+
+    - name: Get information about a specific Child Account
+      linode.cloud.child_account_info:
+        euuid: '{{ children.child_accounts[0].euuid }}'
+      register: child
+
+    - assert:
+        that:
+          - child.child_account.email == children.child_accounts[0].email
+          - child.child_account.euuid == children.child_accounts[0].euuid
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/user_basic/tasks/main.yaml
+++ b/tests/integration/targets/user_basic/tasks/main.yaml
@@ -15,6 +15,7 @@
         that:
           - create_user.user.email != None
           - create_user.user.restricted == True
+          - create_user.user.user_type is not none
 
     - name: Update the Linode User
       linode.cloud.user:

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -15,6 +15,7 @@
         that:
           - create.user.email != None
           - create.user.restricted == True
+          - create.user.user_type is not none
 
     - name: List users with no filter
       linode.cloud.user_list:


### PR DESCRIPTION
## 📝 Description

This change adds the `child_account_info` and `child_account_list` modules, as well as a new `user_type` attribute to the user-related examples.

NOTE: This PR intentionally does not include functionality for creating child account tokens because they are short-lived and we cannot view their state after creation. If you feel this should be added to the scope of this PR, definitely let me know 🙂 

For the time being users can use something like this:

```yaml
- linode.cloud.api_request:
    path: 'account/child-accounts/{{ euuid }}/token'
    method: POST
```

## ✔️ How to Test

The following test steps assume you have pulled this PR locally and run `pip install --force -r requirements.txt`.

Additionally, the following environment variables should be set before running any of the following:

```bash
export TEST_API_CA=$PWD/cacert.pem
export TEST_API_URL=https://.../
export LINODE_TOKEN=...
```

### Integration Testing

```bash
make TEST_ARGS="-v child_accounts --tags=parent_child" test
make TEST_ARGS="-v user_basic" test
make TEST_ARGS="-v user_list" test
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: List all children under the current account
      linode.cloud.child_account_list: { }
      register: children

    - name: Get information about a specific Child Account
      linode.cloud.child_account_info:
        euuid: '{{ children.child_accounts[0].euuid }}'
      register: child

    - name: All child accounts
      debug:
        var: children.child_accounts

    - name: Single child account
      debug:
        var: child.child_account
```

2. Ensure the playbook succeeds as expected. 