### PR TITLE
test: refactor all integration tests for consistency

### DIFF
--- a/tests/integration/targets/account_availability_info/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_info/tasks/main.yaml
@@ -1,11 +1,12 @@
 - name: account_availability_info
   block:
-    - name: Get info about the current account availability
+    - name: GET account_availability_info request
       linode.cloud.account_availability_info:
         region: us-east
       register: account_availability
 
-    - assert:
+    - name: Assert GET account_availability_info response
+      assert:
         that:
           - account_availability.account_availability.region == "us-east"
 

--- a/tests/integration/targets/account_availability_list/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_list/tasks/main.yaml
@@ -1,10 +1,12 @@
 - name: account_availability_list
   block:
-    - linode.cloud.account_availability_list:
+    - name: GET account_availability_list request w no filter
+      linode.cloud.account_availability_list:
         count: 5
       register: no_filter
 
-    - assert:
+    - name: Assert GET account_availability_list response w no filter
+      assert:
         that:
           - no_filter.account_availabilities | length == 5
 

--- a/tests/integration/targets/api_request_basic/tasks/main.yaml
+++ b/tests/integration/targets/api_request_basic/tasks/main.yaml
@@ -1,20 +1,23 @@
-- name: api_request_baisc
+- name: api_request_basic
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - linode.cloud.api_request:
+    - name: GET api_request request
+      linode.cloud.api_request:
         # Arbitrary authorized endpoint
         path: lke/versions
         method: GET
       register: response_get
 
-    - assert:
+    - name: Assert GET api_request response
+      assert:
         that:
           - response_get.status == 200
           - response_get.changed == False
 
-    - linode.cloud.api_request:
+    - name: POST api_request request
+      linode.cloud.api_request:
         path: domains
         method: POST
         body:
@@ -23,25 +26,29 @@
           soa_email: ansible@example.com
       register: response_post
 
-    - assert:
+    - name: Assert POST api_request response
+      assert:
         that:
           - response_post.status == 200
           - response_post.changed == True
 
-    - linode.cloud.api_request:
+    - name: PUT api_request request
+      linode.cloud.api_request:
         path: 'domains/{{ response_post.body.id }}'
         method: PUT
         body:
           description: cool
       register: response_put
 
-    - assert:
+    - name: Assert PUT api_request response
+      assert:
         that:
           - response_put.status == 200
           - response_put.changed == True
           - response_put.body.description == 'cool'
 
-    - linode.cloud.api_request:
+    - name: PUT api_request request (negative case)
+      linode.cloud.api_request:
         path: 'reallycoolfakepath'
         method: PUT
       register: response_failed
@@ -49,12 +56,14 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.api_request:
+        - name: DELETE api_request request
+          linode.cloud.api_request:
             path: 'domains/{{ response_post.body.id }}'
             method: DELETE
           register: response_delete
 
-        - assert:
+        - name: Assert DELETE api_request response
+          assert:
             that:
               - response_delete.status == 200
               - response_delete.changed == True

--- a/tests/integration/targets/api_request_extra/tasks/main.yaml
+++ b/tests/integration/targets/api_request_extra/tasks/main.yaml
@@ -5,11 +5,11 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: List all available Linode regions
+    - name: GET region_list request
       linode.cloud.region_list:
       register: regions
     
-    - name: Create a volume by the api_request module
+    - name: POST volume request
       linode.cloud.api_request:
         path: "/volumes"
         method: POST
@@ -29,7 +29,7 @@
   always:
     - ignore_errors: true
       block:
-        - name: Delete the volume
+        - name: DELETE volume request
           linode.cloud.volume:
             label: '{{ response.body.label }}'
             state: absent
@@ -38,7 +38,7 @@
           retries: 5
           delay: 10
 
-        - name: Assert the volume was deleted
+        - name: Assert volume deleted
           assert:
             that:
               - delete_volume.changed

--- a/tests/integration/targets/database_engine_list/tasks/main.yaml
+++ b/tests/integration/targets/database_engine_list/tasks/main.yaml
@@ -1,21 +1,23 @@
 - name: database_engine_list
   block:
-    - name: List database engines with no filter
+    - name: List database_engine_list with no filter
       linode.cloud.database_engine_list:
       register: no_filter
 
-    - assert:
+    - name: Assert database_engine_list with no filter
+      assert:
         that:
           - no_filter.database_engines | length >= 1
 
-    - name: List database engines with filter on engine
+    - name: List database_engine_list with filter on engine
       linode.cloud.database_engine_list:
         filters:
           - name: engine
             values: mysql
       register: filter
 
-    - assert:
+    - name: Assert List database_engine_list with filter on engine
+      assert:
         that:
           - filter.database_engines | length >= 1
           - filter.database_engines[0].engine == 'mysql'

--- a/tests/integration/targets/domain_basic/tasks/main.yaml
+++ b/tests/integration/targets/domain_basic/tasks/main.yaml
@@ -3,7 +3,7 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Create a domain
+    - name: Create domain
       linode.cloud.domain:
         description: 'really cool domain'
         domain: 'ansible-test-domain-{{ r }}.com'
@@ -19,7 +19,8 @@
         state: present
       register: create
 
-    - assert:
+    - name: Assert domain is created
+      assert:
         that:
           - create.domain.description == 'really cool domain'
           - create.domain.expire_sec == 300
@@ -31,7 +32,7 @@
           - create.domain.ttl_sec == 14400
           - create.domain.type == 'master'
 
-    - name: Update a domain
+    - name: Update domain label
       linode.cloud.domain:
         description: 'really cool'
         domain: '{{ create.domain.domain }}'
@@ -47,7 +48,8 @@
         state: present
       register: update
 
-    - assert:
+    - name: Assert domain is updated
+      assert:
         that:
           - update.domain.description == 'really cool'
           - update.domain.expire_sec == 14400
@@ -59,12 +61,13 @@
           - update.domain.ttl_sec == 604800
           - update.domain.type == 'slave'
 
-    - name: Get domain info
+    - name: Get domain_info
       linode.cloud.domain_info:
         domain: '{{ create.domain.domain }}'
       register: info
 
-    - assert:
+    - name: Assert domain_info response
+      assert:
         that:
           - info.domain.description == 'really cool'
           - info.domain.expire_sec == 14400
@@ -79,13 +82,13 @@
   always:
     - ignore_errors: yes
       block:
-        - name: Delete the domain
+        - name: Delete domain
           linode.cloud.domain:
             domain: '{{ create.domain.domain }}'
             state: absent
           register: delete
 
-        - name: Assert domain delete succeeded
+        - name: Assert domain is deleted
           assert:
             that:
               - delete.changed

--- a/tests/integration/targets/domain_list/tasks/main.yaml
+++ b/tests/integration/targets/domain_list/tasks/main.yaml
@@ -3,7 +3,7 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Create a domain
+    - name: Create domain
       linode.cloud.domain:
         description: 'really cool domain'
         domain: 'ansible-test-domain-{{ r }}.com'
@@ -19,7 +19,7 @@
         state: present
       register: create
 
-    - name: Assert domain created
+    - name: Assert domain is created
       assert:
         that:
           - create.domain.description == 'really cool domain'
@@ -32,15 +32,16 @@
           - create.domain.ttl_sec == 14400
           - create.domain.type == 'master'
 
-    - name: List domains with no filter
+    - name: List domain_list with no filter
       linode.cloud.domain_list:
       register: no_filter
 
-    - assert:
+    - name: Assert domain_list with no filter
+      assert:
         that:
           - no_filter.domains | length >= 1
 
-    - name: List domains with filter on domain
+    - name: List domain_list with filter on domain
       linode.cloud.domain_list:
         order_by: created
         order: desc
@@ -49,20 +50,21 @@
             values: ansible-test-domain-{{ r }}.com
       register: filter
 
-    - assert:
+    - name: Assert domain_list with filter on domain
+      assert:
         that:
           - filter.domains | length >= 1
           - filter.domains[0].domain == 'ansible-test-domain-{{ r }}.com'
   always:
     - ignore_errors: yes
       block:
-        - name: Delete the domain
+        - name: Delete domain
           linode.cloud.domain:
             domain: '{{ create.domain.domain }}'
             state: absent
           register: delete
 
-        - name: Assert domain delete succeeded
+        - name: Assert domain is deleted
           assert:
             that:
               - delete.changed

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -3,7 +3,7 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Create a domain
+    - name: Create domain
       linode.cloud.domain:
         domain: 'ansible-test-domain-{{ r }}.com'
         soa_email: 'realemail@example.com'
@@ -17,7 +17,7 @@
           - domain_create.domain.status == 'active'
           - domain_create.domain.type == 'master'
 
-    - name: Create a domain record
+    - name: Create domain_record
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         name: 'sub'
@@ -28,6 +28,7 @@
         state: present
       register: record_create
 
+    - name: Assert domain_record is created
     - assert:
         that:
           - record_create.record.name == 'sub'
@@ -36,7 +37,7 @@
           - record_create.record.ttl_sec == 3600
           - record_create.record.weight == 55
 
-    - name: Update the domain record
+    - name: Update domain_record
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         record_id: '{{ record_create.record.id }}'
@@ -45,7 +46,8 @@
         state: present
       register: record_update
 
-    - assert:
+    - name: Assert domain_record is updated
+      assert:
         that:
           - record_update.record.id == record_create.record.id
           - record_update.record.name == 'sub'
@@ -54,13 +56,14 @@
           - record_update.record.ttl_sec == 14400
           - record_update.record.weight == 62
 
-    - name: Get info about the record
+    - name: Get domain_record_info
       linode.cloud.domain_record_info:
         domain: '{{ domain_create.domain.domain }}'
         name: '{{ record_create.record.name }}'
       register: record_info
 
-    - assert:
+    - name: Assert get domain_record_info
+      assert:
         that:
           - record_info.record[0].name == 'sub'
           - record_info.record[0].type == 'A'
@@ -68,13 +71,14 @@
           - record_info.record[0].ttl_sec == 14400
           - record_info.record[0].weight == 62
 
-    - name: Get info about the record by id
+    - name: Get domain_record_info by id
       linode.cloud.domain_record_info:
         domain: '{{ domain_create.domain.domain }}'
         id: '{{ record_create.record.id }}'
       register: record_info_id
 
-    - assert:
+    - name: Assert get domain_record_info by id
+      assert:
         that:
           - record_info_id.record[0].name == 'sub'
           - record_info_id.record[0].type == 'A'
@@ -82,7 +86,7 @@
           - record_info_id.record[0].ttl_sec == 14400
           - record_info_id.record[0].weight == 62
 
-    - name: Create a domain record by domain id
+    - name: Create domain_record with domain id
       linode.cloud.domain_record:
         domain_id: '{{ domain_create.domain.id }}'
         name: 'cool'
@@ -93,7 +97,8 @@
         state: present
       register: record2_create
 
-    - assert:
+    - name: Assert domain_record is created with domain id
+      assert:
         that:
           - record2_create.record.name == 'cool'
           - record2_create.record.type == 'TXT'
@@ -101,7 +106,7 @@
           - record2_create.record.ttl_sec == 7200
           - record2_create.record.weight == 32
 
-    - name: Create a duplicate record with a different target
+    - name: Create duplicate domain_record with different target
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         name: 'sub'
@@ -112,7 +117,8 @@
         state: present
       register: record_dupe_create
 
-    - assert:
+    - name: Assert duplicate domain_record is created with different target
+      assert:
         that:
           - record_dupe_create.record.name == 'sub'
           - record_dupe_create.record.type == 'A'
@@ -120,7 +126,7 @@
           - record_dupe_create.record.ttl_sec == 3600
           - record_dupe_create.record.weight == 55
 
-    - name: Update the record by id
+    - name: Update domain_record by id
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         record_id: '{{ record_dupe_create.record.id }}'
@@ -129,7 +135,8 @@
         state: present
       register: record_dupe_update
 
-    - assert:
+    - name: Assert domain_record is updated by id
+      assert:
         that:
           - record_dupe_update.changed == true
           - record_dupe_update.record.name == 'sub'
@@ -138,16 +145,17 @@
           - record_dupe_update.record.ttl_sec == 300
           - record_dupe_update.record.weight == 55
 
-    - name: Get all domain records
+    - name: Get domain_info
       linode.cloud.domain_info:
         domain: '{{ domain_create.domain.domain }}'
       register: domain_info
 
-    - assert:
+    - name: Assert domain_info response
+      assert:
         that:
           - domain_info.records|length == 3
 
-    - name: Create a record containing FQDN
+    - name: Create domain_record containing FQDN
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         name: 'fqdn.{{ domain_create.domain.domain }}'
@@ -156,12 +164,13 @@
         state: present
       register: record_fqdn_create
 
-    - assert:
+    - name: Assert domain_record is created containing FQDN
+      assert:
         that:
           - record_fqdn_create.record.name == 'fqdn'
           - record_fqdn_create.changed
 
-    - name: Create a record containing FQDN
+    - name: Create second domain_record containing FQDN
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         name: 'fqdn.{{ domain_create.domain.domain }}'
@@ -170,12 +179,13 @@
         state: present
       register: record_fqdn_nochange
 
-    - assert:
+    - name: Assert second domain_record is created containing FQDN
+      assert:
         that:
           - record_fqdn_nochange.record.name == 'fqdn'
           - record_fqdn_nochange.changed == False
 
-    - name: Delete a record containing FQDN
+    - name: Delete domain_record containing FQDN
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
         name: 'fqdn.{{ domain_create.domain.domain }}'
@@ -184,7 +194,8 @@
         state: absent
       register: record_fqdn_delete
 
-    - assert:
+    - name: Assert domain_record containing FQDN is deleted
+      assert:
         that:
           - record_fqdn_delete.record.name == 'fqdn'
           - record_fqdn_delete.changed
@@ -192,19 +203,20 @@
   always:
     - ignore_errors: yes
       block:
-        - name: Delete the record
+        - name: Delete domain_record
           linode.cloud.domain_record:            
             domain: '{{ domain_create.domain.domain }}'
             record_id: '{{ record_create.record.id }}'
             state: absent
           register: record_delete
 
-        - assert:
+        - name: Assert domain_record is deleted
+          assert:
             that:
               - record_delete.changed
               - record_delete.record.id == record_create.record.id
 
-        - name: Delete the second record
+        - name: Delete second domain_record
           linode.cloud.domain_record:            
             domain: '{{ domain_create.domain.domain }}'
             name: '{{ record2_create.record.name }}'
@@ -213,30 +225,33 @@
             state: absent
           register: record2_delete
 
-        - assert:
+        - name: Assert second domain_record is deleted
+          assert:
             that:
               - record2_delete.changed
               - record2_delete.record.id == record2_create.record.id
 
-        - name: Delete the duplicated record
+        - name: Delete duplicated domain_record
           linode.cloud.domain_record:            
             domain: '{{ domain_create.domain.domain }}'
             record_id: '{{ record_dupe_create.record.id }}'
             state: absent
           register: record_dupe_delete
 
-        - assert:
+        - name: Assert duplicated domain_record is deleted
+          assert:
             that:
               - record_dupe_delete.changed
               - record_dupe_delete.record.id == record_dupe_delete.record.id
 
-        - name: Delete the domain
+        - name: Delete domain
           linode.cloud.domain:            
             domain: '{{ domain_create.domain.domain }}'
             state: absent
           register: domain_delete
 
-        - assert:
+        - name: Assert domain is deleted
+          assert:
             that:
               - domain_delete.changed
               - domain_delete.domain.id == domain_create.domain.id

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -11,7 +11,8 @@
         state: present
       register: domain_create
 
-    - assert:
+    - name: Assert domain is created
+      assert:
         that:
           - domain_create.domain.soa_email == 'realemail@example.com'
           - domain_create.domain.status == 'active'
@@ -29,7 +30,7 @@
       register: record_create
 
     - name: Assert domain_record is created
-    - assert:
+      assert:
         that:
           - record_create.record.name == 'sub'
           - record_create.record.type == 'A'

--- a/tests/integration/targets/domain_zone_file/tasks/main.yaml
+++ b/tests/integration/targets/domain_zone_file/tasks/main.yaml
@@ -3,7 +3,7 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Create a domain
+    - name: Create domain
       linode.cloud.domain:
         description: 'really cool domain'
         domain: 'ansible-test-domain-{{ r }}.com'
@@ -22,7 +22,8 @@
       retries: 5
       delay: 10
 
-    - assert:
+    - name: Assert domain is created
+      assert:
         that:
           - create.domain.description == 'really cool domain'
           - create.domain.expire_sec == 300
@@ -34,7 +35,7 @@
           - create.domain.ttl_sec == 14400
           - create.domain.type == 'master'
 
-    - name: Get domain info
+    - name: Get domain_info
       linode.cloud.domain_info:
         domain: '{{ create.domain.domain }}'
       register: info
@@ -45,13 +46,14 @@
   always:
     - ignore_errors: yes
       block:
-        - name: Delete the domain
+        - name: Delete domain
           linode.cloud.domain:            
             domain: '{{ create.domain.domain }}'
             state: absent
           register: delete
 
-        - assert:
+        - name: Assert domain_info response
+          assert:
             that:
               - delete.changed
               - delete.domain.id == create.domain.id

--- a/tests/integration/targets/event_list/tasks/main.yaml
+++ b/tests/integration/targets/event_list/tasks/main.yaml
@@ -13,17 +13,18 @@
         state: present
       register: create_stackscript
 
-    - name: List the events for the current Linode Account
+    - name: List event_list for current Linode Account
       linode.cloud.event_list:
         count: 5
       register: no_filter
 
-    - assert:
+    - name: Assert event_list length for current Account
+      assert:
         that:
           # We can't ensure that the testing account will have 5 events
           - no_filter.events | length <= 5
 
-    - name: Resolve the StackScript event
+    - name: Get StackScript event in event_list
       linode.cloud.event_list:
         count: 1
         order_by: created
@@ -33,7 +34,8 @@
             values: stackscript_create
       register: filter
 
-    - assert:
+    - name: Assert StackScript event in event_list
+      assert:
         that:
           - filter.events | length == 1
           - filter.events[0].entity.id == create_stackscript.stackscript.id

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -2,7 +2,7 @@
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
-    - name: Create a Linode Instance
+    - name: Create a Linode instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
         region: us-ord
@@ -11,7 +11,7 @@
         state: present
       register: create_instance
 
-    - name: Create another Linode Instance
+    - name: Create another instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}-2'
         region: us-ord
@@ -20,7 +20,7 @@
         state: present
       register: create_instance_2
 
-    - name: Create a Linode Firewall
+    - name: Create Linode firewall
       linode.cloud.firewall:
         api_version: v4beta
         label: 'ansible-test-{{ r }}'
@@ -33,12 +33,12 @@
         state: present
       register: create
 
-    - name: Assert firewall created
+    - name: Assert firewall is created
       assert:
         that:
           - create.changed
 
-    - name: Update a Linode Firewall
+    - name: Update Linode firewall
       linode.cloud.firewall:
         api_version: v4beta
         label: '{{ create.firewall.label }}'
@@ -52,7 +52,7 @@
         state: present
       register: update
 
-    - name: Assert firewall updated
+    - name: Assert firewall is updated
       assert:
         that:
           - update.changed
@@ -74,7 +74,7 @@
         state: present
       register: update_devices
 
-    - name: Assert firewall devices updated
+    - name: Assert firewall devices are updated
       assert:
         that:
           - update_devices.changed
@@ -98,7 +98,7 @@
         state: present
       register: update_devices
 
-    - name: Assert firewall devices updated
+    - name: Assert firewall devices are updated
       assert:
         that:
           - update_devices.changed
@@ -122,7 +122,7 @@
         state: present
       register: update_devices_unchanged
 
-    - name: Assert firewall devices unchanged
+    - name: Assert firewall devices are unchanged
       assert:
         that:
           - update_devices_unchanged.changed == false
@@ -156,7 +156,7 @@
         state: present
       register: updaterules
 
-    - name: Assert firewall rules updated
+    - name: Assert firewall rules are updated
       assert:
         that:
           - updaterules.changed
@@ -206,7 +206,7 @@
         state: present
       register: updaterules_unchanged
 
-    - name: Assert firewall rules updated
+    - name: Assert firewall rules are updated
       assert:
         that:
           - updaterules_unchanged.changed == false
@@ -248,7 +248,7 @@
             state: absent
           register: delete
 
-        - name: Assert Firewall delete succeeded
+        - name: Assert Firewall is deleted
           assert:
             that:
               - delete.changed
@@ -260,7 +260,7 @@
             state: absent
           register: delete_instance
 
-        - name: Assert instance delete succeeded
+        - name: Assert instance is deleted
           assert:
             that:
               - delete_instance.changed
@@ -272,7 +272,7 @@
             state: absent
           register: delete_instance_2
 
-        - name: Assert instance delete succeeded
+        - name: Assert instance is deleted
           assert:
             that:
               - delete_instance_2.changed

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -77,23 +77,28 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.firewall_device:
+        - name: Delete firewall device in linode
+          linode.cloud.firewall_device:
             firewall_id: '{{ fw.firewall.id }}'
             entity_id: '{{ inst.instance.id }}'
             entity_type: 'linode'
             state: absent
-        - linode.cloud.firewall_device:
+        - name: Delete firewall device in nodebalancer
+          linode.cloud.firewall_device:
             firewall_id: '{{ fw.firewall.id }}'
             entity_id: '{{ nb.node_balancer.id }}'
             entity_type: 'nodebalancer'
             state: absent
-        - linode.cloud.nodebalancer:
+        - name: Delete nodebalancer
+          linode.cloud.nodebalancer:
             label: '{{ nb.node_balancer.label }}'
             state: absent
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ inst.instance.label }}'
             state: absent
-        - linode.cloud.firewall:
+        - name: Delete Firewall
+          linode.cloud.firewall:
             label: '{{ fw.firewall.label }}'
             state: absent
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -2,6 +2,7 @@
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
+
     - name: Create a Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
@@ -54,7 +55,8 @@
         state: present
       register: unchanged
 
-    - assert:
+    - name: Assert firewall is unchanged
+      assert:
         that:
           - unchanged.changed == False
 
@@ -68,7 +70,7 @@
             state: absent
           register: delete
 
-        - name: Assert Firewall delete succeeded
+        - name: Assert Firewall is deleted
           assert:
             that:
               - delete.changed
@@ -80,7 +82,7 @@
             state: absent
           register: delete_instance
 
-        - name: Assert instance delete succeeded
+        - name: Assert instance is deleted
           assert:
             that:
               - delete_instance.changed

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -39,7 +39,8 @@
             values: ansible-test-{{ r }}
       register: filter
 
-    - assert:
+    - name: Assert firewall_list with filter on label
+      assert:
         that:
           - filter.firewalls | length >= 1
           - filter.firewalls[0].label == 'ansible-test-{{ r }}'

--- a/tests/integration/targets/firewall_list/tasks/main.yaml
+++ b/tests/integration/targets/firewall_list/tasks/main.yaml
@@ -21,15 +21,16 @@
         that:
           - create.changed
 
-    - name: List firewalls with no filter
+    - name: List firewall_list with no filter
       linode.cloud.firewall_list:
       register: no_filter
 
-    - assert:
+    - name: Assert firewall_list with no filter
+      assert:
         that:
           - no_filter.firewalls | length >= 1
 
-    - name: List firewalls with filter on label
+    - name: List firewall_list with filter on label
       linode.cloud.firewall_list:
         order_by: created
         order: desc

--- a/tests/integration/targets/firewall_update/tasks/main.yaml
+++ b/tests/integration/targets/firewall_update/tasks/main.yaml
@@ -20,6 +20,7 @@
       assert:
         that:
           - create.changed
+
     - name: Set Linode Firewall with just IPv4
       linode.cloud.firewall:
         state: present

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -21,29 +21,32 @@
         state: present
       register: image_create
 
-    - assert:
+    - name: Assert image is created
+      assert:
         that:
           - image_create.image.status == 'available'
           - image_create.image.description == 'cool'
           - image_create.image.capabilities[0] == 'cloud-init'
 
-    - name: Get info about the image by ID
+    - name: Get image_info by ID
       linode.cloud.image_info:
         id: '{{ image_create.image.id }}'
       register: info_id
 
-    - assert:
+    - name: Assert image_info by ID
+      assert:
         that:
           - info_id.image.status == 'available'
           - info_id.image.description == 'cool'
           - info_id.image.id == image_create.image.id
 
-    - name: Get info about the image by label
+    - name: Get image_info by label
       linode.cloud.image_info:
         label: '{{ image_create.image.label }}'
       register: info_label
 
-    - assert:
+    - name: Assert image_info by label
+      assert:
         that:
           - info_label.image.status == 'available'
           - info_label.image.description == 'cool'
@@ -57,7 +60,8 @@
         state: present
       register: image_update
 
-    - assert:
+    - name: Assert image is updated
+      assert:
         that:
           - image_update.image.status == 'available'
           - image_update.image.description == 'cool2'
@@ -72,7 +76,8 @@
         state: present
       register: image_recreate
 
-    - assert:
+    - name: Assert image is overwritten
+      assert:
         that:
           - image_recreate.changed
           - image_recreate.image.id != image_create.image.id

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -86,11 +86,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.image:
+        - name:  Delete image
+          linode.cloud.image:
             label: '{{ image_create.image.label }}'
             state: absent
 
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -3,15 +3,17 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - linode.cloud.image_list:
+    - name: List image_list with no filter
+      linode.cloud.image_list:
         count: 5
       register: no_filter
 
-    - assert:
+    - name: Assert image_list with no filter
+      assert:
         that:
           - no_filter.images | length == 5
 
-    - name: Resolve an image
+    - name: List image_list with filter on label
       linode.cloud.image_list:
         count: 1
         order_by: created
@@ -21,19 +23,21 @@
             values: Alpine 3.19
       register: filter
 
-    - assert:
+    - name: Assert image_list with filter on label
+      assert:
         that:
           - filter.images | length == 1
           - filter.images[0].id == 'linode/alpine3.19'
 
-    - name: Resolve an empty list of images
+    - name: List image_list with empty filter
       linode.cloud.image_list:
         filters:
           - name: vendor
             values: DefinitelyRealVendor
       register: filter_empty
 
-    - assert:
+    - name: Assert image_list with empty filter
+      assert:
         that:
           - filter_empty.images | length == 0
 

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -32,7 +32,8 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.image:
+        - name: Delete image
+          linode.cloud.image:
             label: '{{ image_create.image.label }}'
             state: absent
 

--- a/tests/integration/targets/image_upload/tasks/main.yaml
+++ b/tests/integration/targets/image_upload/tasks/main.yaml
@@ -10,7 +10,8 @@
         suffix: .img.gz
       register: source_file
 
-    - copy:
+    - name: Copy temp file to destination
+      copy:
         dest: '{{ source_file.path }}'
         content: '{{ file_content | b64decode }}'
 
@@ -22,7 +23,8 @@
         state: present
       register: image_create
 
-    - assert:
+    - name: Assert image is created from image file
+      assert:
         that:
           - image_create.image.size == 1
           - image_create.image.status == 'available'

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -32,7 +32,8 @@
         state: present
       register: create
 
-    - assert:
+    - name: Assert instance is created with explicit disks and config
+      assert:
         that:
           - create.changed
           - create.disks[0].label == 'test-disk'
@@ -81,7 +82,8 @@
         state: present
       register: unchanged
 
-    - assert:
+    - name: Assert config is unchanged
+      assert:
         that:
           - unchanged.changed == False
 
@@ -110,7 +112,8 @@
         state: present
       register: update_config
 
-    - assert:
+    - name: Assert config is updated
+      assert:
         that:
           - update_config.changed
           - update_config.disks[0].label == 'test-disk'
@@ -132,7 +135,8 @@
         state: present
       register: resize
 
-    - assert:
+    - name: Assert config is deleted and disk is resized
+      assert:
         that:
           - resize.changed
           - resize.configs|length == 0
@@ -192,7 +196,8 @@
         state: present
       register: boot
 
-    - assert:
+    - name: Assert instance is booted with new config and disk
+      assert:
         that:
           - boot.changed
           - boot.instance.status == 'running'

--- a/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
@@ -10,7 +10,8 @@
         suffix: .img.gz
       register: source_file
 
-    - copy:
+    - name: Copy temporary image file to destination path
+      copy:
         dest: '{{ source_file.path }}'
         content: '{{ file_content | b64decode }}'
 
@@ -21,7 +22,8 @@
         state: present
       register: image_create
 
-    - assert:
+    - name: Assert private image is file is created from temporary image file
+      assert:
         that:
           - image_create.image.status == 'available'
 
@@ -52,7 +54,8 @@
         state: present
       register: instance_create
 
-    - assert:
+    - name: Assert instance is provisioned consuming the image
+      assert:
         that:
           - instance_create.changed
           - instance_create.disks | length == 2

--- a/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
@@ -63,11 +63,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
 
-        - linode.cloud.image:
+        - name: Delete image
+          linode.cloud.image:
             label: '{{ image_create.image.label }}'
             state: absent
 

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -57,7 +57,8 @@
         state: present
       register: update_instance
 
-    - assert:
+    - name: Assert instance is updated
+      assert:
         that:
           - update_instance.changed
           - update_instance.instance.ipv4|length == 1
@@ -89,7 +90,8 @@
         state: present
       register: unchanged_instance
 
-    - assert:
+    - name: Assert instance is unchanged
+      assert:
         that:
           - unchanged_instance.changed == False
 
@@ -102,7 +104,7 @@
             state: absent
           register: delete_instance
 
-        - name: Assert instance delete succeeded
+        - name: Assert instance is deleted
           assert:
             that:
               - delete_instance.changed

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -31,7 +31,8 @@
         state: present
       register: instance_create
 
-    - assert:
+    - name: Assert instance is created with explicit disk and stackscript
+      assert:
         that:
           - instance_create.changed
           - instance_create.disks[0].label == "test-disk"
@@ -52,21 +53,25 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: "{{ instance_create.instance.label }}"
             state: absent
           register: instance_delete
 
-        - assert:
+        - name: Assert instance is deleted
+          assert:
             that:
               - instance_delete.changed
 
+        - name: Delete stackscript
         - linode.cloud.stackscript:
             label: "{{ stackscript_create.stackscript.label }}"
             state: absent
           register: stackscript_delete
 
-        - assert:
+        - name: Assert stackscript is deleted
+          assert:
             that:
               - stackscript_delete.changed
 

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -65,7 +65,7 @@
               - instance_delete.changed
 
         - name: Delete stackscript
-        - linode.cloud.stackscript:
+          linode.cloud.stackscript:
             label: "{{ stackscript_create.stackscript.label }}"
             state: absent
           register: stackscript_delete

--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -113,7 +113,8 @@
         state: present
       register: unchanged_instance
 
-    - assert:
+    - name: Assert instance interface is unchanged
+      assert:
         that:
           - unchanged_instance.changed == False
 

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_filter.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_filter.yml
@@ -5,7 +5,8 @@
   tasks:
     - meta: refresh_inventory
 
-    - assert:
+    - name: Assert inventory
+      assert:
         that:
           - '"ansible-test-inventory" in hostvars'
           - hostvars | length == 1

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_templatetoken.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_templatetoken.yml
@@ -5,7 +5,8 @@
   tasks:
     - meta: refresh_inventory
 
-    - assert:
+    - name: Assert inventory
+      assert:
         that:
           - '"ansible-test-inventory" in hostvars'
           - hostvars | length == 1

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -21,11 +21,12 @@
           - create.instance.ipv4|length > 1
           - create.networking.ipv4.public[0].address != None
 
-    - name: List instances with no filter
+    - name: List instance_list with no filter
       linode.cloud.instance_list:
       register: no_filter
 
-    - assert:
+    - name: Assert instance_list with no filter
+      assert:
         that:
           - no_filter.instances | length >= 1
 
@@ -38,7 +39,8 @@
             values: us-ord
       register: filter
 
-    - assert:
+    - name: Assert instance_list with filter on region
+      assert:
         that:
           - filter.instances | length >= 1
           - filter.instances[0].region == 'us-ord'

--- a/tests/integration/targets/instance_region_migration/tasks/main.yaml
+++ b/tests/integration/targets/instance_region_migration/tasks/main.yaml
@@ -3,7 +3,8 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - linode.cloud.instance:
+    - name: Create instance
+      linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-nanode-1
@@ -11,12 +12,14 @@
         state: present
       register: create
 
-    - assert:
+    - name: Assert instance is created
+      assert:
         that:
           - create.changed
           - create.instance.region == "us-mia"
 
-    - linode.cloud.instance:
+    - name: Migrate instance (cold)
+      linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
         region: us-iad
         type: g6-nanode-1
@@ -25,7 +28,8 @@
         state: present
       register: migrated
 
-    - assert:
+    - name: Assert instance migrated (cold)
+      assert:
         that:
           - migrated.changed
           - migrated.instance.region == "us-iad"
@@ -33,12 +37,14 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ create.instance.label }}'
             state: absent
           register: delete
 
-        - assert:
+        - name: Assert instance is deleted
+          assert:
             that:
               - delete.changed
               - delete.instance.id == create.instance.id

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -18,7 +18,8 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.instance:
+        - name: Instance state is absent
+          linode.cloud.instance:
             label: 'ansible-test-{{ r }}'
             state: absent
 

--- a/tests/integration/targets/instance_type_change/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_change/tasks/main.yaml
@@ -3,7 +3,8 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - linode.cloud.instance:
+    - name: Create Linode instance
+      linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
         region: us-mia
         type: g6-nanode-1
@@ -11,12 +12,14 @@
         state: present
       register: create
 
-    - assert:
+    - name: Assert instance is created
+      assert:
         that:
           - create.changed
           - create.instance.type == "g6-nanode-1"
 
-    - linode.cloud.type_list:
+    - name: List type_list with filter on label
+      linode.cloud.type_list:
         filters:
           - name: label
             values: Linode 2GB
@@ -32,11 +35,12 @@
         state: present
       register: resize_disks
 
-    - assert:
+    - name: Assert instance is resized with resizing disks
+      assert:
         that:
           - resize_disks.changed
           - resize_disks.instance.type == "g6-standard-1"
-          - resize_disks.disks[0].size == type_info.types[0].disk - 512
+          - resize_disks.instance.specs.disk == type_info.types[0].disk
 
     - name: Run a warm resize without resizing disks
       linode.cloud.instance:
@@ -48,7 +52,8 @@
         state: present
       register: resize_disks
 
-    - assert:
+    - name: Assert warm resize without resizing disks
+      assert:
         that:
           - resize_disks.changed
           - resize_disks.instance.type == "g6-standard-2"
@@ -63,7 +68,8 @@
             state: absent
           register: delete
 
-        - assert:
+        - name: Asser instance is deleted
+          assert:
             that:
               - delete.changed
               - delete.instance.id == create.instance.id

--- a/tests/integration/targets/instance_type_change/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_change/tasks/main.yaml
@@ -63,12 +63,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ create.instance.label }}'
             state: absent
           register: delete
 
-        - name: Asser instance is deleted
+        - name: Assert instance is deleted
           assert:
             that:
               - delete.changed

--- a/tests/integration/targets/instance_type_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_list/tasks/main.yaml
@@ -1,10 +1,11 @@
 - name: instance_type_list
   block:
-    - name: List instance types with no filter
+    - name: List instance_type_list with no filter
       linode.cloud.instance_type_list:
       register: no_filter
 
-    - assert:
+    - name: Assert instance_type_list with no filter
+      assert:
         that:
           - no_filter.instance_types | length >= 1
 
@@ -15,7 +16,8 @@
             values: nanode
       register: filter
 
-    - assert:
+    - name: Assert instance_type_list with filter on class
+      assert:
         that:
           - filter.instance_types | length >= 1
           - filter.instance_types[0].class == 'nanode'

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -49,10 +49,12 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ create_instance.instance.label }}'
             state: absent
-        - linode.cloud.instance:
+        - name: Delete instance 2
+          linode.cloud.instance:
             label: '{{ create_instance_2.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -26,7 +26,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -13,12 +13,13 @@
         state: present
       register: instance_create
 
-    - name: Get info about the instance's primary IP
+    - name: Get ip_info about the instance's primary IP
       linode.cloud.ip_info:
         address: '{{ instance_create.instance.ipv4[0] }}'
       register: ip_info
 
-    - assert:
+    - name: Assert ip_info about instance's primary IP
+      assert:
         that:
           - ip_info.ip.address == instance_create.instance.ipv4[0]
 

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -44,7 +44,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -34,7 +34,8 @@
         address: '{{ instance_create.instance.ipv4[0] }}'
       register: ip_rdns_removed
 
-    - assert:
+    - name: Assert reverse DNS of IP is removed
+      assert:
         that:
           - ip_info.ip.address == instance_create.instance.ipv4[0]
           - ip_rdns_modified.ip.rdns == new_rdns

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -72,11 +72,11 @@
         linode_id: '{{ instance_create_shared.instance.id }}'
       register: ip_unshared
 
-    - name: Assert shared IPs configured.
-      set_fact:
+    - set_fact:
         ip_shared_address: "{{ instance_create.instance.ipv4[0] }}"
 
-    - assert:
+    - name: Assert shared IPs configured.
+      assert:
         that:
           - ip_shared.ips[0] == ip_shared_address
           - ip_already_shared.changed == false

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -85,10 +85,12 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
-        - linode.cloud.instance:
+        - name: Delete shared instance
+          linode.cloud.instance:
             label: '{{ instance_create_shared.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -24,12 +24,13 @@
         body_json: '{{ ipv6_body | to_json }}'
       register: range_create
 
-    - name: Get info about the IPv6 range
+    - name: Get ipv6_range_info about the IPv6 range
       linode.cloud.ipv6_range_info:
         range: '{{ range_create.body.range }}'
       register: range_info
 
-    - assert:
+    - name: Assert ipv6_range_info about IPv6 range
+      assert:
         that:
           - range_info.range.is_bgp == False
           - range_info.range.linodes[0] == instance_create.instance.id
@@ -40,11 +41,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.api_request:            
+        - name: Delete IPv6 range
+          linode.cloud.api_request:
             path: 'networking/ipv6/ranges/{{ range_create.body.range.split("/")[0] }}'
             method: DELETE
 
-        - linode.cloud.instance:            
+        - name: Assert IPv6 range is deleted
+          linode.cloud.instance:
             label: '{{ instance_create.instance.label }}'
             state: absent
 

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -34,7 +34,8 @@
         state: present
       register: create_cluster
 
-    - assert:
+    - name: Assert LKE cluster is created
+      assert:
         that:
           - create_cluster.cluster.k8s_version == old_kube_version
           - create_cluster.cluster.region == 'us-southeast'
@@ -60,7 +61,8 @@
         state: present
       register: update_pools
 
-    - assert:
+    - name: Assert cluster's node pools are updated
+      assert:
         that:
           - update_pools.cluster.k8s_version == old_kube_version
           - update_pools.cluster.region == 'us-southeast'
@@ -93,7 +95,8 @@
         state: present
       register: upgrade
 
-    - assert:
+    - name: Assert cluster is updated
+      assert:
         that:
           - upgrade.cluster.k8s_version == kube_version
           - upgrade.cluster.control_plane.high_availability == True
@@ -108,14 +111,15 @@
           - upgrade.node_pools[0].autoscaler.min == 1
           - upgrade.node_pools[0].autoscaler.max == 3
 
-    - name: Get info about the cluster by id
+    - name: Get lke_cluster_info about the cluster by id
       linode.cloud.lke_cluster_info:
         id: '{{ upgrade.cluster.id }}'
         
         
       register: info_by_id
 
-    - assert:
+    - name: Assert lke_cluster_info about cluster by id
+      assert:
         that:
           - info_by_id.cluster.k8s_version == kube_version
           - info_by_id.cluster.region == 'us-southeast'
@@ -126,12 +130,13 @@
           - info_by_id.node_pools[0].count == 1
           - info_by_id.node_pools[0].id == create_cluster.node_pools[0].id
 
-    - name: Get info about the cluster by label
+    - name: Get lke_cluster_info about the cluster by label
       linode.cloud.lke_cluster_info:
         label: '{{ upgrade.cluster.label }}'
       register: info_by_label
 
-    - assert:
+    - name: Assert lke_cluster_info about cluster by label
+      assert:
         that:
           - info_by_label.cluster.k8s_version == kube_version
           - info_by_label.cluster.region == 'us-southeast'

--- a/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_info_ro/tasks/main.yaml
@@ -29,7 +29,8 @@
         state: present
       register: create_cluster
 
-    - assert:
+    - name: Assert LKE cluster is created
+      assert:
         that:
           - create_cluster.cluster.k8s_version == kube_version
           - create_cluster.cluster.region == 'us-southeast'
@@ -43,7 +44,8 @@
         label: '{{ create_cluster.cluster.label }}'
       register: cluster_info
 
-    - assert:
+    - name: Assert lke_cluster_info with read-only token
+      assert:
         that:
           - cluster_info.cluster.k8s_version == kube_version
           - cluster_info.cluster.region == 'us-southeast'
@@ -54,11 +56,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.lke_cluster:            
+        - name: Delete lke_cluster
+          linode.cloud.lke_cluster:
             label: '{{ create_cluster.cluster.label }}'
             state: absent
 
-        - linode.cloud.token:            
+        - name: Delete token
+          linode.cloud.token:
             label: 'ansible-test-{{ r }}'
             state: absent
 

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -22,7 +22,8 @@
         state: present
       register: create_cluster
 
-    - assert:
+    - name: Assert minimal LKE cluster is created
+      assert:
         that:
           - create_cluster.cluster.k8s_version == kube_version
           - create_cluster.cluster.region == 'us-southeast'
@@ -39,7 +40,8 @@
         state: present
       register: new_pool
 
-    - assert:
+    - name: Assert node pool is added to cluster
+      assert:
         that:
           - new_pool.node_pool.count == 2
           - new_pool.node_pool.type == 'g6-standard-1'
@@ -72,7 +74,8 @@
         state: present
       register: update_pool
 
-    - assert:
+    - name: Assert node pool is updated
+      assert:
         that:
           - update_pool.node_pool.count == 1
           - update_pool.node_pool.type == 'g6-standard-1'

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -1,10 +1,11 @@
 - name: lke_version_list
   block:
-    - name: List lke versions with no filter
+    - name: List lke_version_list with no filter
       linode.cloud.lke_version_list:
       register: no_filter
 
-    - assert:
+    - name: Assert lke_version_list with no filter
+      assert:
         that:
           - no_filter.lke_versions | length >= 1
 

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -4,14 +4,15 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Get available mysql engines list
+    - name: Get available database_engine_list
       linode.cloud.database_engine_list:
         filters:
           - name: engine
             values: mysql
       register: available_engines
 
-    - assert:
+    - name: Assert available database_engine_list
+      assert:
         that:
           - available_engines.database_engines | length >= 1
 
@@ -30,7 +31,8 @@
         state: present
       register: db_create
 
-    - assert:
+    - name: Assert database is created
+      assert:
         that:
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
@@ -44,12 +46,13 @@
         id: '{{ db_create.database.id }}'
       register: by_id
 
-    - name: Get info about the database by label
+    - name: Get database_mysql_info by label
       linode.cloud.database_mysql_info:
         label: '{{ db_create.database.label }}'
       register: by_label
 
-    - assert:
+    - name: Assert database_mysql_info by label
+      assert:
         that:
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
@@ -82,7 +85,8 @@
         state: present
       register: db_update
 
-    - assert:
+    - name: Assert database is updated
+      assert:
         that:
           - db_update.database.allow_list | length == 1
           - db_update.database.allow_list[0] == '10.0.0.1/32'
@@ -92,7 +96,8 @@
       linode.cloud.database_list:
       register: all_dbs
 
-    - assert:
+    - name: Assert listing all databases
+      assert:
         that:
           - all_dbs.databases | length > 0
 

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -134,7 +134,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.database_mysql:
+        - name: Delete mysql db
+          linode.cloud.database_mysql:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -11,7 +11,8 @@
             values: mysql
       register: available_engines
 
-    - assert:
+    - name: Assert available mysql engines list
+      assert:
         that:
           - available_engines.database_engines | length >= 1
 
@@ -52,7 +53,8 @@
         state: present
       register: db_create
 
-    - assert:
+    - name: Assert database is created
+      assert:
         that:
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
@@ -76,7 +78,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.database_mysql:
+        - name: Delete mysql database
+          linode.cloud.database_mysql:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -48,7 +48,8 @@
             algorithm: roundrobin
       register: create_config
 
-    - assert:
+    - name: Assert nb config is added
+      assert:
         that:
           - create_config.configs|length == 1
           - create_config.configs[0].port == 80
@@ -66,7 +67,8 @@
             check_timeout: 1
       register: update_config
 
-    - assert:
+    - name: Assert nb config is updated
+      assert:
         that:
           - update_config.configs|length == 1
           - update_config.configs[0].check_timeout == 1
@@ -87,7 +89,8 @@
             recreate: true
       register: recreate_config
 
-    - assert:
+    - name: Assert nb config is recreated
+      assert:
         that:
           - recreate_config.changed
           - update_config.configs|length == 1

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -20,7 +20,8 @@
       linode.cloud.nodebalancer_list:
       register: no_filter
 
-    - assert:
+    - name: Assert nodebalancer_list with no filter
+      assert:
         that:
           - no_filter.nodebalancers | length >= 1
 
@@ -33,7 +34,8 @@
             values: us-ord
       register: filter
 
-    - assert:
+    - name: Assert nodebalancer_list with filter on region
+      assert:
         that:
           - filter.nodebalancers | length >= 1
           - filter.nodebalancers[0].region == 'us-ord'

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -3,7 +3,8 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - linode.cloud.nodebalancer:
+    - name: Create nodebalancer with basic configs
+      linode.cloud.nodebalancer:
         label: 'ansible-nb-{{ r }}'
         region: us-ord
         state: present
@@ -22,7 +23,8 @@
             stickiness: none
       register: nb
 
-    - linode.cloud.instance:
+    - name: Assert nodebalancer is created with basic configs
+      linode.cloud.instance:
         label: 'ansible-node-{{ r }}'
         region: '{{ nb.node_balancer.region }}'
         private_ip: true
@@ -30,7 +32,8 @@
         state: present
       register: inst
 
-    - linode.cloud.nodebalancer_node:
+    - name: Create nodebalancer_node
+      linode.cloud.nodebalancer_node:
         nodebalancer_id: '{{ nb.node_balancer.id }}'
         config_id: '{{ nb.configs[0].id }}'
 
@@ -45,7 +48,8 @@
     - set_fact:
         inst_ipv4_address: "{{ inst.instance.ipv4[1] }}:80"
 
-    - assert:
+    - name: Assert nb node config
+      assert:
         that:
           - nb_node.changed
           - nb_node.node.label == 'cool'
@@ -53,7 +57,8 @@
           - nb_node.node.mode == 'accept'
           - nb_node.node.weight == 10
 
-    - linode.cloud.nodebalancer_node:
+    - name: Update nodebalancer node config
+      linode.cloud.nodebalancer_node:
         nodebalancer_id: '{{ nb.node_balancer.id }}'
         config_id: '{{ nb.configs[0].id }}'
 
@@ -65,7 +70,8 @@
         state: present
       register: nb_node_update
 
-    - assert:
+    - name: Assert nb node config is updated
+      assert:
         that:
           - nb_node_update.changed
           - nb_node_update.node.label == 'cool'
@@ -96,11 +102,13 @@
     - debug:
         var: nb_update
 
-    - linode.cloud.nodebalancer_info:
+    - name: Get nodebalancer_info
+      linode.cloud.nodebalancer_info:
         label: 'ansible-nb-{{ r }}'
       register: nb_info
 
-    - assert:
+    - name: Assert nb config
+      assert:
         that:
           - nb_update.changed == False
           - nb_update.nodes[0].id == nb_node.node.id
@@ -109,18 +117,21 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.nodebalancer_node:
+        - name: Delete nodebalancer node
+          linode.cloud.nodebalancer_node:
             nodebalancer_id: '{{ nb.node_balancer.id }}'
             config_id: '{{ nb.configs[0].id }}'
             label: '{{ nb_node.node.label }}'
 
             state: absent
 
-        - linode.cloud.instance:
+        - name: Delete instance
+          linode.cloud.instance:
             label: '{{ inst.instance.label }}'
             state: absent
 
-        - linode.cloud.nodebalancer:
+        - name: Delete nodebalancer
+          linode.cloud.nodebalancer:
             label: '{{ nb.node_balancer.label }}'
             state: absent
 

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -11,7 +11,8 @@
             values: postgresql
       register: available_engines
 
-    - assert:
+    - name: Assert postgresql database_engine_list
+      assert:
         that:
           - available_engines.database_engines | length >= 1
 
@@ -30,7 +31,8 @@
         state: present
       register: db_create
 
-    - assert:
+    - name: Assert database_postgresql is created
+      assert:
         that:
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
@@ -49,7 +51,8 @@
         label: '{{ db_create.database.label }}'
       register: by_label
 
-    - assert:
+    - name: Assert database_postgresql_info
+      assert:
         that:
           - by_label.database.allow_list | length == 1
           - by_label.database.allow_list[0] == '0.0.0.0/0'
@@ -75,7 +78,8 @@
         state: present
       register: db_update
 
-    - assert:
+    - name: Assert postgres database is updated
+      assert:
         that:
           - db_update.database.allow_list | length == 1
           - db_update.database.allow_list[0] == '10.0.0.1/32'
@@ -96,7 +100,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.database_postgresql:
+        - name: Delete postgres db
+          linode.cloud.database_postgresql:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -11,7 +11,8 @@
             values: postgresql
       register: available_engines
 
-    - assert:
+    - name: Assert database_engine_list for postgresql
+      assert:
         that:
           - available_engines.database_engines | length >= 1
 
@@ -53,7 +54,8 @@
         state: present
       register: db_create
 
-    - assert:
+    - name: Assert postgres db is created
+      assert:
         that:
           - db_create.database.allow_list | length == 1
           - db_create.database.allow_list[0] == '0.0.0.0/0'
@@ -78,7 +80,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.database_postgresql:
+        - name: Delete postgres db
+          linode.cloud.database_postgresql:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/profile_info/tasks/main.yaml
+++ b/tests/integration/targets/profile_info/tasks/main.yaml
@@ -1,10 +1,11 @@
 - name: account_info
   block:
-    - name: Get info about the current profile
+    - name: Get profile_info about current profile
       linode.cloud.profile_info:
       register: profile
 
-    - assert:
+    - name: Assert profile_info about current profile
+      assert:
         that:
           - profile.profile.email | length > 0
 

--- a/tests/integration/targets/region_list/tasks/main.yaml
+++ b/tests/integration/targets/region_list/tasks/main.yaml
@@ -4,7 +4,8 @@
       linode.cloud.region_list:
       register: no_filter
 
-    - assert:
+    - name: Assert region_list with no filter
+      assert:
         that:
           - no_filter.regions | length >= 0
 
@@ -15,7 +16,8 @@
             values: us
       register: filter_us
 
-    - assert:
+    - name: Assert region_list with filter on country
+      assert:
         that:
           - filter_us.regions | length >= 0
           - filter_us.regions[0].country == 'us'
@@ -27,7 +29,8 @@
             values: core
       register: filter_core_site
 
-    - assert:
+    - name:  Assert region_list with filter on site type
+      assert:
         that:
           - filter_core_site.regions | length >= 0
           - filter_core_site.regions[0].site_type == 'core'

--- a/tests/integration/targets/ssh_key/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key/tasks/main.yaml
@@ -4,7 +4,8 @@
         r: "{{ 1000000000 | random }}"
         ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCloBr83q7v2/kipfpChnN1cPr+DA++JN3RdLBid3tFjy5UmAelpRmKO9Uhija7ElC9/x187t13smc35NGaDOG+s+zrSMlSfygqA6pf8njEPDRBhvyp12Fjwb8i+ILFXiU1GYaVprbQwpgdApwqieoCZ4pathc/HdPvznX/Aqgyiq+5+dSRa5GUftAPWrt3ScFXttlfihU+0wIanyxoxnrtPcqNshs39dRg8UP2zrB5aK+9nPurO/6qSWDqVnIVlparlqXxZdwKl+Gfiq93pGicrPgVEy49Tbl75Y8Nxj7zDsJsQuO0UlRk9IUoe1asAy5DXqQ6foOb6vR9rld6owqRHCG/tjYDpuw1uYCYj5xm+DDfkNRowWJktIgnajzaYqZ3ytWzg31m8a7X2Wol8foxlFrUqqqesJ05I28A3JvLIU5s4vSzi1hK4cWKSi15UFdxX1f1a+pRsRgY446k+i3uWcFZVybzp5tDRdjUMRO6XQrbjrxFnKurRY0+S1NeRF0="
 
-    - linode.cloud.ssh_key:
+    - name: Upload ssh key
+      linode.cloud.ssh_key:
         api_token: "{{ api_token }}"
         ua_prefix: "{{ ua_prefix }}"
 
@@ -20,7 +21,8 @@
         id: "{{ create_ssh_key.ssh_key.id }}"
       register: by_id
 
-    - assert:
+    - name: Assert ssh_key_info by ID
+      assert:
         that:
           - create_ssh_key.ssh_key.label == "test-key-{{ r }}"
           - create_ssh_key.ssh_key.ssh_key == "{{ ssh_pub_key }}"

--- a/tests/integration/targets/ssh_key_info/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_info/tasks/main.yaml
@@ -4,7 +4,8 @@
         r: "{{ 1000000000 | random }}"
         ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCloBr83q7v2/kipfpChnN1cPr+DA++JN3RdLBid3tFjy5UmAelpRmKO9Uhija7ElC9/x187t13smc35NGaDOG+s+zrSMlSfygqA6pf8njEPDRBhvyp12Fjwb8i+ILFXiU1GYaVprbQwpgdApwqieoCZ4pathc/HdPvznX/Aqgyiq+5+dSRa5GUftAPWrt3ScFXttlfihU+0wIanyxoxnrtPcqNshs39dRg8UP2zrB5aK+9nPurO/6qSWDqVnIVlparlqXxZdwKl+Gfiq93pGicrPgVEy49Tbl75Y8Nxj7zDsJsQuO0UlRk9IUoe1asAy5DXqQ6foOb6vR9rld6owqRHCG/tjYDpuw1uYCYj5xm+DDfkNRowWJktIgnajzaYqZ3ytWzg31m8a7X2Wol8foxlFrUqqqesJ05I28A3JvLIU5s4vSzi1hK4cWKSi15UFdxX1f1a+pRsRgY446k+i3uWcFZVybzp5tDRdjUMRO6XQrbjrxFnKurRY0+S1NeRF0="
 
-    - linode.cloud.api_request:
+    - name: Upload ssh pub key
+      linode.cloud.api_request:
         path: profile/sshkeys
         method: POST
         body:
@@ -17,12 +18,13 @@
         id: "{{ create_ssh_key.body.id }}"
       register: by_id
 
-    - name: Get info about the SSH key by label
+    - name: Get ssh_key_info by label
       linode.cloud.ssh_key_info:
         label: "{{ create_ssh_key.body.label }}"
       register: by_label
 
-    - assert:
+    - name: Assert ssh_key_info by label
+      assert:
         that:
           - by_id.ssh_key.id == create_ssh_key.body.id
           - by_id.ssh_key.ssh_key == create_ssh_key.body.ssh_key
@@ -34,8 +36,8 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.api_request:
-
+        - name: Delete ssh key
+          linode.cloud.api_request:
             path: "profile/sshkeys/{{ create_ssh_key.body.id }}"
             method: DELETE
 

--- a/tests/integration/targets/ssh_key_list/tasks/main.yaml
+++ b/tests/integration/targets/ssh_key_list/tasks/main.yaml
@@ -4,7 +4,8 @@
         r: "{{ 1000000000 | random }}"
         ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCloBr83q7v2/kipfpChnN1cPr+DA++JN3RdLBid3tFjy5UmAelpRmKO9Uhija7ElC9/x187t13smc35NGaDOG+s+zrSMlSfygqA6pf8njEPDRBhvyp12Fjwb8i+ILFXiU1GYaVprbQwpgdApwqieoCZ4pathc/HdPvznX/Aqgyiq+5+dSRa5GUftAPWrt3ScFXttlfihU+0wIanyxoxnrtPcqNshs39dRg8UP2zrB5aK+9nPurO/6qSWDqVnIVlparlqXxZdwKl+Gfiq93pGicrPgVEy49Tbl75Y8Nxj7zDsJsQuO0UlRk9IUoe1asAy5DXqQ6foOb6vR9rld6owqRHCG/tjYDpuw1uYCYj5xm+DDfkNRowWJktIgnajzaYqZ3ytWzg31m8a7X2Wol8foxlFrUqqqesJ05I28A3JvLIU5s4vSzi1hK4cWKSi15UFdxX1f1a+pRsRgY446k+i3uWcFZVybzp5tDRdjUMRO6XQrbjrxFnKurRY0+S1NeRF0="
 
-    - linode.cloud.api_request:
+    - name: Uplooad ssh pub key
+      linode.cloud.api_request:
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
 
@@ -14,8 +15,9 @@
           ssh_key: "{{ ssh_pub_key }}"
           label: "test-key-1-{{ r }}"
       register: create_ssh_key1
-    
-    - linode.cloud.api_request:
+
+    - name: Uplooad ssh pub key 2
+      linode.cloud.api_request:
         api_token: '{{ api_token }}'
         ua_prefix: '{{ ua_prefix }}'
 
@@ -58,7 +60,8 @@
         count: 1
       register: key_list_random
 
-    - assert:
+    - name: Assert ssh_key_list for current account
+      assert:
         that:
           - key_list_1.ssh_keys | length == 1
           - key_list_12.ssh_keys | length == 2
@@ -67,12 +70,14 @@
   always:
     - ignore_errors: true
       block:
-        - linode.cloud.api_request:
+        - name: Delete SSH key 1
+          linode.cloud.api_request:
             api_token: '{{ api_token }}'
             ua_prefix: '{{ ua_prefix }}'
             path: "profile/sshkeys/{{ create_ssh_key1.body.id }}"
             method: DELETE
-        - linode.cloud.api_request:
+        - name: Delete SSH key 2
+          linode.cloud.api_request:
             api_token: '{{ api_token }}'
             ua_prefix: '{{ ua_prefix }}'
             path: "profile/sshkeys/{{ create_ssh_key2.body.id }}"

--- a/tests/integration/targets/stackscript_basic/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_basic/tasks/main.yaml
@@ -21,7 +21,8 @@
         state: present
       register: create_stackscript
 
-    - assert:
+    - name: Assert basic stackscript is created
+      assert:
         that:
           - create_stackscript.stackscript.id != None
           - create_stackscript.stackscript.rev_note == ''
@@ -41,7 +42,8 @@
         state: present
       register: update_stackscript
 
-    - assert:
+    - name: Assert stackscript is updated
+      assert:
         that:
           - update_stackscript.stackscript.id != None
           - update_stackscript.stackscript.rev_note == 'cool'
@@ -51,7 +53,8 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.stackscript:
+        - name: Delete stackscript
+          linode.cloud.stackscript:
             label: '{{ create_stackscript.stackscript.label }}'
             state: absent
 

--- a/tests/integration/targets/stackscript_info/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_info/tasks/main.yaml
@@ -14,7 +14,8 @@
         state: present
       register: create_stackscript
 
-    - assert:
+    - name: Assert stackscript is created
+      assert:
         that:
           - create_stackscript.stackscript.id != None
           - create_stackscript.stackscript.rev_note == ''
@@ -31,7 +32,8 @@
         label: '{{ create_stackscript.stackscript.label }}'
       register: by_label
 
-    - assert:
+    - name: Assert stackscript_info by label
+      assert:
         that:
           - by_id.stackscript.id != None
           - by_id.stackscript.rev_note == ''
@@ -45,7 +47,8 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.stackscript:
+        - name: Delete stackscript
+          linode.cloud.stackscript:
             label: '{{ create_stackscript.stackscript.label }}'
             state: absent
 

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -22,7 +22,8 @@
             values: '{{ create_stackscript.stackscript.label }}'
       register: stack_list
 
-    - assert:
+    - name: Assert stackscript_list with filter on Label
+      assert:
         that:
           - stack_list.stackscripts | length == 1
           - stack_list.stackscripts[0].id != None
@@ -33,6 +34,7 @@
   always:
     - ignore_errors: yes
       block:
+        - name: Delete stackscript
         - linode.cloud.stackscript:
             label: '{{ create_stackscript.stackscript.label }}'
             state: absent

--- a/tests/integration/targets/stackscript_list/tasks/main.yaml
+++ b/tests/integration/targets/stackscript_list/tasks/main.yaml
@@ -35,7 +35,7 @@
     - ignore_errors: yes
       block:
         - name: Delete stackscript
-        - linode.cloud.stackscript:
+          linode.cloud.stackscript:
             label: '{{ create_stackscript.stackscript.label }}'
             state: absent
 

--- a/tests/integration/targets/token_info/tasks/main.yaml
+++ b/tests/integration/targets/token_info/tasks/main.yaml
@@ -26,7 +26,8 @@
         id: '{{ create_token.token.id }}'
       register: by_id
 
-    - assert:
+    - name: Assert token_info by ID
+      assert:
         that:
           - by_label.token.label == create_token.token.label
           - by_id.token.label == create_token.token.label

--- a/tests/integration/targets/token_list/tasks/main.yaml
+++ b/tests/integration/targets/token_list/tasks/main.yaml
@@ -23,7 +23,8 @@
       linode.cloud.token_list:
       register: no_filter
 
-    - assert:
+    - name: Assert token_list with no filter
+      assert:
         that:
           - no_filter.tokens | length >= 1
 
@@ -36,7 +37,8 @@
             values: ansible-test-{{ r }}
       register: filter
 
-    - assert:
+    - name: Assert token_list with filter on label
+      assert:
         that:
           - filter.tokens | length >= 1
           - filter.tokens[0].label == 'ansible-test-{{ r }}'

--- a/tests/integration/targets/type_info/tasks/main.yaml
+++ b/tests/integration/targets/type_info/tasks/main.yaml
@@ -8,7 +8,8 @@
         id: g6-standard-2
       register: type_info
 
-    - assert:
+    - name: Assert type_info by ID
+      assert:
         that:
           - type_info.type.class == "standard"
 

--- a/tests/integration/targets/type_list/tasks/main.yaml
+++ b/tests/integration/targets/type_list/tasks/main.yaml
@@ -11,7 +11,8 @@
             values: Nanode 1GB
       register: filter
 
-    - assert:
+    - name: Assert type_list by Linode type
+      assert:
         that:
           - filter.types | length == 1
           - filter.types[0].label == 'Nanode 1GB'

--- a/tests/integration/targets/user_grants/tasks/main.yaml
+++ b/tests/integration/targets/user_grants/tasks/main.yaml
@@ -76,11 +76,13 @@
   always:
     - ignore_errors: yes
       block:
-        - linode.cloud.user:
+        - name: Delete user
+          linode.cloud.user:
             username: '{{ create_user.user.username }}'
             state: absent
 
-        - linode.cloud.domain:
+        - name: Delete domain
+          linode.cloud.domain:
             domain: '{{ create_domain.domain.domain }}'
             state: absent
 

--- a/tests/integration/targets/user_list/tasks/main.yaml
+++ b/tests/integration/targets/user_list/tasks/main.yaml
@@ -20,7 +20,8 @@
       linode.cloud.user_list:
       register: no_filter
 
-    - assert:
+    - name: Assert user_list with no filter
+      assert:
         that:
           - no_filter.users | length >= 1
 

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -28,7 +28,8 @@
             values: really-cool-vlan
       register: filter
 
-    - assert:
+    - name: Assert vlan_list with filter on label
+      assert:
         that:
           - filter.vlans | length == 1
           - filter.vlans[0].label == 'really-cool-vlan'

--- a/tests/integration/targets/volume_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_list/tasks/main.yaml
@@ -21,7 +21,8 @@
       linode.cloud.volume_list:
       register: no_filter
 
-    - assert:
+    - name: Assert volume_list with no filter
+      assert:
         that:
           - no_filter.volumes | length >= 1
 
@@ -33,8 +34,9 @@
           - name: region
             values: us-ord
       register: filter
-    
-    - assert:
+
+    - name: Assert volume_list with filter on region
+      assert:
         that:
           - filter.volumes | length >= 1
           - filter.volumes[0].region == 'us-ord'


### PR DESCRIPTION
Refactoring all integration tests:
- for better consistency in defining name in each steps in the suite
e.g. `- assert` and `linode.cloud.method` steps without names defined are all updated with proper value
- fix intermittent test on disk resize test (instance_type_resize)


## 📝 Description

**What does this PR do and why is this change necessary?**

## ✔️ How to Test

To test fix for intermittent failure:
`make TEST_ARGS="-v instance_type_change" test `

`make test` to test locally but will post a green build on GHA


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**