### PR TITLE
fix: Add conditional update logic for the `ip_rdns` module

### DIFF
--- a/docs/modules/ip_rdns.md
+++ b/docs/modules/ip_rdns.md
@@ -38,7 +38,7 @@ Manage a Linode IP address's rDNS.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `address` | <center>`str`</center> | <center>**Required**</center> | The IP address.   |
 | `state` | <center>`str`</center> | <center>Optional</center> | The state of this rDNS of the IP address.  **(Choices: `present`, `absent`)** |
-| `rdns` | <center>`str`</center> | <center>Optional</center> | The desired rDNS value.  **(Updatable)** |
+| `rdns` | <center>`str`</center> | <center>Optional</center> | The desired RDNS value.  **(Updatable)** |
 
 ## Return Values
 

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -247,7 +247,7 @@ class LinodeModuleBase:
             )
             return self.fail(
                 msg=f"failed to get {resource_name} "
-                "with id {resource_id}: {exception}"
+                f"with id {resource_id}: {exception}"
             )
 
     @property

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -92,12 +92,15 @@ class LinodeSSHKeyInfo(LinodeModuleBase):
 
         params = filter_null_values(self.module.params)
 
+        ssh_key = None
+
         if "id" in params:
             ssh_key = self._get_ssh_key_by_id(params.get("id"))
         elif "label" in params:
             ssh_key = self._get_ssh_key_by_label(params.get("label"))
 
         self.results["ssh_key"] = ssh_key._raw_json
+
         return self.results
 
 

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -27,7 +27,25 @@
         address: '{{ instance_create.instance.ipv4[0] }}'
         rdns: '{{ new_rdns }}'
       register: ip_rdns_modified
-    
+
+    - name: Assert RDNS has been updated for the IP
+      assert:
+        that:
+          - ip_rdns_modified.changed
+          - ip_rdns_modified.ip.rdns == new_rdns
+
+    - name: Attempt to modify reverse DNS of the IP again
+      linode.cloud.ip_rdns:
+        state: present
+        address: '{{ instance_create.instance.ipv4[0] }}'
+        rdns: '{{ new_rdns }}'
+      register: ip_rdns_modified
+
+    - name: Assert RDNS has not been updated for the IP
+      assert:
+        that:
+          - not ip_rdns_modified.changed
+
     - name: Remove reverse DNS of the IP
       linode.cloud.ip_rdns:
         state: absent
@@ -40,6 +58,17 @@
           - ip_info.ip.address == instance_create.instance.ipv4[0]
           - ip_rdns_modified.ip.rdns == new_rdns
           - ip_rdns_removed.ip.rdns != new_rdns
+
+    - name: Attempt to remove RDNS of the IP again
+      linode.cloud.ip_rdns:
+        state: absent
+        address: '{{ instance_create.instance.ipv4[0] }}'
+      register: ip_rdns_removed_again
+
+    - name: Assert RDNS of the IP is unchanged
+      assert:
+        that:
+          - not ip_rdns_removed_again.changed
 
   always:
     - ignore_errors: true

--- a/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
@@ -1,0 +1,87 @@
+- name: ip_rdns_ipv6
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create an instance
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: g6-standard-1
+        image: linode/ubuntu22.04
+        wait: no
+        state: present
+      register: instance_create
+
+    - name: Extract the IPv6 SLAAC address
+      set_fact:
+        slaac: '{{ instance_create.networking.ipv6.slaac.address }}'
+
+    - name: Compute a new RDNS address
+      set_fact:
+        new_rdns: '{{ slaac | replace(":", "-") }}.sslip.io'
+
+    - name: Modify reverse DNS of the IP
+      linode.cloud.ip_rdns:
+        state: present
+        address: '{{ slaac }}'
+        rdns: '{{ new_rdns }}'
+      register: ip_rdns_modified
+
+    - name: Assert RDNS has been updated for the IP
+      assert:
+        that:
+          - ip_rdns_modified.changed
+          - ip_rdns_modified.ip.rdns == new_rdns
+
+    - name: Attempt to modify reverse DNS of the IP again
+      linode.cloud.ip_rdns:
+        state: present
+        address: '{{ slaac }}'
+        rdns: '{{ new_rdns }}'
+      register: ip_rdns_modified
+
+    - name: Assert RDNS has not been updated for the IP
+      assert:
+        that:
+          - not ip_rdns_modified.changed
+
+    - name: Remove reverse DNS of the IP
+      linode.cloud.ip_rdns:
+        state: absent
+        address: '{{ slaac }}'
+      register: ip_rdns_removed
+
+    - name: Assert reverse DNS of IP is removed
+      assert:
+        that:
+          - ip_rdns_removed.ip.address == slaac
+          - ip_rdns_modified.ip.rdns == new_rdns
+          - ip_rdns_removed.ip.rdns != new_rdns
+
+    - name: Attempt to remove RDNS of the IP again
+      linode.cloud.ip_rdns:
+        state: absent
+        address: '{{ slaac }}'
+      register: ip_rdns_removed_again
+
+    - name: Assert RDNS of the IP is unchanged
+      assert:
+        that:
+          - not ip_rdns_removed_again.changed
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Delete instance
+          linode.cloud.instance:
+            label: '{{ instance_create.instance.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+


### PR DESCRIPTION
## 📝 Description

This pull request adds conditional update logic for the `ip_rdns` module, which prevents the result from being marked as `changed` when the RDNS of an IP has not been updated.

Resolves #500 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make TEST_ARGS="-v ip_rdns" test
make TEST_ARGS="-v ip_rdns_ipv6" test
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a Linode instance
      linode.cloud.instance:
        label: 'rdns-test'
        type: g6-nanode-1
        region: us-mia
        state: present
      register: instance_create

    - set_fact:
        new_rdns: '{{ instance_create.instance.ipv4[0] }}.nip.io'
        old_rdns: '{{ instance_create.instance.ipv4[0] | replace(".", "-") }}.ip.linodeusercontent.com'
        ip_address: '{{ instance_create.instance.ipv4[0] }}'

    - name: Update reverse DNS of the instance's primary IPv4 address
      linode.cloud.ip_rdns:
        address: '{{ ip_address }}'
        rdns: '{{ new_rdns }}'
        state: present
      register: rdns_update

    - name: Assert that the RDNS was successfully updated
      assert:
        that:
          - rdns_update.changed
          - rdns_update.ip.address == ip_address
          - rdns_update.ip.rdns == new_rdns

    - name: Make no changes to the RDNS address
      linode.cloud.ip_rdns:
        address: '{{ ip_address }}'
        rdns: '{{ new_rdns }}'
        state: present
      register: rdns_update_no_changes

    - name: Assert that the RDNS address was unchanged
      assert:
        that:
          - not rdns_update_no_changes.changed
          - rdns_update_no_changes.ip.address == ip_address
          - rdns_update_no_changes.ip.rdns == new_rdns

    - name: Revert the RDNS address to the Linode API default
      linode.cloud.ip_rdns:
        address: '{{ ip_address }}'
        state: absent
      register: rdns_revert

    - name: Assert that the RDNS was successfully reverted for the instance
      assert:
        that:
          - rdns_revert.changed
          - rdns_revert.ip.address == ip_address
          - rdns_revert.ip.rdns == old_rdns

    - name: Attempt to revert the RDNS again
      linode.cloud.ip_rdns:
        address: '{{ ip_address }}'
        state: absent
      register: rdns_revert_unchanged

    - name: Assert that the RDNS was unchanged
      assert:
        that:
          - not rdns_revert_unchanged.changed
          - rdns_revert_unchanged.ip.address == ip_address
          - rdns_revert_unchanged.ip.rdns == old_rdns
```
2. Ensure all assertions pass successfully.
3. Ensure all log outputs match the expected behavior.   
