### PR TITLE
test: fix assertion in instance_interfaces_vpc

### DIFF
--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -93,7 +93,7 @@
       assert:
         that:
           - subnet_info.subnet.linodes[0].id == update_instance.instance.id
-          - subnet_info.subnet.linodes[0].interfaces[1].id == update_instance.configs[0].interfaces[1].id
+          - subnet_info.subnet.linodes[0].interfaces[0].id == update_instance.configs[0].interfaces[1].id
 
     - name: Unchanged instance interface
       linode.cloud.instance:


### PR DESCRIPTION
## 📝 Description

Fixing assertion that is causing `Assert subnet updated` to fail in `instance_interfaces_vpc`

## ✔️ How to Test

`make TEST_ARGS="-v instance_interfaces_vpc" test`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**