### PR TITLE
fix: Resolve error in `handle_updates` when key is not valid

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -138,7 +138,7 @@ def handle_updates(
         # Python SDK.
         if (
             property_metadata is not None
-            and key in property_metadata
+            and property_metadata.get(key) is not None
             and property_metadata.get(key).unordered
         ):
             has_diff = set(old_value) != set(new_value)

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -136,7 +136,10 @@ def handle_updates(
         # We should convert properties to sets
         # if they are annotated as unordered in the
         # Python SDK.
-        if property_metadata.get(key).unordered:
+        if (
+            property_metadata is not None
+            and property_metadata.get(key).unordered
+        ):
             has_diff = set(old_value) != set(new_value)
 
         if has_diff:

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -138,6 +138,7 @@ def handle_updates(
         # Python SDK.
         if (
             property_metadata is not None
+            and key in property_metadata
             and property_metadata.get(key).unordered
         ):
             has_diff = set(old_value) != set(new_value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 linode-api4>=5.15.0
 polling>=0.3.2
-types-requests==2.31.0.0
+types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 linode-api4>=5.15.0
 polling>=0.3.2
-types-requests==2.31.0.10
+types-requests==2.31.0.0
 ansible-specdoc>=0.0.14


### PR DESCRIPTION
## 📝 Description

This change resolves the following error that would occur when a key was not found in the property list for a Python SDK class:

```
AttributeError: 'NoneType' object has no attribute 'unordered'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

## ✔️ How to Test

### Integration Testing

The following command will run a test case that was previously failing because of this issue:

```
make TEST_ARGS="-v vpc_subnet" test
```