### PR TITLE
new: Add handling to update logic for unordered lists; use update helper in NB & Instance modules

### DIFF
--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -48,6 +48,7 @@ Manage a Linode NodeBalancer.
 | `client_conn_throttle` | <center>`int`</center> | <center>Optional</center> | Throttle connections per second. Set to 0 (zero) to disable throttling.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | The ID of the Region to create this NodeBalancer in.   |
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of the Firewall to assign this NodeBalancer to.   |
+| `tags` | <center>`list`</center> | <center>Optional</center> | Tags to assign to this NodeBalancer.  **(Updatable)** |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 
 ### configs

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1176,7 +1176,7 @@ class LinodeInstance(LinodeModuleBase):
 
         params = filter_null_values(self.module.params)
 
-        params = {
+        update_params = {
             k: v
             for k, v in params.items()
             if k
@@ -1192,7 +1192,7 @@ class LinodeInstance(LinodeModuleBase):
         }
 
         handle_updates(
-            self._instance, params, MUTABLE_FIELDS, self.register_action
+            self._instance, update_params, MUTABLE_FIELDS, self.register_action
         )
 
         backups_enabled = params.get("backups_enabled")

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -23,6 +23,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     drop_empty_strings,
     filter_null_values,
     filter_null_values_recursive,
+    handle_updates,
     paginated_list_to_json,
     parse_linode_types,
     poll_condition,
@@ -538,7 +539,7 @@ SPECDOC_META = SpecDocMeta(
 )
 
 # Fields that can be updated on an existing instance
-linode_instance_mutable = {"group", "tags"}
+MUTABLE_FIELDS = {"group", "tags"}
 
 linode_instance_config_mutable = {
     "comments",
@@ -1172,15 +1173,14 @@ class LinodeInstance(LinodeModuleBase):
 
     def _update_instance(self) -> None:
         """Update instance handles all update functionality for the current instance"""
-        should_update = False
 
         params = filter_null_values(self.module.params)
 
-        for key, new_value in params.items():
-            if not hasattr(self._instance, key):
-                continue
-
-            if key in (
+        params = {
+            k: v
+            for k, v in params.items()
+            if k
+            not in (
                 "configs",
                 "disks",
                 "boot_config_label",
@@ -1188,31 +1188,12 @@ class LinodeInstance(LinodeModuleBase):
                 "backups_enabled",
                 "type",
                 "region",
-            ):
-                continue
+            )
+        }
 
-            old_value = parse_linode_types(getattr(self._instance, key))
-
-            if new_value != old_value:
-                if key in linode_instance_mutable:
-                    setattr(self._instance, key, new_value)
-                    self.register_action(
-                        'Updated instance {0}: "{1}" -> "{2}"'.format(
-                            key, old_value, new_value
-                        )
-                    )
-
-                    should_update = True
-                    continue
-
-                self.fail(
-                    "failed to update instance {0}: {1} is a non-updatable field".format(
-                        self._instance.label, key
-                    )
-                )
-
-        if should_update:
-            self._instance.save()
+        handle_updates(
+            self._instance, params, MUTABLE_FIELDS, self.register_action
+        )
 
         backups_enabled = params.get("backups_enabled")
         if (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-linode-api4>=5.13.1
+# TODO: Blocked by SDK release; revert before merging to dev
+# linode-api4>=5.13.1
+git+https://github.com/linode/linode_api4-python@dev
+
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-# TODO: Blocked by SDK release; revert before merging to dev
-# linode-api4>=5.13.1
-git+https://github.com/linode/linode_api4-python@dev
-
+linode-api4>=5.15.0
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/nodebalancer_reordered_tags/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_reordered_tags/tasks/main.yaml
@@ -1,0 +1,77 @@
+- name: nodebalancer_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a NodeBalancer with tags
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        tags:
+          - test1
+          - test2
+          - test3
+        state: present
+      register: create_nodebalancer
+
+    - name: Assert NodeBalancer is created
+      assert:
+        that:
+          - create_nodebalancer.changed
+          - create_nodebalancer.node_balancer.tags|length == 3
+
+    - name: Reorder the NodeBalancer's tags
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        tags:
+          - test3
+          - test1
+          - test2
+        state: present
+      register: reorder_nodebalancer_tags
+
+    - name: Assert NodeBalancer is not updated
+      assert:
+        that:
+          - not reorder_nodebalancer_tags.changed
+
+    - name: Update the NodeBalancer's tags
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        tags:
+          - test1
+          - test4
+          - test5
+          - test6
+        state: present
+      register: update_nodebalancer_tags
+
+    - name: Assert NodeBalancer is updated
+      assert:
+        that:
+          - update_nodebalancer_tags.changed
+          - update_nodebalancer_tags.node_balancer.tags | length == 4
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the  NodeBalancer
+          linode.cloud.nodebalancer:
+            label: '{{ create_nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_nodebalancer
+
+        - name: Assert NodeBalancer delete
+          assert:
+            that:
+              - delete_nodebalancer.changed
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+


### PR DESCRIPTION
## 📝 Description

This pull request adds logic to the `handle_updates` helper function to respect lists annotated as unordered during the diffing process. This ensures unordered fields like `tags` will not trigger infinite diffs with equivalent values.

Additionally, this PR moves the basic update logic in the `instance` and `nodebalancer` modules over to the `handle_updates` helper. These are NOT the only modules that can be moved over to the helper but I figure we can do that work in a separate PR to keep this PR tightly scoped. (I added an entry for this in the internal feedback tracker)

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally. 
Additionally you will need to run `pip install --force -r requirements.txt` in order to install from the `dev` branch of the Python SDK.

### Integration Testing

```
make test TEST_ARGS="-v nodebalancer_reordered_tags"
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook in verbose (-v) mode:

```yaml
- name: test
  hosts: localhost
  tasks:
    - set_fact:
        r: "{{ 1000000000 | random }}"

    - name: Create a NodeBalancer with tags
      linode.cloud.nodebalancer:
        label: 'ansible-test-{{ r }}'
        region: us-ord
        tags:
          - test1
          - test2
          - test3
        state: present
      register: create_nodebalancer

    - name: Reorder the NodeBalancer's tags
      linode.cloud.nodebalancer:
        label: 'ansible-test-{{ r }}'
        region: us-ord
        tags:
          - test3
          - test1
          - test2
        state: present
      register: reorder_nodebalancer_tags

    - name: Update the NodeBalancer's tags
      linode.cloud.nodebalancer:
        label: 'ansible-test-{{ r }}'
        region: us-ord
        tags:
          - test1
          - test4
          - test5
          - test6
        state: present
      register: update_nodebalancer_tags
```

2. Ensure the playbook runs without any errors.
3. Ensure the `Reorder the NodeBalancer's tags` task is marked as unchanged (green).
4. Ensure the `Update the NodeBalancer's tags` task is marked as changed (yellow) and reflects the diff in the `actions` field.