### PR TITLE
Fix plural noun in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Modules for retrieving and filtering on multiple Linode resources.
 
 Name | Description |
 --- | ------------ |
-[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilitys.|
+[linode.cloud.account_availability_list](./docs/modules/account_availability_list.md)|List and filter on Account Availabilities.|
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|

--- a/docs/modules/account_availability_list.md
+++ b/docs/modules/account_availability_list.md
@@ -1,6 +1,6 @@
 # account_availability_list
 
-List and filter on Account Availabilitys.
+List and filter on Account Availabilities.
 
 **:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
 
@@ -27,10 +27,10 @@ List and filter on Account Availabilitys.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Account Availabilitys in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Account Availabilitys by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Account Availabilitys.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of Account Availabilitys to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Account Availabilities in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Account Availabilities by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Account Availabilities.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Account Availabilities to return. If undefined, all results will be returned.   |
 
 ### filters
 
@@ -41,7 +41,7 @@ List and filter on Account Availabilitys.
 
 ## Return Values
 
-- `account_availabilities` - The returned Account Availabilitys.
+- `account_availabilities` - The returned Account Availabilities.
 
     - Sample Response:
         ```json

--- a/docs/modules/vpc_subnet_list.md
+++ b/docs/modules/vpc_subnet_list.md
@@ -35,7 +35,7 @@ List and filter on VPC Subnets.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for this VPC Subnet.   |
+| `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The parent VPC for the VPC Subnets.   |
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VPC Subnets in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VPC Subnets by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VPC Subnets.   |

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -118,7 +118,7 @@ class ListModule(
             "order": SpecField(
                 type=FieldType.string,
                 description=[
-                    f"The order to list {self.result_display_name}s in."
+                    f"The order to list {self.result_display_name} in."
                 ],
                 default="asc",
                 choices=["desc", "asc"],
@@ -126,7 +126,7 @@ class ListModule(
             "order_by": SpecField(
                 type=FieldType.string,
                 description=[
-                    f"The attribute to order {self.result_display_name}s by."
+                    f"The attribute to order {self.result_display_name} by."
                 ],
             ),
             "filters": SpecField(
@@ -134,13 +134,13 @@ class ListModule(
                 element_type=FieldType.dict,
                 suboptions=spec_filter,
                 description=[
-                    f"A list of filters to apply to the resulting {self.result_display_name}s."
+                    f"A list of filters to apply to the resulting {self.result_display_name}."
                 ],
             ),
             "count": SpecField(
                 type=FieldType.integer,
                 description=[
-                    f"The number of {self.result_display_name}s to return.",
+                    f"The number of {self.result_display_name} to return.",
                     "If undefined, all results will be returned.",
                 ],
             ),
@@ -151,12 +151,12 @@ class ListModule(
             options[param.name] = SpecField(
                 type=param.type,
                 description=[
-                    f"The parent {param.display_name} for this {self.result_display_name}."
+                    f"The parent {param.display_name} for the {self.result_display_name}."
                 ],
                 required=True,
             )
 
-        description = [f"List and filter on {self.result_display_name}s."]
+        description = [f"List and filter on {self.result_display_name}."]
 
         if self.requires_beta:
             description.append(BETA_DISCLAIMER)
@@ -169,7 +169,7 @@ class ListModule(
             examples=self.examples,
             return_values={
                 self.result_field_name: SpecReturnValue(
-                    description=f"The returned {self.result_display_name}s.",
+                    description=f"The returned {self.result_display_name}.",
                     docs_url=self.result_docs_url,
                     type=FieldType.list,
                     elements=FieldType.dict,

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -13,7 +13,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list im
 )
 
 module = ListModule(
-    result_display_name="Account Availability",
+    result_display_name="Account Availabilities",
     result_field_name="account_availabilities",
     endpoint_template="/account/availability",
     result_docs_url="TBD",

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -11,7 +11,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list im
 )
 
 module = ListModule(
-    result_display_name="Image",
+    result_display_name="Images",
     result_field_name="images",
     endpoint_template="/images",
     result_docs_url="https://www.linode.com/docs/api/images/#images-list__responses",

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -11,7 +11,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list im
 )
 
 module = ListModule(
-    result_display_name="VPC",
+    result_display_name="VPCs",
     result_field_name="vpcs",
     endpoint_template="/vpcs",
     result_docs_url="",

--- a/plugins/modules/vpc_subnet_list.py
+++ b/plugins/modules/vpc_subnet_list.py
@@ -13,7 +13,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list im
 from ansible_specdoc.objects import FieldType
 
 module = ListModule(
-    result_display_name="VPC Subnet",
+    result_display_name="VPC Subnets",
     result_field_name="subnets",
     endpoint_template="/vpcs/{vpc_id}/subnets",
     result_docs_url="",


### PR DESCRIPTION
## 📝 Description
Push the naming responsibility to individual module to fix the plural noun in the doc.

## ✔️ How to Test

You can just read the docs.