### PR TITLE
fix: Resolve various bugs when defining a StackScript during disk creation

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -811,7 +811,7 @@ class LinodeInstance(LinodeModuleBase):
     def _create_disk_register(self, **params: Any) -> None:
         size = params.pop("size")
 
-        if params.get("stackscript_id", None) is not None:
+        if params.get("stackscript_id") is not None:
             params["stackscript"] = StackScript(
                 self.client, params.pop("stackscript_id")
             )

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -816,6 +816,11 @@ class LinodeInstance(LinodeModuleBase):
                 self.client, params.pop("stackscript_id")
             )
 
+        # Workaround for an edge case where a StackScript has no UDFs
+        # and the API rejects an empty list for stackscript_data
+        if len(params.get("stackscript_data") or {}) < 1:
+            params.pop("stackscript_data")
+
         # Workaround for race condition on implicit events
         # See: TPT-2738
         self.client.polling.wait_for_entity_free(

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -1,0 +1,75 @@
+- name: instance_disk_stackscript
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode StackScript
+      linode.cloud.stackscript:
+        label: "ansible-test-{{ r }}"
+        images:
+          - "linode/alpine3.19"
+        script: |
+          #!/bin/ash
+          echo "cool stackscript"
+        state: present
+      register: stackscript_create
+
+    - name: Create a Linode instance with an explicit disk & stackscript
+      linode.cloud.instance:
+        label: "ansible-test-{{ r }}"
+        region: us-mia
+        type: g6-nanode-1
+        booted: false
+        disks:
+          - label: test-disk
+            size: 1024
+            image: linode/alpine3.19
+            stackscript_id: "{{ stackscript_create.stackscript.id }}"
+        state: present
+      register: instance_create
+
+    - assert:
+        that:
+          - instance_create.changed
+          - instance_create.disks[0].label == "test-disk"
+          - instance_create.disks[0].size == 1024
+          - instance_create.disks[0].filesystem == "ext4"
+
+    - name: Get info about the StackScript
+      linode.cloud.stackscript_info:
+        label: "{{ stackscript_create.stackscript.label }}"
+      register: stackscript_info
+
+    - name: Ensure the StackScript was successfully deployed to the Linode
+      assert:
+        that:
+          - stackscript_info.stackscript.deployments_active == 1
+
+
+  always:
+    - ignore_errors: yes
+      block:
+        - linode.cloud.instance:
+            label: "{{ instance_create.instance.label }}"
+            state: absent
+          register: instance_delete
+
+        - assert:
+            that:
+              - instance_delete.changed
+
+        - linode.cloud.stackscript:
+            label: "{{ stackscript_create.stackscript.label }}"
+            state: absent
+          register: stackscript_delete
+
+        - assert:
+            that:
+              - stackscript_delete.changed
+
+  environment:
+    LINODE_UA_PREFIX: "{{ ua_prefix }}"
+    LINODE_API_TOKEN: "{{ api_token }}"
+    LINODE_API_URL: "{{ api_url }}"
+    LINODE_API_VERSION: "{{ api_version }}"
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This change resolves the following two bugs that can occur when attempting to create an instance disk with a StackSript:
- The `stackscript_id` argument isn't translated into `stackscript` (required by `linode_api4`), so the StackScript is completely ignored
- The `stackscript_data` field defaults to an empty dict, which causes the API to return an error if the StackScript is defined without any UDFs

Additionally, this PR adds a test to ensure the above fixes function as expected.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make test TEST_ARGS="-v instance_disk_stackscript"
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
- name: Create Linode Instance
  hosts: localhost
  tasks:
    - linode.cloud.stackscript:
        label: "test-stackscript"
        images:
          - "linode/alpine3.19"
        script: |
          #!/bin/ash
          echo "cool stackscript"
        state: present
      register: stackscript_create

    - linode.cloud.instance:
        label: "test-instance"
        region: us-mia
        type: g6-nanode-1
        booted: false
        disks:
          - label: test-disk
            size: 1024
            image: linode/alpine3.19
            stackscript_id: "{{ stackscript_create.stackscript.id }}"
        state: present
      register: instance_create

    - linode.cloud.stackscript_info:
        label: "{{ stackscript_create.stackscript.label }}"
      register: stackscript_info

    - debug:
        var: stackscript_info.stackscript.deployments_active
```

2. Ensure the debug output contains the following, implying the StackScript was successfully deployed to the disk:

```
ok: [localhost] => {
    "stackscript_info.stackscript.deployments_active": 1
}
```