### PR TITLE
fix: Address breaking change from linode_api4 v5.15.0

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1050,7 +1050,7 @@ class LinodeInstance(LinodeModuleBase):
 
             # Special diffing due to handling in linode_api4-python
             if key == "devices":
-                for device_key, device in old_value.items():
+                for device_key, device in vars(config.devices).items():
                     if not self._compare_param_to_device(
                         new_value[device_key], device
                     ):


### PR DESCRIPTION
## 📝 Description

This pull request addresses [this breaking change](https://github.com/linode/linode_api4-python/pull/389) from v5.15.0 of the Python SDK.

## ✔️ How to Test

```
make TEST_ARGS="-v instance_config_disk" test
```