### PR TITLE
new: Add support to `available` field to account_availability info and list module

### DIFF
--- a/docs/modules/account_availability_info.md
+++ b/docs/modules/account_availability_info.md
@@ -40,6 +40,7 @@ Get info about a Linode Account Availability.
         
         {
           "region": "us-east",
+          "available": ["NodeBalancers", "Block Storage", "Kubernetes"],
           "unavailable": ["Linode"]
         }
         

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -48,10 +48,12 @@ List and filter on Account Availabilitys.
         [
             {
               "region": "ap-west",
+              "available": ["NodeBalancers", "Block Storage", "Kubernetes"],
               "unavailable": ["Linode"]
             },
             {
               "region": "ca-central",
+              "available": ["NodeBalancers", "Kubernetes"],
               "unavailable": ["Linode", "Block Storage"]
             }
         ]

--- a/plugins/module_utils/doc_fragments/account_availability_info.py
+++ b/plugins/module_utils/doc_fragments/account_availability_info.py
@@ -3,6 +3,7 @@
 result_account_availability_samples = ['''
 {
   "region": "us-east",
+  "available": ["NodeBalancers", "Block Storage", "Kubernetes"],
   "unavailable": ["Linode"]
 }
 ''']

--- a/plugins/module_utils/doc_fragments/account_availability_list.py
+++ b/plugins/module_utils/doc_fragments/account_availability_list.py
@@ -8,10 +8,12 @@ specdoc_examples = ['''
 result_account_availabilities_samples = ['''[
     {
       "region": "ap-west",
+      "available": ["NodeBalancers", "Block Storage", "Kubernetes"],
       "unavailable": ["Linode"]
     },
     {
       "region": "ca-central",
+      "available": ["NodeBalancers", "Kubernetes"],
       "unavailable": ["Linode", "Block Storage"]
     }
 ]''']

--- a/tests/integration/targets/account_availability_info/tasks/main.yaml
+++ b/tests/integration/targets/account_availability_info/tasks/main.yaml
@@ -9,6 +9,7 @@
       assert:
         that:
           - account_availability.account_availability.region == "us-east"
+          - account_availability.account_availability.available | length + account_availability.account_availability.unavailable | length == 4
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'


### PR DESCRIPTION
## 📝 Description

Update documentations to include the new field `available` to account_availability info and list module. Add test case to verify the new field works on ansible.

## ✔️ How to Test

The endpoints are currently available on alpha and the PR depends on the [python SDK change #395](https://github.com/linode/linode_api4-python/pull/395). You'll need to pull down the python SDK PR and install it locally to run the test cases. You'll also need to set up test url and token to test in alpha.

```
TEST_API_URL=alpha/api-url
TEST_API_CA=your-local-ca-file
LINODE_TOKEN=alpha-linode-token
```
```
make TEST_ARGS="-v account_availability_list" test 
make TEST_ARGS="-v account_availability_info" test 
```

Manual test:
1. In a sandbox environment, run the following ansible playbook script:
```ansible-playbook
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Get account availability information
      linode.cloud.account_availability_info:
        region: us-east
      register: account_availability

    - name: Output info about the accout availability
      debug:
        msg: |
          Account Availability Info:
            Region: {{ account_availability.account_availability.region }}
            Unavailable: {{ account_availability.account_availability.unavailable }}
            Available: {{ account_availability.account_availability.available }}
```
2. Observe that the result correctly shows up.