### PR TITLE
Add `networking_info` attribute to inventory instances

### DIFF
--- a/plugins/inventory/instance.py
+++ b/plugins/inventory/instance.py
@@ -19,7 +19,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
 )
 from linode_api4.objects import Instance
 
-DOCUMENTATION = r"""
+DOCUMENTATION = """
     name: instance
     author:
       - Luke Murphy (@decentral1se)
@@ -59,7 +59,7 @@ DOCUMENTATION = r"""
           type: list
 """
 
-EXAMPLES = r"""
+EXAMPLES = """
 # Minimal example. `LINODE_API_TOKEN` is exposed in environment.
 plugin: linode.cloud.instance
 
@@ -209,7 +209,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def _add_hostvars_for_instances(self) -> None:
         """Add hostvars for instances in the dynamic inventory."""
         for instance in self.instances:
-            hostvars = instance._raw_json
+            hostvars = {}
+            hostvars.update(instance._raw_json)
+            hostvars["networking_info"] = instance.ips.dict
+
             for hostvar_key in hostvars:
                 self.inventory.set_variable(
                     instance.label, hostvar_key, hostvars[hostvar_key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linode-api4>=5.15.0
+linode-api4>=5.15.1
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-linode-api4>=5.13.1
+# TODO: Blocked by SDK release; revert before merging to dev
+# linode-api4>=5.13.1
+git+https://github.com/linode/linode_api4-python@dev
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# TODO: Blocked by SDK release; revert before merging to dev
-# linode-api4>=5.13.1
-git+https://github.com/linode/linode_api4-python@dev
+linode-api4>=5.15.0
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/instance_inventory/playbooks/test_inventory_filter.yml
+++ b/tests/integration/targets/instance_inventory/playbooks/test_inventory_filter.yml
@@ -10,3 +10,6 @@
         that:
           - '"ansible-test-inventory" in hostvars'
           - hostvars | length == 1
+          - '"networking_info" in hostvars["ansible-test-inventory"]'
+          - '"ipv4" in hostvars["ansible-test-inventory"]["networking_info"]'
+          - '"ipv6" in hostvars["ansible-test-inventory"]["networking_info"]'


### PR DESCRIPTION
## 📝 Description

closes #451

This is to add `networking_info` with data received from the [Networking Information List API](https://www.linode.com/docs/api/linode-instances/#networking-information-list) to instances in the dynamic inventory.

## ✔️ How to Test

### Automated Testing

**Automated testing doesn't work on macOS**, and you may want to test it in a Linode.

```bash
ansible-test integration -v instance_inventory
```

### Manual Testing

- `make install`
- Create a dynamic inventory file called `myinstance.linode.yaml` with the content below.

```yaml
plugin: linode.cloud.instance
```

- Create a Linode instance.
- Execute `ansible-inventory --list -i /path/to/myinstance.linode.yaml -v` and verify `networking_info` attribute is in the output Linode instances.