### PR TITLE
test: Fix broken assertion in instance_interfaces_vpc test

### DIFF
--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -93,7 +93,7 @@
       assert:
         that:
           - subnet_info.subnet.linodes[0].id == update_instance.instance.id
-          - subnet_info.subnet.linodes[0].interfaces[0].id == update_instance.configs[0].interfaces[1].id
+          - subnet_info.subnet.linodes[0].interfaces[1].id == update_instance.configs[0].interfaces[1].id
 
     - name: Unchanged instance interface
       linode.cloud.instance:


### PR DESCRIPTION
## 📝 Description

This pull request adjusts an assertion in the `instance_interfaces_vpc` test to reference the second interface returned from `subnet.linodes.*.interfaces`, which is necessary because all interfaces (including non-VPC interfaces) are returned for this field.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Tests

```
make TEST_ARGS="-v instance_interfaces_vpc" test
```
