### PR TITLE
new: Add module to manage placement group assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Name | Description |
 [linode.cloud.nodebalancer_stats](./docs/modules/nodebalancer_stats.md)|View a Linode NodeBalancers Stats.|
 [linode.cloud.object_keys](./docs/modules/object_keys.md)|Manage Linode Object Storage Keys.|
 [linode.cloud.placement_group](./docs/modules/placement_group.md)|Manage a Linode Placement Group.|
+[linode.cloud.placement_group_assign](./docs/modules/placement_group_assign.md)|Manages a single assignment between a Linode and a Placement Group.|
 [linode.cloud.ssh_key](./docs/modules/ssh_key.md)|Manage a Linode SSH key.|
 [linode.cloud.stackscript](./docs/modules/stackscript.md)|Manage a Linode StackScript.|
 [linode.cloud.token](./docs/modules/token.md)|Manage a Linode Token.|

--- a/docs/modules/placement_group_assign.md
+++ b/docs/modules/placement_group_assign.md
@@ -1,0 +1,46 @@
+# placement_group_assign
+
+Manages a single assignment between a Linode and a Placement Group.
+
+**:warning: This module makes use of beta endpoints and requires the `api_version` field be explicitly set to `v4beta`.**
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Assign a Linode to a placement group
+  linode.cloud.placement_group_assign:
+    placement_group_id: 123
+    linode_id: 111
+    state: present
+```
+
+```yaml
+- name: Unassign a Linode from a placement group
+  linode.cloud.placement_group_assign:
+    placement_group_id: 123
+    linode_id: 111
+    state: absent
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `placement_group_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Placement Group for this assignment.   |
+| `linode_id` | <center>`int`</center> | <center>**Required**</center> | The Linode ID to assign or unassign to the Placement Group.   |
+| `compliant_only` | <center>`bool`</center> | <center>Optional</center> | TODO   |
+
+## Return Values
+

--- a/plugins/module_utils/doc_fragments/placement_group_assign.py
+++ b/plugins/module_utils/doc_fragments/placement_group_assign.py
@@ -1,0 +1,14 @@
+"""Documentation fragments for the placement_group_assign module"""
+
+specdoc_examples = ['''
+- name: Assign a Linode to a placement group
+  linode.cloud.placement_group_assign:
+    placement_group_id: 123
+    linode_id: 111
+    state: present''', '''
+- name: Unassign a Linode from a placement group
+  linode.cloud.placement_group_assign:
+    placement_group_id: 123
+    linode_id: 111
+    state: absent
+''']

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all the functionality for Linode Placement Group Assignment."""
+
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.placement_group_assign as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    BETA_DISCLAIMER,
+    global_authors,
+    global_requirements,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+)
+from linode_api4 import PlacementGroup
+
+placement_group_assignment_spec = {
+    # Disable the default values
+    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
+    "placement_group_id": SpecField(
+        type=FieldType.integer,
+        required=True,
+        description="The ID of the Placement Group for this assignment.",
+    ),
+    "linode_id": SpecField(
+        type=FieldType.integer,
+        required=True,
+        description=[
+            "The Linode ID to assign or unassign to the Placement Group."
+        ],
+    ),
+    "compliant_only": SpecField(
+        type=FieldType.bool,
+        description=["TODO"],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Manages a single assignment between a Linode and a Placement Group.", BETA_DISCLAIMER],
+    requirements=global_requirements,
+    author=global_authors,
+    options=placement_group_assignment_spec,
+    examples=docs.specdoc_examples,
+    return_values={},
+)
+
+
+class Module(LinodeModuleBase):
+    """Module for creating and destroying Linode Placement Group Assignment"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.results = {
+            "changed": False,
+            "actions": [],
+        }
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+        )
+
+    def _get_placement_group(self) -> Optional[PlacementGroup]:
+        pg_id: int = self.module.params.get("placement_group_id")
+
+        try:
+            return self.client.load(PlacementGroup, pg_id)
+        except Exception as exception:
+            return self.fail(
+                msg="failed to get placement group {0}: {1}".format(
+                    pg_id, exception
+                )
+            )
+
+    def _handle_present(self) -> None:
+        """
+        Assign a Linode to a placement group.
+        """
+        pg = self._get_placement_group()
+        linode: int = self.module.params.get("linode_id")
+
+        pg.assign([linode], self.module.params.get("compliant_only"))
+
+        self.register_action("Assign linode {0} to placement group {1}".format(linode, pg.id))
+
+    def _handle_absent(self) -> None:
+        """
+        Unassign a Linode from a placement group.
+        """
+        pg = self._get_placement_group()
+        linode: int = self.module.params.get("linode_id")
+
+        pg.unassign([linode])
+
+        self.register_action("Unassign linode {0} from placement group {1}".format(linode, pg.id))
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Placement Group Assignment module"""
+
+        state = kwargs.get("state")
+
+        if state == "absent":
+            self._handle_absent()
+            return self.results
+
+        self._handle_present()
+
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the Placement Group Assignment module"""
+    Module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -8,7 +8,9 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Optional
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.placement_group_assign as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    placement_group_assign as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
     LinodeModuleBase,
 )
@@ -17,11 +19,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
     global_authors,
     global_requirements,
 )
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-)
+from ansible_specdoc.objects import FieldType, SpecDocMeta, SpecField
 from linode_api4 import PlacementGroup
 
 placement_group_assignment_spec = {
@@ -46,7 +44,10 @@ placement_group_assignment_spec = {
 }
 
 SPECDOC_META = SpecDocMeta(
-    description=["Manages a single assignment between a Linode and a Placement Group.", BETA_DISCLAIMER],
+    description=[
+        "Manages a single assignment between a Linode and a Placement Group.",
+        BETA_DISCLAIMER,
+    ],
     requirements=global_requirements,
     author=global_authors,
     options=placement_group_assignment_spec,
@@ -90,7 +91,9 @@ class Module(LinodeModuleBase):
 
         pg.assign([linode], self.module.params.get("compliant_only"))
 
-        self.register_action("Assign linode {0} to placement group {1}".format(linode, pg.id))
+        self.register_action(
+            "Assign linode {0} to placement group {1}".format(linode, pg.id)
+        )
 
     def _handle_absent(self) -> None:
         """
@@ -101,7 +104,9 @@ class Module(LinodeModuleBase):
 
         pg.unassign([linode])
 
-        self.register_action("Unassign linode {0} from placement group {1}".format(linode, pg.id))
+        self.register_action(
+            "Unassign linode {0} from placement group {1}".format(linode, pg.id)
+        )
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for Placement Group Assignment module"""

--- a/tests/integration/targets/placement_group_assign/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_assign/tasks/main.yaml
@@ -1,0 +1,78 @@
+- name: placement_group_basic
+  block:
+    - set_fact:
+          r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode placement group
+      linode.cloud.placement_group:
+        label: 'ansible-test-{{ r }}'
+        region: us-east
+        affinity_type: anti_affinity:local
+        state: present
+      register: pg_created
+
+    - name: Create a Linode instance
+      linode.cloud.instance:
+        label: 'ansible-test-pg-{{ r }}'
+        type: g6-nanode-1
+        region: us-east
+        state: present
+      register: instance
+
+    - name: Assign Linode to the placement group
+      linode.cloud.placement_group_assign:
+        placement_group_id: '{{ pg_created.placement_group.id }}'
+        linode_id: '{{ instance.instance.id }}'
+        state: present
+      register: pg_assign
+
+    - name: Get placement group info
+      linode.cloud.placement_group_info:
+        id: '{{ pg_created.placement_group.id }}'
+      register: pg_assign_info
+
+    - name: Assert that placement group assignment is successful
+      assert:
+        that:
+          - pg_assign.changed
+          - instance.instance.id == pg_assign_info.placement_group.members[0].linode_id
+
+    - name: Unassign Linode to the placement group
+      linode.cloud.placement_group_assign:
+        placement_group_id: '{{ pg_created.placement_group.id }}'
+        linode_id: '{{ instance.instance.id }}'
+        state: absent
+      register: pg_unassign
+
+    - name: Get placement group info
+      linode.cloud.placement_group_info:
+        id: '{{ pg_created.placement_group.id }}'
+      register: pg_unassign_info
+
+    - name: Assert that placement group unassignment is successful
+      assert:
+        that:
+          - pg_unassign.changed
+          - pg_unassign_info.placement_group.members | length < 1
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ instance.instance.label }}'
+            state: absent
+          register: delete_instance
+
+        - name: Delete a placement group
+          linode.cloud.placement_group:
+            label: '{{ pg_created.placement_group.label }}'
+            state: absent
+          register: pg_deleted
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Add a new module `placement_group_assign` to manage the 1:1 assignment between a Linode and a placement group. 

## ✔️ How to Test
Run `pip install --force -r requirements.txt` to install required dependencies.

Also, you need to set up environment variables to test against alpha:

```
export TEST_API_CA=$PWD/cacert.pem
export TEST_API_URL=https://.../
export LINODE_TOKEN=...
```

```
make TEST_ARGS="-v placement_group_assign" test
```

Manual test:

1. In a sandbox environment, i.e. dx-dvenv, run the following ansible playbook
```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a Linode placement group
      linode.cloud.placement_group:
        label: my-ansible-test-pg
        region: us-east
        affinity_type: anti_affinity:local
        state: present
      register: pg_created

    - name: Create a Linode instance
      linode.cloud.instance:
        label: test-pg-instance
        type: g6-nanode-1
        region: us-east
        state: present
      register: instance

    - name: Assign Linode to the placement group
      linode.cloud.placement_group_assign:
        placement_group_id: '{{ pg_created.placement_group.id }}'
        linode_id: '{{ instance.instance.id }}'
        state: present
      register: pg_assign

    - name: Get placement group info
      linode.cloud.placement_group_info:
        id: '{{ pg_created.placement_group.id }}'
      register: pg_assign_info
```
2. Observe that the Linode is successfully assigned to the placement group. And it appears in the members of the placement group info.

3. Run the following playbook to unassign from the placement group
```yaml
    - name: Unassign Linode to the placement group
      linode.cloud.placement_group_assign:
        placement_group_id: '{{ pg_created.placement_group.id }}'
        linode_id: '{{ instance.instance.id }}'
        state: absent
      register: pg_unassign

    - name: Get placement group info
      linode.cloud.placement_group_info:
        id: '{{ pg_created.placement_group.id }}'
      register: pg_unassign_info
```
4. Observe that the Linode is removed from the placement group members.
