### PR TITLE
Revert "doc: Add API token requirement in module description"

### DIFF
--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -24,7 +24,6 @@ Get info about a Linode Account Availability.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `region` | <center>`str`</center> | <center>**Required**</center> | The Region of the Account Availability to resolve.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -21,7 +21,6 @@ List and filter on Account Availabilitys.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list Account Availabilitys in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Account Availabilitys by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Account Availabilitys.   |

--- a/docs/modules/account_info.md
+++ b/docs/modules/account_info.md
@@ -14,12 +14,6 @@ Get info about a Linode Account.
 ```
 
 
-## Parameters
-
-| Field     | Type | Required | Description                                                                  |
-|-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
-
 ## Return Values
 
 - `account` - The account info in JSON serialized form.

--- a/docs/modules/database_engine_list.md
+++ b/docs/modules/database_engine_list.md
@@ -26,7 +26,6 @@ List and filter on Managed Database engine types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list database engine types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order database engine types by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting database engine types.   |

--- a/docs/modules/database_list.md
+++ b/docs/modules/database_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Managed Databases.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list databases in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order databases by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting databases.   |

--- a/docs/modules/database_mysql.md
+++ b/docs/modules/database_mysql.md
@@ -50,7 +50,6 @@ Manage a Linode MySQL database.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`; Default: `1`)** |
 | `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |

--- a/docs/modules/database_mysql_info.md
+++ b/docs/modules/database_mysql_info.md
@@ -25,7 +25,6 @@ Get info about a Linode MySQL Managed Database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`str`</center> | <center>Optional</center> | The ID of the MySQL Database.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the MySQL Database.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/database_postgresql.md
+++ b/docs/modules/database_postgresql.md
@@ -51,7 +51,6 @@ Manage a Linode PostgreSQL database.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This database's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this database.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses that can access the Managed Database. Each item must be a range in CIDR format.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode Instance nodes deployed to the Managed Database.  **(Choices: `1`, `3`; Default: `1`)** |
 | `encrypted` | <center>`bool`</center> | <center>Optional</center> | Whether the Managed Databases is encrypted.   |

--- a/docs/modules/database_postgresql_info.md
+++ b/docs/modules/database_postgresql_info.md
@@ -25,7 +25,6 @@ Get info about a Linode PostgreSQL Managed Database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`str`</center> | <center>Optional</center> | The ID of the PostgreSQL Database.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the PostgreSQL Database.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/domain.md
+++ b/docs/modules/domain.md
@@ -30,7 +30,6 @@ Manage Linode Domains.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `domain` | <center>`str`</center> | <center>**Required**</center> | The domain this Domain represents.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `axfr_ips` | <center>`list`</center> | <center>Optional</center> | The list of IPs that may perform a zone transfer for this Domain.  **(Updatable)** |
 | `description` | <center>`str`</center> | <center>Optional</center> | The list of IPs that may perform a zone transfer for this Domain.  **(Updatable)** |
 | `expire_sec` | <center>`int`</center> | <center>Optional</center> | The amount of time in seconds that may pass before this Domain is no longer authoritative.  **(Updatable)** |

--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Domain.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique domain name of the Domain. Optional if `domain` is defined.  **(Conflicts With: `domain`)** |
 | `domain` | <center>`str`</center> | <center>Optional</center> | The unique id of the Domain. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/domain_list.md
+++ b/docs/modules/domain_list.md
@@ -26,7 +26,6 @@ List and filter on Domains.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list domains in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order domains by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting domains.   |

--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -44,7 +44,6 @@ NOTE: Domain records are identified by their name, target, and type.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain.   |
 | `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain.   |
 | `record_id` | <center>`int`</center> | <center>Optional</center> | The id of the record to modify.  **(Conflicts With: `name`)** |

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -29,7 +29,6 @@ Get info about a Linode Domain Record.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain. Optional if `domain` is defined.  **(Conflicts With: `domain`)** |
 | `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain. Optional if `domain_id` is defined.  **(Conflicts With: `domain_id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique id of the subdomain. Optional if `name` is defined.  **(Conflicts With: `name`)** |

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -34,7 +34,6 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -57,7 +57,6 @@ Manage Linode Firewalls.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`, `update`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this Firewall.   |
 | [`devices` (sub-options)](#devices) | <center>`list`</center> | <center>Optional</center> | The devices that are attached to this Firewall.  **(Updatable)** |
 | [`rules` (sub-options)](#rules) | <center>`dict`</center> | <center>Optional</center> | The inbound and outbound access rules to apply to this Firewall.  **(Updatable)** |

--- a/docs/modules/firewall_device.md
+++ b/docs/modules/firewall_device.md
@@ -43,7 +43,6 @@ Manage Linode Firewall Devices.
 | `entity_id` | <center>`int`</center> | <center>**Required**</center> | The ID for this Firewall Device. This will be the ID of the Linode Entity.   |
 | `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode and nodebalancer.  **(Choices: `linode`, `nodebalancer`)** |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/firewall_info.md
+++ b/docs/modules/firewall_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Firewall.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique id of the Firewall. Optional if `label` is defined.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The Firewall’s label. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/firewall_list.md
+++ b/docs/modules/firewall_list.md
@@ -26,7 +26,6 @@ List and filter on Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list firewalls in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order firewalls by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting firewalls.   |

--- a/docs/modules/image.md
+++ b/docs/modules/image.md
@@ -40,7 +40,6 @@ Manage a Linode Image.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This Image's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this Image.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `cloud_init` | <center>`bool`</center> | <center>Optional</center> | Whether this image supports cloud-init.  **(Default: `False`)** |
 | `description` | <center>`str`</center> | <center>Optional</center> | A description for the Image.  **(Updatable)** |
 | `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to clone this image from.  **(Conflicts With: `source_file`)** |

--- a/docs/modules/image_info.md
+++ b/docs/modules/image_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Image.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`str`</center> | <center>Optional</center> | The ID of the image.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the image.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -34,7 +34,6 @@ List and filter on Images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list Images in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Images by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Images.   |

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -104,7 +104,6 @@ Manage Linode Instances, Configs, and Disks.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this instance.   |
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type of the Linode you are creating.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Instance to resolve.  **(Conflicts With: `label`)** |
 

--- a/docs/modules/instance_list.md
+++ b/docs/modules/instance_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Instances.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list instances in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order instances by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting instances.   |

--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list instance types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order instance types by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting instance types.   |

--- a/docs/modules/ip_assign.md
+++ b/docs/modules/ip_assign.md
@@ -32,7 +32,6 @@ The following restrictions apply:
 |-----------|------|----------|------------------------------------------------------------------------------|
 | [`assignments` (sub-options)](#assignments) | <center>`list`</center> | <center>**Required**</center> | List of assignments to make.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>**Required**</center> | The Region to operate in.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ### assignments
 

--- a/docs/modules/ip_info.md
+++ b/docs/modules/ip_info.md
@@ -20,7 +20,6 @@ Get info about a Linode IP.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `address` | <center>`str`</center> | <center>**Required**</center> | The IP address to operate on.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/ip_rdns.md
+++ b/docs/modules/ip_rdns.md
@@ -31,7 +31,6 @@ Manage a Linode IP address's rDNS.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `address` | <center>`str`</center> | <center>**Required**</center> | The IP address.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `state` | <center>`str`</center> | <center>Optional</center> | The state of this rDNS of the IP address.  **(Choices: `present`, `absent`)** |
 | `rdns` | <center>`str`</center> | <center>Optional</center> | The desired rDNS value.  **(Updatable)** |
 

--- a/docs/modules/ip_share.md
+++ b/docs/modules/ip_share.md
@@ -25,7 +25,6 @@ Manage the Linode shared IPs.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `ips` | <center>`list`</center> | <center>**Required**</center> | A list of secondary Linode IPs to share with the primary Linode.   |
 | `linode_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the primary Linode that the addresses will be shared with.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/ipv6_range_info.md
+++ b/docs/modules/ipv6_range_info.md
@@ -19,7 +19,6 @@ Get info about a Linode IPv6 range.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `range` | <center>`str`</center> | <center>Optional</center> | The IPv6 range to access.   |
 
 ## Return Values

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -51,7 +51,6 @@ Manage Linode LKE clusters.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This Kubernetes cluster’s unique label.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |

--- a/docs/modules/lke_cluster_info.md
+++ b/docs/modules/lke_cluster_info.md
@@ -25,7 +25,6 @@ Get info about a Linode LKE cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the LKE cluster. Optional if `label` is defined.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the LKE cluster. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/lke_node_pool.md
+++ b/docs/modules/lke_node_pool.md
@@ -49,7 +49,6 @@ Manage Linode LKE cluster node pools.
 | `cluster_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the LKE cluster that contains this node pool.   |
 | `tags` | <center>`list`</center> | <center>**Required**</center> | An array of tags applied to this object. Tags must be unique as they are used by the `lke_node_pool` module to uniquely identify node pools.  **(Updatable)** |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | [`autoscaler` (sub-options)](#autoscaler) | <center>`dict`</center> | <center>Optional</center> | When enabled, the number of nodes autoscales within the defined minimum and maximum values.  **(Updatable)** |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of nodes in the Node Pool.  **(Updatable)** |
 | [`disks` (sub-options)](#disks) | <center>`list`</center> | <center>Optional</center> | This Node Pool’s custom disk layout. Each item in this array will create a new disk partition for each node in this Node Pool.   |

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -18,7 +18,6 @@ List Kubernetes versions available for deployment to a Kubernetes cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list lke versions in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -39,7 +39,6 @@ Manage a Linode NodeBalancer.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | The unique label to give this NodeBalancer.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `client_conn_throttle` | <center>`int`</center> | <center>Optional</center> | Throttle connections per second. Set to 0 (zero) to disable throttling.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | The ID of the Region to create this NodeBalancer in.   |
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of the Firewall to assign this NodeBalancer to.   |

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -25,7 +25,6 @@ Get info about a Linode NodeBalancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of this NodeBalancer. Optional if `label` is defined.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of this NodeBalancer. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/nodebalancer_list.md
+++ b/docs/modules/nodebalancer_list.md
@@ -26,7 +26,6 @@ List and filter on Nodebalancers.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list nodebalancers in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order nodebalancers by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting nodebalancers.   |

--- a/docs/modules/nodebalancer_node.md
+++ b/docs/modules/nodebalancer_node.md
@@ -51,7 +51,6 @@ Manage Linode NodeBalancer Nodes.
 | `config_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the NodeBalancer Config that contains this node.   |
 | `label` | <center>`str`</center> | <center>**Required**</center> | The label for this node. This is used to identify nodes within a config.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | Whether the NodeBalancer node should be present or absent.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `address` | <center>`str`</center> | <center>Optional</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
 | `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`; Updatable)** |
 | `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |

--- a/docs/modules/nodebalancer_stats.md
+++ b/docs/modules/nodebalancer_stats.md
@@ -22,7 +22,6 @@ View a Linode NodeBalancers Stats.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The id of the nodebalancer for which the statistics apply to.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the nodebalancer for which the statistics apply to.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/object_cluster_info.md
+++ b/docs/modules/object_cluster_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Object Storage Cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`str`</center> | <center>Optional</center> | The unique id given to the clusters.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region the clusters are in.   |
 | `domain` | <center>`str`</center> | <center>Optional</center> | The domain of the clusters.   |

--- a/docs/modules/object_cluster_list.md
+++ b/docs/modules/object_cluster_list.md
@@ -26,7 +26,6 @@ List and filter on Object Storage Clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list object storage clusters in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order object storage clusters by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting object storage clusters.   |

--- a/docs/modules/object_keys.md
+++ b/docs/modules/object_keys.md
@@ -39,7 +39,6 @@ Manage Linode Object Storage Keys.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this key.   |
 | [`access` (sub-options)](#access) | <center>`list`</center> | <center>Optional</center> | A list of access permissions to give the key.   |
 

--- a/docs/modules/profile_info.md
+++ b/docs/modules/profile_info.md
@@ -14,12 +14,6 @@ Get info about a Linode Profile.
 ```
 
 
-## Parameters
-
-| Field     | Type | Required | Description                                                                  |
-|-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
-
 ## Return Values
 
 - `profile` - The profile info in JSON serialized form.

--- a/docs/modules/region_list.md
+++ b/docs/modules/region_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Regions.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list regions in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order regions by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting regions.   |

--- a/docs/modules/ssh_key.md
+++ b/docs/modules/ssh_key.md
@@ -29,7 +29,6 @@ Manage a Linode SSH key.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This SSH key's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this SSH key.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `ssh_key` | <center>`str`</center> | <center>Optional</center> | The SSH public key value.  **(Updatable)** |
 
 ## Return Values

--- a/docs/modules/ssh_key_info.md
+++ b/docs/modules/ssh_key_info.md
@@ -25,7 +25,6 @@ Get info about the Linode SSH public key.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the SSH key.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the SSH key.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/ssh_key_list.md
+++ b/docs/modules/ssh_key_list.md
@@ -46,7 +46,6 @@ List and filter on SSH keys in the Linode profile.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list ssh keys in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order ssh keys by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting ssh keys.   |

--- a/docs/modules/stackscript.md
+++ b/docs/modules/stackscript.md
@@ -35,7 +35,6 @@ Manage a Linode StackScript.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This StackScript's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this StackScript.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `description` | <center>`str`</center> | <center>Optional</center> | A description for the StackScript.  **(Updatable)** |
 | `images` | <center>`list`</center> | <center>Optional</center> | Images that can be deployed using this StackScript.  **(Updatable)** |
 | `is_public` | <center>`bool`</center> | <center>Optional</center> | This determines whether other users can use your StackScript.  **(Updatable)** |

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -25,7 +25,6 @@ Get info about a Linode StackScript.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.  **(Conflicts With: `label`)** |
 

--- a/docs/modules/stackscript_list.md
+++ b/docs/modules/stackscript_list.md
@@ -34,7 +34,6 @@ List and filter on Linode stackscripts.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |

--- a/docs/modules/token.md
+++ b/docs/modules/token.md
@@ -40,7 +40,6 @@ NOTE: The full Personal Access Token is only returned when a new token has been 
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This token's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `expiry` | <center>`str`</center> | <center>Optional</center> | When this token should be valid until.   |
 | `scopes` | <center>`str`</center> | <center>Optional</center> | The OAuth scopes to create the token with.   |
 

--- a/docs/modules/token_info.md
+++ b/docs/modules/token_info.md
@@ -25,7 +25,6 @@ Get info about a Linode Personal Access Token.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the token.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the token.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/token_list.md
+++ b/docs/modules/token_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Account tokens.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list tokens in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order tokens by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting tokens.   |

--- a/docs/modules/type_info.md
+++ b/docs/modules/type_info.md
@@ -20,7 +20,6 @@ Get info about a Linode Type.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `id` | <center>`str`</center> | <center>**Required**</center> | The ID of the Type to resolve.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/type_list.md
+++ b/docs/modules/type_list.md
@@ -27,7 +27,6 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list Instance Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Instance Types by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Instance Types.   |

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -46,7 +46,6 @@ Manage a Linode User.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `username` | <center>`str`</center> | <center>**Required**</center> | The username of this user.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this user.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `restricted` | <center>`bool`</center> | <center>Optional</center> | If true, the User must be granted access to perform actions or access entities on this Account.  **(Default: `True`; Updatable)** |
 | `email` | <center>`str`</center> | <center>Optional</center> | The email address for the User. Linode sends emails to this address for account management communications. May be used for other communications as configured.   |
 | [`grants` (sub-options)](#grants) | <center>`dict`</center> | <center>Optional</center> | Update the grants a user has.  **(Updatable)** |

--- a/docs/modules/user_info.md
+++ b/docs/modules/user_info.md
@@ -20,7 +20,6 @@ Get info about a Linode User.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `username` | <center>`str`</center> | <center>**Required**</center> | The username of the user.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/user_list.md
+++ b/docs/modules/user_list.md
@@ -18,7 +18,6 @@ List Users.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list users in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -23,7 +23,6 @@ Get info about a Linode VLAN.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | The VLAN’s label.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 
 ## Return Values
 

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -31,7 +31,6 @@ List and filter on Linode VLANs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VLANs in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VLANs by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VLANs.   |

--- a/docs/modules/volume.md
+++ b/docs/modules/volume.md
@@ -63,7 +63,6 @@ Manage a Linode Volume.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The Volume’s label, which is also used in the filesystem_path of the resulting volume.   |
 | `config_id` | <center>`int`</center> | <center>Optional</center> | When creating a Volume attached to a Linode, the ID of the Linode Config to include the new Volume in.   |
 | `linode_id` | <center>`int`</center> | <center>Optional</center> | The Linode this volume should be attached to upon creation. If not given, the volume will be created without an attachment.  **(Updatable)** |

--- a/docs/modules/volume_info.md
+++ b/docs/modules/volume_info.md
@@ -23,7 +23,6 @@ Get info about a Linode Volume.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Volume. Optional if `label` is defined.  **(Conflicts With: `label`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Volume. Optional if `id` is defined.  **(Conflicts With: `id`)** |
 

--- a/docs/modules/volume_list.md
+++ b/docs/modules/volume_list.md
@@ -26,7 +26,6 @@ List and filter on Linode Volumes.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list volumes in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order volumes by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting volumes.   |

--- a/docs/modules/vpc.md
+++ b/docs/modules/vpc.md
@@ -31,7 +31,6 @@ Create, read, and update a Linode VPC.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `description` | <center>`str`</center> | <center>Optional</center> | A description describing this VPC.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region this VPC is located in.   |
 

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -25,7 +25,6 @@ Get info about a Linode VPC.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC to resolve.  **(Conflicts With: `label`)** |
 

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -26,7 +26,6 @@ List and filter on VPCs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPCs in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPCs by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPCs.   |

--- a/docs/modules/vpc_subnet.md
+++ b/docs/modules/vpc_subnet.md
@@ -33,7 +33,6 @@ Create, read, and update a Linode VPC Subnet.
 | `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the parent VPC for this subnet.   |
 | `label` | <center>`str`</center> | <center>**Required**</center> | This VPC's unique label.   |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of this token.  **(Choices: `present`, `absent`)** |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `ipv4` | <center>`str`</center> | <center>Optional</center> | The IPV4 range for this subnet in CIDR format.   |
 
 ## Return Values

--- a/docs/modules/vpc_subnet_info.md
+++ b/docs/modules/vpc_subnet_info.md
@@ -28,7 +28,6 @@ Get info about a Linode VPC Subnet.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC for this resource.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC Subnet to resolve.  **(Conflicts With: `label`)** |
 

--- a/docs/modules/vpc_subnet_list.md
+++ b/docs/modules/vpc_subnet_list.md
@@ -30,7 +30,6 @@ List and filter on VPC Subnets.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for this VPC Subnet.   |
-| `api_token` | <center>`str`</center> | <center>Optional</center> | The Linode account personal access token. It is necessary to run the module. It can be exposed by the environment variable `LINODE_API_TOKEN` instead.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPC Subnets in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPC Subnets by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPC Subnets.   |

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -23,7 +23,6 @@ from ansible.module_utils.basic import (
     env_fallback,
     missing_required_lib,
 )
-from ansible_specdoc.objects import FieldType, SpecField
 
 try:
     from linode_api4 import VPC, ApiError
@@ -123,15 +122,6 @@ RESOURCE_NAMES = (
 MAX_RETRIES = 5
 RETRY_INTERVAL_SECONDS = float(4)
 RETRY_STATUSES = {408, 429, 502}
-
-API_TOKEN_SPEC = SpecField(
-    type=FieldType.string,
-    required=False,
-    description="The Linode account personal access token. "
-    "It is necessary to run the module. "
-    "It can be exposed by the "
-    "environment variable `LINODE_API_TOKEN` instead.",
-)
 
 
 class LinodeModuleBase:

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -160,7 +159,6 @@ class InfoModule(LinodeModuleBase):
         """
 
         options = {
-            "api_token": API_TOKEN_SPEC,
             "state": SpecField(
                 type=FieldType.string, required=False, doc_hide=True
             ),

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -109,7 +108,6 @@ class ListModule(
         }
 
         options = {
-            "api_token": API_TOKEN_SPEC,
             # Disable the default values
             "state": SpecField(
                 type=FieldType.string, required=False, doc_hide=True

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -24,7 +23,6 @@ from ansible_specdoc.objects import (
 )
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -10,7 +10,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     database_engine_list as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -51,7 +50,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.database_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -52,7 +51,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -10,7 +10,6 @@ from typing import Any, Optional, Set
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.database_mysql as docs
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import (
@@ -39,7 +38,6 @@ from linode_api4 import ApiError
 from linode_api4.objects import MySQLDatabase
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -14,7 +14,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     database_mysql_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import (
@@ -38,7 +37,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import MySQLDatabase
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -12,7 +12,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     database_postgresql as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import (
@@ -40,7 +39,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ApiError, PostgreSQLDatabase
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -14,7 +14,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     database_postgresql_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import (
@@ -38,7 +37,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import PostgreSQLDatabase
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional, Set
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain
 
 linode_domain_spec = {
-    "api_token": API_TOKEN_SPEC,
     # Unused for domain objects
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "axfr_ips": SpecField(

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -30,7 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain
 
 linode_domain_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -48,7 +47,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional, Set
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -28,7 +27,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain, DomainRecord
 
 linode_domain_record_spec = {
-    "api_token": API_TOKEN_SPEC,
     # Unused for domain record objects
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "domain_id": SpecField(

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -14,7 +14,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     domain_record_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -33,7 +32,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain, DomainRecord
 
 linode_domain_record_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.event_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -11,7 +11,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -129,7 +128,6 @@ linode_firewall_device_spec: dict = {
 }
 
 linode_firewall_spec: dict = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         description=["The unique label to give this Firewall."],

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_device as docs
 import linode_api4
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -24,7 +23,6 @@ from ansible_specdoc.objects import (
 )
 
 MODULE_SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "firewall_id": SpecField(
         type=FieldType.integer,
         required=True,

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -30,7 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Firewall
 
 linode_firewall_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/firewall_list.py
+++ b/plugins/modules/firewall_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -12,7 +12,6 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image
 import polling
 import requests
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -32,7 +31,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Image
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Image
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -13,7 +13,6 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.insta
 import linode_api4
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -301,7 +300,6 @@ spec_additional_ipv4 = {
 }
 
 linode_instance_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         description=["The unique label to give this instance."],

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -10,7 +10,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     instance_type_list as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -51,7 +50,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/ip_assign.py
+++ b/plugins/modules/ip_assign.py
@@ -8,7 +8,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ip_assign as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -36,7 +35,6 @@ linode_ip_assignments_spec: dict = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ip_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import IPAddress
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ip_info as ip_docs
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ip_rdns as ip_rdns_docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ExplicitNullValue, IPAddress
 
 ip_rdns_spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ip_share as ip_share_docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 from linode_api4.objects import Instance
 
 ip_share_spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ipv6_range_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -28,7 +27,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import IPv6Range
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -11,7 +11,6 @@ from typing import Any, List, Optional, Set
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_cluster as docs
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -97,7 +96,6 @@ linode_lke_cluster_node_pool_spec = {
 }
 
 linode_lke_cluster_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -14,7 +14,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     lke_cluster_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -34,7 +33,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ApiError, LKECluster
 
 linode_lke_cluster_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -9,7 +9,6 @@ import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_n
 import linode_api4
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -71,7 +70,6 @@ linode_lke_pool_disks = {
 }
 
 MODULE_SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "cluster_id": SpecField(
         type=FieldType.integer,

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_version_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 )
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -11,7 +11,6 @@ from typing import Any, List, Optional, Set, Tuple, cast
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer as docs
 import linode_api4
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -228,7 +227,6 @@ linode_configs_spec = {
 }
 
 linode_nodebalancer_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         description=["The unique label to give this NodeBalancer."],

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -14,7 +14,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     nodebalancer_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -33,7 +32,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import NodeBalancer, NodeBalancerConfig, NodeBalancerNode
 
 linode_nodebalancer_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/nodebalancer_list.py
+++ b/plugins/modules/nodebalancer_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -11,7 +11,6 @@ from typing import Any, List, Optional, Set
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer_node as docs
 import linode_api4
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 )
 
 MODULE_SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "nodebalancer_id": SpecField(
         type=FieldType.integer,
         required=True,

--- a/plugins/modules/nodebalancer_stats.py
+++ b/plugins/modules/nodebalancer_stats.py
@@ -11,7 +11,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     nodebalancer_stats as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -27,7 +26,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import NodeBalancer
 
 linode_nodebalancer_stats_spec = {
-    "api_token": API_TOKEN_SPEC,
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(
         type=FieldType.integer,

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -11,7 +11,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     object_cluster_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -27,7 +26,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ObjectStorageCluster, Region
 
 linode_object_cluster_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -10,7 +10,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
     object_cluster_list as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -51,7 +50,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional, Union
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.object_keys as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -48,7 +47,6 @@ linode_access_spec = {
 }
 
 linode_object_keys_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         description=["The unique label to give this key."],

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.profile_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -24,7 +23,6 @@ from ansible_specdoc.objects import (
 )
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/region_list.py
+++ b/plugins/modules/region_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.region_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ssh_key as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -28,7 +27,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import SSHKey
 
 ssh_key_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ssh_key_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -28,7 +27,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import SSHKey
 
 linode_ssh_key_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/ssh_key_list.py
+++ b/plugins/modules/ssh_key_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.ssh_key_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -52,7 +51,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -30,7 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import StackScript
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -50,7 +49,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -25,7 +24,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import PersonalAccessToken
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,

--- a/plugins/modules/token_info.py
+++ b/plugins/modules/token_info.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import PersonalAccessToken
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/token_list.py
+++ b/plugins/modules/token_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.token_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.type_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.user as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LINODE_COMMON_ARGS,
     LinodeModuleBase,
 )
@@ -166,7 +165,6 @@ SPEC_GRANTS = {
 }
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     # We don't use label for this module
     "label": SpecField(
         type=FieldType.string,

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.user_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -25,7 +24,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import User
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/user_list.py
+++ b/plugins/modules/user_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.user_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 )
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -9,7 +9,6 @@ from typing import Any, List, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vlan_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import VLAN
 
 linode_vlan_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vlan_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -50,7 +49,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -10,7 +10,6 @@ from typing import Any, Optional, Set
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume as docs
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -26,7 +25,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Volume
 
 linode_volume_spec = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         description=[

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume_info as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -29,7 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Volume
 
 linode_volume_info_spec = {
-    "api_token": API_TOKEN_SPEC,
     # We need to overwrite attributes to exclude them as requirements
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(

--- a/plugins/modules/volume_list.py
+++ b/plugins/modules/volume_list.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume_list as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -49,7 +48,6 @@ spec_filter = {
 }
 
 spec = {
-    "api_token": API_TOKEN_SPEC,
     # Disable the default values
     "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -30,7 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import VPC
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "label": SpecField(
         type=FieldType.string,
         required=True,
@@ -54,7 +52,9 @@ SPEC = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["Create, read, and update a Linode VPC."],
+    description=[
+        "Create, read, and update a Linode VPC.",
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=SPEC,

--- a/plugins/modules/vpc_subnet.py
+++ b/plugins/modules/vpc_subnet.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc_subnet as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    API_TOKEN_SPEC,
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
@@ -30,7 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import VPC, VPCSubnet
 
 SPEC = {
-    "api_token": API_TOKEN_SPEC,
     "vpc_id": SpecField(
         type=FieldType.integer,
         required=True,
@@ -55,7 +53,9 @@ SPEC = {
 
 
 SPECDOC_META = SpecDocMeta(
-    description=["Create, read, and update a Linode VPC Subnet."],
+    description=[
+        "Create, read, and update a Linode VPC Subnet.",
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=SPEC,


### PR DESCRIPTION
Reverts linode/ansible_linode#477 because it caused integration test failures.