### PR TITLE
fix: Resolve issues in firewall diff logic

### DIFF
--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -67,6 +67,7 @@ Manage Linode Firewalls.
 | [`devices` (sub-options)](#devices) | <center>`list`</center> | <center>Optional</center> | The devices that are attached to this Firewall.  **(Updatable)** |
 | [`rules` (sub-options)](#rules) | <center>`dict`</center> | <center>Optional</center> | The inbound and outbound access rules to apply to this Firewall.  **(Updatable)** |
 | `status` | <center>`str`</center> | <center>Optional</center> | The status of this Firewall.  **(Updatable)** |
+| `tags` | <center>`list`</center> | <center>Optional</center> | A list of tags to apply to this Firewall.  **(Updatable)** |
 
 ### devices
 

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -153,6 +153,11 @@ linode_firewall_spec: dict = {
         editable=True,
         description=["The status of this Firewall."],
     ),
+    "tags": SpecField(
+        type=FieldType.list,
+        editable=True,
+        description=["A list of tags to apply to this Firewall."]
+    ),
     "state": SpecField(
         type=FieldType.string,
         description=["The desired state of the target."],

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -355,17 +355,20 @@ class LinodeFirewall(LinodeModuleBase):
     def _change_rules(self) -> Optional[dict]:
         """Updates remote firewall rules relative to user-supplied new rules,
         and returns whether anything changed."""
-        local_rules = filter_null_values_recursive(self.module.params["rules"])
-        remote_rules = filter_null_values_recursive(
-            mapping_to_dict(self._firewall.rules)
+        local_rules = (
+            filter_null_values_recursive(self.module.params["rules"]) or {}
+        )
+        remote_rules = (
+            filter_null_values_recursive(mapping_to_dict(self._firewall.rules))
+            or {}
         )
 
-        # user did not specify any rules updates
-        if local_rules is None:
-            local_rules = {}
+        # Ensure only user-defined rules will be used for diffing
+        configurable_fields = set(linode_firewall_rules_spec.keys())
 
-        if remote_rules is None:
-            remote_rules = {}
+        remote_rules = {
+            k: v for k, v in remote_rules.items() if k in configurable_fields
+        }
 
         # Normalize IP addresses for all rules
         for direction in ["inbound", "outbound"]:
@@ -403,6 +406,7 @@ class LinodeFirewall(LinodeModuleBase):
             filter_null_values(self.module.params),
             set(MUTABLE_FIELDS),
             self.register_action,
+            ignore_keys={"devices", "rules"},
         )
 
         changes = self._change_rules()

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -156,7 +156,7 @@ linode_firewall_spec: dict = {
     "tags": SpecField(
         type=FieldType.list,
         editable=True,
-        description=["A list of tags to apply to this Firewall."]
+        description=["A list of tags to apply to this Firewall."],
     ),
     "state": SpecField(
         type=FieldType.string,


### PR DESCRIPTION
## 📝 Description

This pull request resolves the following issues present in the `firewall` module's diff logic:
* Diffs are always detected on the `rules` field due to a new `fingerprint` field returned by the API
* An error is raised when attempting to update devices because the `devices` field was not excluded from the key/value update logic

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make TEST_ARGS="-v firewall_basic firewall_device firewall_icmp firewall_list firewall_update" test
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
  - name: Create an Instance
    linode.cloud.instance:
      label: my-instance
      type: g6-nanode-1
      region: us-mia
      state: present
    register: instance

  - name: Create a Linode Firewall
    linode.cloud.firewall:
      label: "my-firewall"
      rules:
        inbound_policy: DROP
        inbound:
          - label: allow-http-in
            addresses:
              ipv6: ["ff00::/8"]
            ports: "80,443"
            protocol: TCP
            action: ACCEPT

        outbound_policy: DROP
        outbound: []
      state: present

  - name: Refresh the firewall
    linode.cloud.firewall:
      label: "my-firewall"
      rules:
        inbound_policy: DROP
        inbound:
          - label: allow-http-in
            addresses:
              ipv6: ["ff00::/8"]
            ports: "80,443"
            protocol: TCP
            action: ACCEPT

        outbound_policy: DROP
        outbound: []
      state: present
    register: refresh

  - name: Assert that the firewall rules have not been updated
    assert:
      that:
        - not refresh.changed

  - name: Update the firewall's devices
    linode.cloud.firewall:
      label: "my-firewall"
      devices:
        - id: "{{ instance.instance.id }}"
          type: linode
      rules:
        inbound_policy: DROP
        inbound:
          - label: allow-http-in
            addresses:
              ipv6: [ "ff00::/8" ]
            ports: "80,443"
            protocol: TCP
            action: ACCEPT

        outbound_policy: DROP
        outbound: [ ]
      state: present
    register: update_devices

  - name: Assert that the firewall's devices have been updated
    assert:
      that:
        - update_devices.changed
        - update_devices.devices[0].entity.id == instance.instance.id
```
2. Ensure all assertions pass and the playbook finished running successfully.
