### PR TITLE
new: Add modules for Placement group

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Name | Description |
 [linode.cloud.nodebalancer_node](./docs/modules/nodebalancer_node.md)|Manage Linode NodeBalancer Nodes.|
 [linode.cloud.nodebalancer_stats](./docs/modules/nodebalancer_stats.md)|View a Linode NodeBalancers Stats.|
 [linode.cloud.object_keys](./docs/modules/object_keys.md)|Manage Linode Object Storage Keys.|
+[linode.cloud.placement_group](./docs/modules/placement_group.md)|Manage a Linode Placement Group.|
 [linode.cloud.ssh_key](./docs/modules/ssh_key.md)|Manage a Linode SSH key.|
 [linode.cloud.stackscript](./docs/modules/stackscript.md)|Manage a Linode StackScript.|
 [linode.cloud.token](./docs/modules/token.md)|Manage a Linode Token.|
@@ -68,6 +69,7 @@ Name | Description |
 [linode.cloud.lke_cluster_info](./docs/modules/lke_cluster_info.md)|Get info about a Linode LKE cluster.|
 [linode.cloud.nodebalancer_info](./docs/modules/nodebalancer_info.md)|Get info about a Linode NodeBalancer.|
 [linode.cloud.object_cluster_info](./docs/modules/object_cluster_info.md)|Get info about a Linode Object Storage Cluster.|
+[linode.cloud.placement_group_info](./docs/modules/placement_group_info.md)|Get info about a Linode Placement Group.|
 [linode.cloud.profile_info](./docs/modules/profile_info.md)|Get info about a Linode Profile.|
 [linode.cloud.ssh_key_info](./docs/modules/ssh_key_info.md)|Get info about the Linode SSH public key.|
 [linode.cloud.stackscript_info](./docs/modules/stackscript_info.md)|Get info about a Linode StackScript.|
@@ -98,6 +100,7 @@ Name | Description |
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List Kubernetes versions available for deployment to a Kubernetes cluster.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Nodebalancers.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|List and filter on Object Storage Clusters.|
+[linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|
 [linode.cloud.region_list](./docs/modules/region_list.md)|List and filter on Linode Regions.|
 [linode.cloud.ssh_key_list](./docs/modules/ssh_key_list.md)|List and filter on SSH keys in the Linode profile.|
 [linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on Linode stackscripts.|

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -93,7 +93,19 @@ Manage Linode Instances, Configs, and Disks.
     image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     metadata:
-        user_data: myuserdata
+      user_data: myuserdata
+    state: present
+```
+
+```yaml
+- name: Create a new Linode instance under a placement group.
+  linode.cloud.instance:
+    label: my-linode
+    type: g6-nanode-1
+    region: us-east
+    placement_group: 
+      id: 123
+      compliant_only: false
     state: present
 ```
 
@@ -136,6 +148,7 @@ Manage Linode Instances, Configs, and Disks.
 | `migration_type` | <center>`str`</center> | <center>Optional</center> | The type of migration to use for Region and Type migrations.  **(Choices: `cold`, `warm`; Default: `cold`)** |
 | `auto_disk_resize` | <center>`bool`</center> | <center>Optional</center> | Whether implicitly created disks should be resized during a type change operation.  **(Default: `False`)** |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to this object. Tags are for organizational purposes only.  **(Updatable)** |
+| [`placement_group` (sub-options)](#placement_group) | <center>`dict`</center> | <center>Optional</center> | A Placement Group to create this Linode under.   |
 
 ### configs
 
@@ -278,6 +291,13 @@ Manage Linode Instances, Configs, and Disks.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `public` | <center>`bool`</center> | <center>**Required**</center> | Whether the allocated IPv4 address should be public or private.   |
 
+### placement_group
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `id` | <center>`int`</center> | <center>**Required**</center> | The id of the placement group.   |
+| `compliant_only` | <center>`bool`</center> | <center>Optional</center> | Whether the newly added/migrated/resized linode must be compliant for flexible placement groups.  **(Default: `False`)** |
+
 ## Return Values
 
 - `instance` - The instance description in JSON serialized form.
@@ -326,7 +346,13 @@ Manage Linode Instances, Configs, and Disks.
           ],
           "type": "g6-standard-1",
           "updated": "2018-01-01T00:01:01",
-          "watchdog_enabled": true
+          "watchdog_enabled": true,
+          "placement_group": {
+            "id": 123,
+            "label": "test",
+            "affinity_type": "anti_affinity:local",
+            "is_strict": true
+          }
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linode-view__responses) for a list of returned fields

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -82,7 +82,13 @@ Get info about a Linode Instance.
           ],
           "type": "g6-standard-1",
           "updated": "2018-01-01T00:01:01",
-          "watchdog_enabled": true
+          "watchdog_enabled": true,
+          "placement_group": {
+            "id": 123,
+            "label": "test",
+            "affinity_type": "anti_affinity:local",
+            "is_strict": true
+          }
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linode-view__responses) for a list of returned fields

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -2,6 +2,8 @@
 
 Manage a Linode Placement Group.
 
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
 - [Parameters](#parameters)

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -27,20 +27,27 @@ Manage a Linode Placement Group.
 ```
 
 ```yaml
-- name: Update a placement group label
+- name: Update a Linode placement group label
   linode.cloud.placement_group:
+    # id is required to update the label
+    id: 123
     label: my-pg-updated
-    region: us-east
-    affinity_type: anti_affinity:local
-    is_strict: True
     state: present
 ```
 
 ```yaml
-- name: Delete a placement group
+- name: Delete a placement group by label
   linode.cloud.placement_group:
     label: my-pg
     state: absent
+```
+
+```yaml
+- name: Delete a placement group by id
+  linode.cloud.placement_group:
+    id: 123
+    state: absent    
+
 ```
 
 
@@ -48,7 +55,8 @@ Manage a Linode Placement Group.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>**Required**</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The unique ID of the placement group.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region that the placement group is in.   |
 | `affinity_type` | <center>`str`</center> | <center>Optional</center> | The affinity policy for Linodes in a placement group.   |
 | `is_strict` | <center>`bool`</center> | <center>Optional</center> | Whether Linodes must be able to become compliant during assignment.  **(Default: `False`)** |

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -1,0 +1,77 @@
+# placement_group
+
+Manage a Linode Placement Group.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Create a placement group
+  linode.cloud.placement_group:
+    label: my-pg
+    region: us-east
+    affinity_type: anti_affinity:local
+    is_strict: True
+    state: present
+```
+
+```yaml
+- name: Update a placement group label
+  linode.cloud.placement_group:
+    label: my-pg-updated
+    region: us-east
+    affinity_type: anti_affinity:local
+    is_strict: True
+    state: present
+```
+
+```yaml
+- name: Delete a placement group
+  linode.cloud.placement_group:
+    label: my-pg
+    state: absent
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `label` | <center>`str`</center> | <center>**Required**</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
+| `region` | <center>`str`</center> | <center>Optional</center> | The region that the placement group is in.   |
+| `affinity_type` | <center>`str`</center> | <center>Optional</center> | The affinity policy for Linodes in a placement group.   |
+| `is_strict` | <center>`bool`</center> | <center>Optional</center> | Whether Linodes must be able to become compliant during assignment.  **(Default: `False`)** |
+
+## Return Values
+
+- `placement_group` - The Placement Group in JSON serialized form.
+
+    - Sample Response:
+        ```json
+        {
+          "id": 123,
+          "label": "my-pg",
+          "region": "eu-west",
+          "affinity_type": "anti_affinity:local",
+          "is_strict": true,
+          "is_compliant": true,
+          "members": [
+            {
+              "linode_id": 123,
+              "is_compliant": true
+            }
+          ]
+        }
+        ```
+    - See the [Linode API response documentation](TBD) for a list of returned fields
+
+

--- a/docs/modules/placement_group_info.md
+++ b/docs/modules/placement_group_info.md
@@ -1,0 +1,59 @@
+# placement_group_info
+
+Get info about a Linode Placement Group.
+
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get info about a Linode placement group
+  linode.cloud.placement_group_info: 
+    api_version: v4beta
+    id: 123
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Placement Group to resolve.   |
+
+## Return Values
+
+- `placement_group` - The returned Placement Group.
+
+    - Sample Response:
+        ```json
+        
+        {
+          "id": 123,
+          "label": "test",
+          "region": "eu-west",
+          "affinity_type": "anti_affinity:local",
+          "is_strict": true,
+          "is_compliant": true,
+          "members": [
+            {
+              "linode_id": 123,
+              "is_compliant": true
+            }
+          ]
+        }
+        
+        ```
+    - See the [Linode API response documentation](TBD) for a list of returned fields
+
+

--- a/docs/modules/placement_group_list.md
+++ b/docs/modules/placement_group_list.md
@@ -1,0 +1,67 @@
+# placement_group_list
+
+List and filter on Placement Groups.
+
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of Linode placement group for the current account
+  linode.cloud.placement_group_list:
+    api_version: v4beta
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Placement Groups in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Placement Groups by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Placement Groups.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Placement Groups to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](TBD).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `placement_groups` - The returned Placement Groups.
+
+    - Sample Response:
+        ```json
+        [
+            {
+              "id": 123,
+              "label": "test",
+              "region": "eu-west",
+              "affinity_type": "anti_affinity:local",
+              "is_strict": true,
+              "is_compliant": true,
+              "members": [
+                {
+                  "linode_id": 123,
+                  "is_compliant": true
+                }
+              ]
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](TBD) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -70,7 +70,16 @@ specdoc_examples = ['''
     image: linode/ubuntu22.04
     root_pass: verysecurepassword!!!
     metadata:
-        user_data: myuserdata
+      user_data: myuserdata
+    state: present''', '''
+- name: Create a new Linode instance under a placement group.
+  linode.cloud.instance:
+    label: my-linode
+    type: g6-nanode-1
+    region: us-east
+    placement_group: 
+      id: 123
+      compliant_only: false
     state: present''', '''
 - name: Delete a Linode instance.
   linode.cloud.instance:
@@ -119,7 +128,13 @@ result_instance_samples = ['''{
   ],
   "type": "g6-standard-1",
   "updated": "2018-01-01T00:01:01",
-  "watchdog_enabled": true
+  "watchdog_enabled": true,
+  "placement_group": {
+    "id": 123,
+    "label": "test",
+    "affinity_type": "anti_affinity:local",
+    "is_strict": true
+  }
 }''']
 
 result_configs_samples = ['''[

--- a/plugins/module_utils/doc_fragments/placement_group.py
+++ b/plugins/module_utils/doc_fragments/placement_group.py
@@ -8,17 +8,21 @@ specdoc_examples = ['''
     affinity_type: anti_affinity:local
     is_strict: True
     state: present''', '''
-- name: Update a placement group label
+- name: Update a Linode placement group label
   linode.cloud.placement_group:
+    # id is required to update the label
+    id: 123
     label: my-pg-updated
-    region: us-east
-    affinity_type: anti_affinity:local
-    is_strict: True
     state: present''', '''
-- name: Delete a placement group
+- name: Delete a placement group by label
   linode.cloud.placement_group:
     label: my-pg
-    state: absent''']
+    state: absent''', '''
+- name: Delete a placement group by id
+  linode.cloud.placement_group:
+    id: 123
+    state: absent    
+''']
 
 result_placement_group_samples = ['''{
   "id": 123,

--- a/plugins/module_utils/doc_fragments/placement_group.py
+++ b/plugins/module_utils/doc_fragments/placement_group.py
@@ -1,0 +1,36 @@
+"""Documentation fragments for the placement_group module"""
+
+specdoc_examples = ['''
+- name: Create a placement group
+  linode.cloud.placement_group:
+    label: my-pg
+    region: us-east
+    affinity_type: anti_affinity:local
+    is_strict: True
+    state: present''', '''
+- name: Update a placement group label
+  linode.cloud.placement_group:
+    label: my-pg-updated
+    region: us-east
+    affinity_type: anti_affinity:local
+    is_strict: True
+    state: present''', '''
+- name: Delete a placement group
+  linode.cloud.placement_group:
+    label: my-pg
+    state: absent''']
+
+result_placement_group_samples = ['''{
+  "id": 123,
+  "label": "my-pg",
+  "region": "eu-west",
+  "affinity_type": "anti_affinity:local",
+  "is_strict": true,
+  "is_compliant": true,
+  "members": [
+    {
+      "linode_id": 123,
+      "is_compliant": true
+    }
+  ]
+}''']

--- a/plugins/module_utils/doc_fragments/placement_group_info.py
+++ b/plugins/module_utils/doc_fragments/placement_group_info.py
@@ -1,0 +1,26 @@
+"""Documentation fragments for the placement_group module"""
+
+result_placement_group_samples = ['''
+{
+  "id": 123,
+  "label": "test",
+  "region": "eu-west",
+  "affinity_type": "anti_affinity:local",
+  "is_strict": true,
+  "is_compliant": true,
+  "members": [
+    {
+      "linode_id": 123,
+      "is_compliant": true
+    }
+  ]
+}
+''']
+
+
+specdoc_examples = ['''
+- name: Get info about a Linode placement group
+  linode.cloud.placement_group_info: 
+    api_version: v4beta
+    id: 123
+''']

--- a/plugins/module_utils/doc_fragments/placement_group_list.py
+++ b/plugins/module_utils/doc_fragments/placement_group_list.py
@@ -1,0 +1,23 @@
+"""Documentation fragments for the placement_group_list module"""
+
+specdoc_examples = ['''
+- name: List all of Linode placement group for the current account
+  linode.cloud.placement_group_list:
+    api_version: v4beta''']
+
+result_placement_groups_samples = ['''[
+    {
+      "id": 123,
+      "label": "test",
+      "region": "eu-west",
+      "affinity_type": "anti_affinity:local",
+      "is_strict": true,
+      "is_compliant": true,
+      "members": [
+        {
+          "linode_id": 123,
+          "is_compliant": true
+        }
+      ]
+    }
+]''']

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -213,6 +213,15 @@ class LinodeModuleBase:
         """
         self.module.fail_json(msg=msg, **kwargs)
 
+    def warn(self, msg: str) -> None:
+        """
+        Shortcut for calling module.warn
+
+        :param msg: Error message
+        :return: None
+        """
+        self.module.warn(msg)
+
     def exec_module(self, **kwargs: Any) -> Any:
         """Returns a not implemented error"""
         self.fail(

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1207,6 +1207,7 @@ class LinodeInstance(LinodeModuleBase):
                 "backups_enabled",
                 "type",
                 "region",
+                "placement_group",
             )
         }
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1240,6 +1240,19 @@ class LinodeInstance(LinodeModuleBase):
                     "non-updatable field".format(self._instance.label)
                 )
 
+        pg = params.get("placement_group")
+        if pg is not None:
+            if pg.get("id") != self._instance.placement_group.id:
+                self.fail(
+                    "failed to update instance {0}: placement_group.id is a "
+                    "non-updatable field".format(self._instance.label)
+                )
+            if pg.get("compliant_only"):
+                self.warn(
+                    "placement_group.compliant_only is non-updatable and only can be "
+                    "specified in the instance creation."
+                )
+
         # Update interfaces
         self._update_interfaces()
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -301,6 +301,20 @@ spec_additional_ipv4 = {
     )
 }
 
+linode_instance_placement_group_spec = {
+    "id": SpecField(
+        type=FieldType.integer,
+        description="The id of the placement group.",
+        required=True,
+    ),
+    "compliant_only": SpecField(
+        type=FieldType.bool,
+        description="Whether the newly added/migrated/resized linode "
+        "must be compliant for flexible placement groups.",
+        default=False,
+    ),
+}
+
 linode_instance_spec = {
     "label": SpecField(
         type=FieldType.string,
@@ -499,6 +513,11 @@ linode_instance_spec = {
             "Tags are for organizational purposes only.",
         ],
         editable=True,
+    ),
+    "placement_group": SpecField(
+        type=FieldType.dict,
+        suboptions=linode_instance_placement_group_spec,
+        description=["A Placement Group to create this Linode under."],
     ),
 }
 

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -13,6 +13,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common import 
     LinodeModuleBase,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    BETA_DISCLAIMER,
     global_authors,
     global_requirements,
 )
@@ -55,7 +56,7 @@ placement_group_spec = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["Manage a Linode Placement Group."],
+    description=["Manage a Linode Placement Group.", BETA_DISCLAIMER],
     requirements=global_requirements,
     author=global_authors,
     options=placement_group_spec,

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Placement Groups."""
+
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.placement_group as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    handle_updates,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import PlacementGroup
+
+placement_group_spec = {
+    "label": SpecField(
+        type=FieldType.string,
+        required=True,
+        description=[
+            "The label of the Placement Group. "
+            "This field can only contain ASCII letters, digits and dashes."
+        ],
+    ),
+    "region": SpecField(
+        type=FieldType.string,
+        description=["The region that the placement group is in."],
+    ),
+    "affinity_type": SpecField(
+        type=FieldType.string,
+        description=["The affinity policy for Linodes in a placement group."],
+    ),
+    "is_strict": SpecField(
+        type=FieldType.bool,
+        default=False,
+        description=[
+            "Whether Linodes must be able to become compliant during assignment."
+        ],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Manage a Linode Placement Group."],
+    requirements=global_requirements,
+    author=global_authors,
+    options=placement_group_spec,
+    examples=docs.specdoc_examples,
+    return_values={
+        "placement_group": SpecReturnValue(
+            description="The Placement Group in JSON serialized form.",
+            docs_url="TBD",
+            type=FieldType.dict,
+            sample=docs.result_placement_group_samples,
+        )
+    },
+)
+
+CREATE_FIELDS = {"label", "region", "affinity_type", "is_strict"}
+# Fields that can be updated on an existing placement group
+MUTABLE_FIELDS = {"label"}
+
+
+class Module(LinodeModuleBase):
+    """Module for creating and destroying Linode Placement Group"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.results = {
+            "changed": False,
+            "actions": [],
+            "placement_group": None,
+        }
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_one_of=[("state", "label")],
+        )
+
+    def _get_placement_group_by_label(
+        self, label: str
+    ) -> Optional[PlacementGroup]:
+        try:
+            return self.client.placement.groups(PlacementGroup.label == label)[
+                0
+            ]
+        except IndexError:
+            return None
+        except Exception as exception:
+            return self.fail(
+                msg="failed to get placement group {0}: {1}".format(
+                    label, exception
+                )
+            )
+
+    def _create_placement_group(self) -> Optional[PlacementGroup]:
+        params = filter_null_values(
+            {k: v for k, v in self.module.params.items() if k in CREATE_FIELDS}
+        )
+
+        try:
+            return self.client.placement.group_create(**params)
+        except Exception as exception:
+            return self.fail(
+                msg="failed to create placement group: {0}".format(exception)
+            )
+
+    def _update_placement_group(self, pg: PlacementGroup) -> None:
+        pg._api_get()
+
+        params = filter_null_values(self.module.params)
+
+        handle_updates(pg, params, MUTABLE_FIELDS, self.register_action)
+
+    def _handle_present(self) -> None:
+        params = self.module.params
+
+        label = params.get("label")
+
+        pg = self._get_placement_group_by_label(label)
+
+        # Create the placement group if it does not already exist
+        if pg is None:
+            pg = self._create_placement_group()
+            self.register_action("Created placement_group {0}".format(pg.id))
+
+        self._update_placement_group(pg)
+
+        # Force lazy-loading
+        pg._api_get()
+
+        self.results["placement_group"] = pg._raw_json
+
+    def _handle_absent(self) -> None:
+        label: str = self.module.params.get("label")
+
+        pg = self._get_placement_group_by_label(label)
+
+        if pg is not None:
+            self.results["placement_group"] = pg._raw_json
+            pg.delete()
+            self.register_action("Deleted placement group {0}".format(label))
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Placement Group module"""
+
+        state = kwargs.get("state")
+
+        if state == "absent":
+            self._handle_absent()
+            return self.results
+
+        self._handle_present()
+
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the Placement Group module"""
+    Module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/placement_group_info.py
+++ b/plugins/modules/placement_group_info.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Placement Group info."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    placement_group_info as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import PlacementGroup
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="Placement Group",
+        field_name="placement_group",
+        field_type=FieldType.dict,
+        docs_url="TBD",
+        samples=docs.result_placement_group_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            name="id",
+            display_name="ID",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                PlacementGroup, params.get("id")
+            )._raw_json,
+        ),
+    ],
+    requires_beta=True,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/placement_group_list.py
+++ b/plugins/modules/placement_group_list.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Placement Groups."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    placement_group_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Placement Groups",
+    result_field_name="placement_groups",
+    endpoint_template="/placement/groups",
+    result_docs_url="TBD",
+    result_samples=docs.result_placement_groups_samples,
+    examples=docs.specdoc_examples,
+    requires_beta=True,
+)
+
+SPECDOC_META = module.spec
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -92,6 +92,8 @@ class LinodeSSHKeyInfo(LinodeModuleBase):
 
         params = filter_null_values(self.module.params)
 
+        ssh_key = None
+
         if "id" in params:
             ssh_key = self._get_ssh_key_by_id(params.get("id"))
         elif "label" in params:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-linode-api4>=5.15.1
+# TODO: Revert before merging to dev
+# linode-api4>=5.15.1
+git+https://github.com/linode/linode_api4-python@proj/vm-placement
+
+
 polling>=0.3.2
 types-requests==2.31.0.10
 ansible-specdoc>=0.0.14

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -137,6 +137,30 @@
           - info_label.instance.region == 'us-ord'
           - info_label.configs|length == 1
 
+    - name: Create a Linode placement group
+      linode.cloud.placement_group:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        affinity_type: anti_affinity:local
+        state: present
+      register: pg_created
+
+    - name: Create a Linode instance under a placement group
+      linode.cloud.instance:
+        label: 'ansible-test-pg-{{ r }}'
+        type: g6-nanode-1
+        region: us-east
+        placement_group:
+          id: '{{ pg_created.placement_group.id }}'
+          compliant_only: false
+        state: present
+      register: instance_pg
+
+    - name: Assert instance under a placement group
+      assert:
+        that:
+          instance_pg.instance.placement_group.id == pg_created.placement_group.id
+
   always:
     - ignore_errors: yes
       block:
@@ -163,6 +187,30 @@
             that:
               - delete_nopass_ips.changed
               - delete_nopass_ips.instance.id == create_additional_ips.instance.id
+
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ instance_pg.instance.label }}'
+            state: absent
+          register: delete_instance_pg
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_instance_pg.changed
+              - delete_instance_pg.instance.id == instance_pg.instance.id
+
+        - name: Delete a placement group
+          linode.cloud.placement_group:
+            label: '{{ pg_created.placement_group.label }}'
+            state: absent
+          register: pg_deleted
+
+        - name: Assert placement group is deleted
+          assert:
+            that:
+              - pg_deleted.changed
+              - pg_deleted.placement_group.id == pg_created.placement_group.id
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/placement_group_basic/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_basic/tasks/main.yaml
@@ -1,0 +1,51 @@
+- name: placement_group_basic
+  block:
+    - set_fact:
+          r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode placement group
+      linode.cloud.placement_group:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        affinity_type: anti_affinity:local
+        state: present
+      register: pg_created
+
+    - name: Assert placement group is created
+      assert:
+        that:
+          - pg_created.placement_group.region == 'us-east'
+          - pg_created.placement_group.affinity_type == 'anti_affinity:local'
+          - pg_created.placement_group.is_strict == false
+
+    - name: Update a Linode placement group label
+      linode.cloud.placement_group:
+        label: '{{ pg_created.placement_group.label }}-updated'
+        region: us-east
+        affinity_type: anti_affinity:local
+        state: present
+      register: pg_updated
+
+    - name: Assert placement group is updated
+      assert:
+        that:
+          - pg_updated.changed
+
+    - name: Delete a placement group
+      linode.cloud.placement_group:
+        label: '{{ pg_created.placement_group.label }}'
+        state: absent
+      register: pg_deleted
+
+    - name: Assert placement group is deleted
+      assert:
+        that:
+          - pg_deleted.changed
+          - pg_deleted.placement_group.id == pg_created.placement_group.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/placement_group_basic/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_basic/tasks/main.yaml
@@ -20,9 +20,8 @@
 
     - name: Update a Linode placement group label
       linode.cloud.placement_group:
+        id: '{{ pg_created.placement_group.id }}'
         label: '{{ pg_created.placement_group.label }}-updated'
-        region: us-east
-        affinity_type: anti_affinity:local
         state: present
       register: pg_updated
 
@@ -33,7 +32,7 @@
 
     - name: Delete a placement group
       linode.cloud.placement_group:
-        label: '{{ pg_created.placement_group.label }}'
+        label: '{{ pg_updated.placement_group.label }}'
         state: absent
       register: pg_deleted
 

--- a/tests/integration/targets/placement_group_info/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_info/tasks/main.yaml
@@ -1,0 +1,38 @@
+- name: placement_group_info
+  block:
+    - set_fact:
+          r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode placement group
+      linode.cloud.placement_group:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        affinity_type: anti_affinity:local
+        is_strict: True
+        state: present
+      register: pg_created
+
+    - name: Get a Linode placement group
+      linode.cloud.placement_group_info:
+        id: '{{ pg_created.placement_group.id }}'
+      register: pg
+
+    - name: Assert GET placement_group_info response
+      assert:
+        that:
+          - pg_created.placement_group.label == pg.placement_group.label
+          - pg_created.placement_group.region == pg.placement_group.region
+          - pg_created.placement_group.affinity_type == pg.placement_group.affinity_type
+          - pg_created.placement_group.is_strict == pg.placement_group.is_strict
+
+    - name: Delete a placement group
+      linode.cloud.placement_group:
+        label: '{{ pg_created.placement_group.label }}'
+        state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/placement_group_info/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_info/tasks/main.yaml
@@ -12,7 +12,7 @@
         state: present
       register: pg_created
 
-    - name: Get a Linode placement group
+    - name: Get a Linode placement group info
       linode.cloud.placement_group_info:
         id: '{{ pg_created.placement_group.id }}'
       register: pg
@@ -25,9 +25,9 @@
           - pg_created.placement_group.affinity_type == pg.placement_group.affinity_type
           - pg_created.placement_group.is_strict == pg.placement_group.is_strict
 
-    - name: Delete a placement group
+    - name: Delete a placement group by id
       linode.cloud.placement_group:
-        label: '{{ pg_created.placement_group.label }}'
+        id: '{{ pg_created.placement_group.id }}'
         state: absent
 
   environment:

--- a/tests/integration/targets/placement_group_list/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_list/tasks/main.yaml
@@ -1,0 +1,40 @@
+- name: placement_group_list
+  block:
+    - set_fact:
+          r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode placement group
+      linode.cloud.placement_group:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        affinity_type: anti_affinity:local
+        is_strict: True
+        state: present
+      register: pg_created
+
+    - name: List Linode placement groups for the current account
+      linode.cloud.placement_group_list:
+        filters:
+          - name: label
+            values: ['ansible-test-{{ r }}']
+      register: pg_list
+
+    - name: Assert GET placement_group_list response
+      assert:
+        that:
+          - pg_list.placement_groups[0].label == pg_created.placement_group.label
+          - pg_list.placement_groups[0].region == pg_created.placement_group.region
+          - pg_list.placement_groups[0].affinity_type == pg_created.placement_group.affinity_type
+          - pg_list.placement_groups[0].is_strict == pg_created.placement_group.is_strict
+
+    - name: Delete a placement group
+      linode.cloud.placement_group:
+        label: '{{ pg_created.placement_group.label }}'
+        state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This PR includes the following change for VM placement functionalities:
1. Add new modules:
    - placement_group: accept both label and id as identifier
    - placement_group_info
    - placement_group_list

2. In the `instance` module, allow to create a new linode instance under a placement group.

## ✔️ How to Test

Run `pip install --force -r requirements.txt`  to install required dependencies. 

Also, you need to set up environment variables to test against alpha:

```
export TEST_API_CA=$PWD/cacert.pem
export TEST_API_URL=https://.../
export LINODE_TOKEN=...
```

**Integration tests:**
```
make TEST_ARGS="-v placement_group" test
make TEST_ARGS="-v placement_group_info" test
make TEST_ARGS="-v placement_group_list" test
make TEST_ARGS="-v instance_basic" test
```

**Manual Test:**

1. In a sandbox environment, i.e. dx-devenv, run the following ansible playbook
```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a Linode placement group
      linode.cloud.placement_group:
        label: my-ansible-test-pg
        region: us-east
        affinity_type: anti_affinity:local
        state: present
      register: pg_created

    - name: Get a Linode placement group info
      linode.cloud.placement_group_info:
        id: '{{ pg_created.placement_group.id }}'
      register: pg

    - name: Update a Linode placement group label
      linode.cloud.placement_group:
        id: '{{ pg.placement_group.id }}'
        label: '{{ pg.placement_group.label }}-updated'
        state: present
      register: pg_updated

    - name: List Linode placement groups for the current account
      linode.cloud.placement_group_list:
        filters:
          - name: label
            values: ['{{ pg_updated.placement_group.label }}']
      register: pg_list
```

2. Observe no error is raised.

3. Create an instance under the placement group
```yaml
    - name: Create a Linode instance under a placement group
      linode.cloud.instance:
        label: 'ansible-test-pg-{{ r }}'
        type: g6-nanode-1
        region: us-east
        placement_group:
          id: '{{ pg_updated.placement_group.id }}'
          compliant_only: false
        state: present
      register: instance_pg
```

4. Observe that the instance is created successfully.

5. Clean up the resources created.
```yaml
    - name: Delete a Linode instance
      linode.cloud.instance:
        label: '{{ instance_pg.instance.label }}'
        state: absent
      register: delete_instance_pg

    - name: Delete a placement group
      linode.cloud.placement_group:
        label: '{{ pg_updated.placement_group.label }}'
        state: absent
      register: pg_deleted
```