### PR TITLE
fix: Translate `stackscript_data` to kwargs during disk creation

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -816,10 +816,9 @@ class LinodeInstance(LinodeModuleBase):
                 self.client, params.pop("stackscript_id")
             )
 
-        # Workaround for an edge case where a StackScript has no UDFs
-        # and the API rejects an empty list for stackscript_data
-        if len(params.get("stackscript_data") or {}) < 1:
-            params.pop("stackscript_data")
+        # StackScript data is expected to be specified as kwargs
+        if params.get("stackscript_data") is not None:
+            params.update(params.pop("stackscript_data"))
 
         # Workaround for race condition on implicit events
         # See: TPT-2738

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -811,14 +811,14 @@ class LinodeInstance(LinodeModuleBase):
     def _create_disk_register(self, **params: Any) -> None:
         size = params.pop("size")
 
-        if params.get("stackscript_id") is not None:
-            params["stackscript"] = StackScript(
-                self.client, params.pop("stackscript_id")
-            )
+        stackscript_id = params.pop("stackscript_id", None)
+        if stackscript_id is not None:
+            params["stackscript"] = StackScript(self.client, stackscript_id)
 
         # StackScript data is expected to be specified as kwargs
-        if params.get("stackscript_data") is not None:
-            params.update(params.pop("stackscript_data"))
+        stackscript_data = params.pop("stackscript_data", None)
+        if stackscript_data is not None and isinstance(stackscript_data, dict):
+            params.update(stackscript_data)
 
         # Workaround for race condition on implicit events
         # See: TPT-2738

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -11,7 +11,7 @@
         script: |
           #!/bin/ash
           # <UDF name="package" label="System Package to Install" example="nginx">
-          apt-get -q update && apt-get -q -y install $PACKAGE
+          apk add $PACKAGE
         state: present
       register: stackscript_create
 

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -10,7 +10,8 @@
           - "linode/alpine3.19"
         script: |
           #!/bin/ash
-          echo "cool stackscript"
+          # <UDF name="package" label="System Package to Install" example="nginx" default="">
+          apt-get -q update && apt-get -q -y install $PACKAGE
         state: present
       register: stackscript_create
 
@@ -25,6 +26,8 @@
             size: 1024
             image: linode/alpine3.19
             stackscript_id: "{{ stackscript_create.stackscript.id }}"
+            stackscript_data:
+              package: cowsay
         state: present
       register: instance_create
 

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -10,7 +10,7 @@
           - "linode/alpine3.19"
         script: |
           #!/bin/ash
-          # <UDF name="package" label="System Package to Install" example="nginx" default="">
+          # <UDF name="package" label="System Package to Install" example="nginx">
           apt-get -q update && apt-get -q -y install $PACKAGE
         state: present
       register: stackscript_create


### PR DESCRIPTION
## 📝 Description

This change resolves a bug that prevented `stackscript_data` from being properly embedded in `instance` module disk creation requests.

This is necessary because linode_api4 expects StackScript data to be specified as kwargs during disk creation: https://github.com/linode/linode_api4-python/blob/dev/linode_api4/objects/linode.py#L1161

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make test TEST_ARGS="-v instance_disk_stackscript"
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
- name: Create Linode Instance
  hosts: localhost
  tasks:
    - linode.cloud.stackscript:
        label: "test-stackscript"
        images:
          - "linode/alpine3.19"
        script: |
          #!/bin/ash
          # <UDF name="package" label="System Package to Install" example="nginx">
          apk add $PACKAGE
        state: present
      register: stackscript_create

    - linode.cloud.instance:
        label: "test-instance"
        region: us-mia
        type: g6-nanode-1
        booted: false
        disks:
          - label: test-disk
            size: 1024
            image: linode/alpine3.19
            stackscript_id: "{{ stackscript_create.stackscript.id }}"
            stackscript_data:
              package: cowsay
        state: present
      register: instance_create

    - linode.cloud.stackscript_info:
        label: "{{ stackscript_create.stackscript.label }}"
      register: stackscript_info

    - debug:
        var: stackscript_info.stackscript.deployments_active
```


2. Ensure the debug output contains the following, implying the StackScript was successfully deployed to the disk:

```
ok: [localhost] => {
    "stackscript_info.stackscript.deployments_active": 1
}
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**