### PR TITLE
test: Add cloud firewall to integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ unittest:
 
 create-integration-config:
 ifneq ("${LINODE_TOKEN}", "")
-	touch $INTEGRATION_CONFIG
+	@echo -n > $(INTEGRATION_CONFIG)
+	ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 	@echo "api_token: ${LINODE_TOKEN}" >> $(INTEGRATION_CONFIG);
-    ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 else ifneq ("${LINODE_API_TOKEN}", "")
-	touch $INTEGRATION_CONFIG
+	@echo -n > $(INTEGRATION_CONFIG)
+	ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 	@echo "api_token: ${LINODE_API_TOKEN}" >> $(INTEGRATION_CONFIG);
-    ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 else
 	echo "LINODE_API_TOKEN must be set"; \
 	exit 1;

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,13 @@ unittest:
 
 create-integration-config:
 ifneq ("${LINODE_TOKEN}", "")
-	@echo "api_token: ${LINODE_TOKEN}" > $(INTEGRATION_CONFIG);
+	touch $INTEGRATION_CONFIG
+	@echo "api_token: ${LINODE_TOKEN}" >> $(INTEGRATION_CONFIG);
+    ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 else ifneq ("${LINODE_API_TOKEN}", "")
-	@echo "api_token: ${LINODE_API_TOKEN}" > $(INTEGRATION_CONFIG);
+	touch $INTEGRATION_CONFIG
+	@echo "api_token: ${LINODE_API_TOKEN}" >> $(INTEGRATION_CONFIG);
+    ansible-playbook scripts/create_e2e_cloud_firewall.yaml
 else
 	echo "LINODE_API_TOKEN must be set"; \
 	exit 1;

--- a/scripts/create_e2e_cloud_firewall.yaml
+++ b/scripts/create_e2e_cloud_firewall.yaml
@@ -1,0 +1,66 @@
+- name: Create Linode E2E Cloud Firewall
+  hosts: localhost
+  gather_facts: yes
+
+  vars:
+    linode_api_token: "{{ lookup('env', 'LINODE_TOKEN') | default(lookup('env', 'LINODE_API_TOKEN')) }}"
+    firewall_label: "e2e-firewall-{{ lookup('password', '/dev/null length=6 chars=ascii_letters') }}"
+
+  tasks:
+    - name: Get public IP address of local machine
+      uri:
+        url: "https://api.ipify.org?format=json"
+        return_content: yes
+      register: public_ip
+
+    - name: Set public IP address fact
+      set_fact:
+        public_ipv4: "{{ public_ip.json.ip }}"
+
+    - name: Validate public IPv4 address
+      block:
+        - name: Create Linode firewall with inbound rule
+          linode.cloud.firewall:
+            label: "{{ firewall_label }}"
+            rules:
+              inbound_policy: "DROP"
+              outbound_policy: "ACCEPT"
+              inbound:
+                - label: ssh-accept-inbound-rule
+                  addresses:
+                    ipv4: [ "{{ public_ipv4 }}/32" ]
+                  description: 'ACCEPT SSH from test machine'
+                  ports: '22'
+                  protocol: TCP
+                  action: ACCEPT
+              outbound: []
+            state: present
+          register: create
+        - name: Display Firewall Info
+          debug:
+            var: create
+      rescue:
+        - name: Create Linode firewall without inbound rule
+          linode.cloud.firewall:
+            label: "{{ firewall_label }}"
+            rules:
+              inbound_policy: "DROP"
+              outbound_policy: "ACCEPT"
+              inbound: []
+              outbound: []
+            state: present
+          register: create_without_inbound
+        - name: Display Firewall Info (without inbound rule)
+          debug:
+            var: create
+
+    - name: Return Firewall ID
+      set_fact:
+        firewall_id: "{{ create.firewall.id }}"
+      when: create is defined
+
+    - name: Write firewall ID to configuration file
+      lineinfile:
+        path: "../tests/integration/integration_config.yml"
+        line: "firewall_id: {{ firewall_id }}"
+        insertafter: EOF

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -10,6 +10,7 @@
         type: g6-standard-1
         image: linode/alpine3.19
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Create an image from the instance

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -28,6 +28,7 @@
         wait: false
         state: present
         backups_enabled: true
+        firewall_id : "{{ lookup('env', 'E2E_FIREWALL_ID') }}"
       register: create_backups_enabled
 
     - name: Assert instance created
@@ -99,3 +100,5 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
+    E2E_FIREWALL_ID: '{{ firewall_id }}'
+

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/ubuntu22.04
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_no_set_backup
 
     - name: Assert instance created
@@ -28,7 +29,7 @@
         wait: false
         state: present
         backups_enabled: true
-        firewall_id : "{{ lookup('env', 'E2E_FIREWALL_ID') }}"
+        firewall_id: '{{ firewall_id }}'
       register: create_backups_enabled
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -32,6 +32,7 @@
         state: present
         additional_ipv4:
           - public: true
+        firewall_id : "{{ lookup('env', 'E2E_FIREWALL_ID') }}"
       register: create_additional_ips
 
     - name: Assert instance created
@@ -170,4 +171,5 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
+    E2E_FIREWALL_ID: '{{ firewall_id }}'
 

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -12,6 +12,7 @@
         private_ip: true
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance created
@@ -20,6 +21,16 @@
           - create.changed
           - create.instance.ipv4|length > 1
           - create.networking.ipv4.public[0].address != None
+
+    - name: Get info about the firewall
+      linode.cloud.firewall_info:
+        id: '{{ firewall_id }}'
+      register: firewall_info
+
+    - name: Assert instance is assigned to the firewall
+      assert:
+        that:
+          - firewall_info.devices[0].entity.id == create.instance.id
 
     - name: Create a Linode instance with additional ips and without a root password
       linode.cloud.instance:
@@ -32,7 +43,7 @@
         state: present
         additional_ipv4:
           - public: true
-        firewall_id : "{{ lookup('env', 'E2E_FIREWALL_ID') }}"
+        firewall_id: '{{ firewall_id }}'
       register: create_additional_ips
 
     - name: Assert instance created
@@ -171,5 +182,4 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
-    E2E_FIREWALL_ID: '{{ firewall_id }}'
 

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -13,6 +13,7 @@
         private_ip: true
         booted: true
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -30,6 +30,7 @@
               sda:
                 disk_label: test-disk
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance is created with explicit disks and config

--- a/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
@@ -52,6 +52,7 @@
               sdb:
                 disk_label: swap
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Assert instance is provisioned consuming the image

--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -23,6 +23,7 @@
         wait: false
         booted: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_config_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vpc/tasks/main.yaml
@@ -48,6 +48,7 @@
         wait: false
         booted: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -29,6 +29,7 @@
             stackscript_data:
               package: cowsay
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Assert instance is created with explicit disk and stackscript

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -15,6 +15,7 @@
         private_ip: true
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_interface
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -35,6 +35,7 @@
             ip_ranges: ["10.0.0.5/32"]
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -12,6 +12,7 @@
         private_ip: true
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -14,6 +14,7 @@
         metadata:
           user_data: cool
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_reboot/tasks/main.yaml
+++ b/tests/integration/targets/instance_reboot/tasks/main.yaml
@@ -14,6 +14,7 @@
         rebooted: true
         booted: true
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance created

--- a/tests/integration/targets/instance_region_migration/tasks/main.yaml
+++ b/tests/integration/targets/instance_region_migration/tasks/main.yaml
@@ -10,6 +10,7 @@
         type: g6-nanode-1
         image: linode/ubuntu22.04
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance is created

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -13,6 +13,7 @@
         wait_timeout: 0
         booted: yes
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: timeout
       failed_when: "'timeout period expired' not in timeout.msg"
   always:

--- a/tests/integration/targets/instance_type_change/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_change/tasks/main.yaml
@@ -10,6 +10,7 @@
         type: g6-nanode-1
         image: linode/ubuntu22.04
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert instance is created

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -10,6 +10,7 @@
         type: g6-standard-1
         image: linode/alpine3.19
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Create another Linode Instance
@@ -19,6 +20,7 @@
         type: g6-standard-1
         image: linode/alpine3.19
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance_2
 
     - name: Swap Both IPs

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/alpine3.19
         wait: no
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Get ip_info about the instance's primary IP

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/ubuntu22.04
         wait: no
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Get info about the instance's primary IP

--- a/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/ubuntu22.04
         wait: no
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - name: Extract the IPv6 SLAAC address

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -23,6 +23,7 @@
         image: linode/alpine3.19
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create_shared
 
     - name: Create an IPv6 range

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/alpine3.19
         wait: no
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - set_fact:

--- a/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_basic/tasks/main.yaml
@@ -8,6 +8,7 @@
         label: 'ansible-test-empty-{{ r }}'
         region: us-ord
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_empty_nodebalancer
 
     - name: Assert empty NodeBalancer is created

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -8,6 +8,7 @@
         label: 'ansible-test-empty-{{ r }}'
         region: us-ord
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create
 
     - name: Assert empty NodeBalancer is created

--- a/tests/integration/targets/nodebalancer_node/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_node/tasks/main.yaml
@@ -21,6 +21,7 @@
             protocol: http
             proxy_protocol: none
             stickiness: none
+        firewall_id: '{{ firewall_id }}'
       register: nb
 
     - name: Assert nodebalancer is created with basic configs

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -13,7 +13,7 @@
         root_pass: Fn$$oobar123
         private_ip: true
         state: present
-
+        firewall_id: '{{ firewall_id }}'
       register: node1_inst
 
     - name: Assert node1 is created

--- a/tests/integration/targets/nodebalancer_reordered_tags/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_reordered_tags/tasks/main.yaml
@@ -12,6 +12,7 @@
           - test2
           - test3
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_nodebalancer
 
     - name: Assert NodeBalancer is created

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -12,6 +12,7 @@
         root_pass: Fn$$oobar123
         private_ip: true
         state: present
+        firewall_id: '{{ firewall_id }}'
 
       register: node_inst
 
@@ -27,6 +28,7 @@
         label: 'ansible-nb-populated-{{ r }}'
         region: us-ord
         state: present
+        firewall_id: '{{ firewall_id }}'
         configs:
           - port: 80
             algorithm: roundrobin

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -15,6 +15,7 @@
         private_ip: true
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Assert instance created

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -15,6 +15,7 @@
         private_ip: true
         wait: false
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_instance
 
     - name: Resolve a VLAN

--- a/tests/integration/targets/volume_basic/tasks/main.yaml
+++ b/tests/integration/targets/volume_basic/tasks/main.yaml
@@ -11,6 +11,7 @@
         image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         state: present
+        firewall_id: '{{ firewall_id }}'
       register: create_inst
 
     - name: Assert instance is created


### PR DESCRIPTION
## 📝 Description

This PR implements Linode Cloud Firewall for integration tests to enhance security.
More info can be found in [Best Practices to keep VMs safe](https://docs.google.com/document/d/1XowpyiU09AfsXxtt1Jnmeev8W9o6GuwaShW7kK-zjlM/edit?parentUrl=https%3A%2F%2Fac-aloha.akamai.com%2Fhome%2Flinode-vm-best-practices%2Flinode-vm-best-practices&iframeId=b8819df3-0010-5c00-8d3a-26aa6d14b1a5#heading=h.r7cjnl29apd1).

Note: GHA does not support ipv6 so only ipv4 will get added in firewall during GHA execution. However, ipv6 will get added automatically if ipv6 address and route exist

## ✔️ How to Test

`make test`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**