### PR TITLE
new: Add support for LKE cluster control plane ACLs

### DIFF
--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -104,6 +104,13 @@ Manage Linode LKE clusters.
         ```json
         {
           "control_plane": {
+            "acl": {
+                "addresses": {
+                    "ipv4": ["0.0.0.0/0"], 
+                    "ipv6": ["2001:db8:1234:abcd::/64"]
+                }, 
+                "enabled": true
+            },
             "high_availability": true
           },
           "created": "2019-09-12T21:25:30Z",

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -61,7 +61,7 @@ Manage Linode LKE clusters.
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |
 | `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`; Updatable)** |
-| [`acl` (sub-options)](#acl) | <center>`dict`</center> | <center>Optional</center> | The ACL configuration for this cluster's control plane.  **(Updatable)** |
+| [`acl` (sub-options)](#acl) | <center>`dict`</center> | <center>Optional</center> | The ACL configuration for this cluster's control plane. NOTE: Control Plane ACLs may not currently be available to all users.  **(Updatable)** |
 | [`node_pools` (sub-options)](#node_pools) | <center>`list`</center> | <center>Optional</center> | A list of node pools to configure the cluster with  **(Updatable)** |
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -61,9 +61,24 @@ Manage Linode LKE clusters.
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |
 | `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`; Updatable)** |
+| [`acl` (sub-options)](#acl) | <center>`dict`</center> | <center>Optional</center> | The ACL configuration for this cluster's control plane.  **(Updatable)** |
 | [`node_pools` (sub-options)](#node_pools) | <center>`list`</center> | <center>Optional</center> | A list of node pools to configure the cluster with  **(Updatable)** |
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |
+
+### acl
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `enabled` | <center>`bool`</center> | <center>Optional</center> | Whether control plane ACLs are enabled for this cluster.  **(Updatable)** |
+| [`addresses` (sub-options)](#addresses) | <center>`dict`</center> | <center>Optional</center> | The addresses allowed to access this cluster's control plane.  **(Updatable)** |
+
+### addresses
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `ipv4` | <center>`list`</center> | <center>Optional</center> | A list of IPv4 addresses to grant access to this cluster's control plane.   |
+| `ipv6` | <center>`list`</center> | <center>Optional</center> | A list of IPv6 addresses to grant access to this cluster's control plane.   |
 
 ### node_pools
 

--- a/docs/modules/lke_cluster_info.md
+++ b/docs/modules/lke_cluster_info.md
@@ -42,6 +42,13 @@ Get info about a Linode LKE cluster.
         ```json
         {
           "control_plane": {
+            "acl": {
+                "addresses": {
+                    "ipv4": ["0.0.0.0/0"], 
+                    "ipv6": ["2001:db8:1234:abcd::/64"]
+                }, 
+                "enabled": true
+            },
             "high_availability": true
           },
           "created": "2019-09-12T21:25:30Z",

--- a/plugins/module_utils/doc_fragments/lke_cluster.py
+++ b/plugins/module_utils/doc_fragments/lke_cluster.py
@@ -32,6 +32,13 @@ examples = ['''
 
 result_cluster = ['''{
   "control_plane": {
+    "acl": {
+        "addresses": {
+            "ipv4": ["0.0.0.0/0"], 
+            "ipv6": ["2001:db8:1234:abcd::/64"]
+        }, 
+        "enabled": true
+    },
     "high_availability": true
   },
   "created": "2019-09-12T21:25:30Z",

--- a/plugins/module_utils/linode_lke_shared.py
+++ b/plugins/module_utils/linode_lke_shared.py
@@ -1,3 +1,7 @@
+"""
+Contains shared helper functions related to LKE.
+"""
+
 from typing import Any, Dict, Optional
 
 from linode_api4 import ApiError, LKECluster

--- a/plugins/module_utils/linode_lke_shared.py
+++ b/plugins/module_utils/linode_lke_shared.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, Optional
+
+from linode_api4 import ApiError, LKECluster
+
+
+def safe_get_cluster_acl(cluster: LKECluster) -> Optional[Dict[str, Any]]:
+    """
+    Gets the control plane ACL configuration of a cluster, returning None
+    if the user does not currently have access to LKE ACLs.
+    """
+    # Invalidate the cached ACL
+    cluster.invalidate()
+
+    try:
+        return cluster.control_plane_acl.dict
+    except ApiError as err:
+        if err.status not in (404, 400):
+            raise err
+
+    return None

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -635,9 +635,7 @@ class LinodeLKECluster(LinodeModuleBase):
         if cluster is None:
             cluster = self._create_cluster()
 
-        acl = None
-
-        self._update_cluster(cluster, acl)
+        self._update_cluster(cluster)
 
         # Force lazy-loading
         cluster._api_get()

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -31,11 +31,7 @@ from ansible_specdoc.objects import (
     SpecField,
     SpecReturnValue,
 )
-from linode_api4 import (
-    ApiError,
-    KubeVersion,
-    LKECluster,
-)
+from linode_api4 import ApiError, KubeVersion, LKECluster
 
 linode_lke_cluster_acl_addresses = {
     "ipv4": SpecField(

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -162,7 +162,7 @@ class LinodeLKEClusterInfo(LinodeModuleBase):
 
         # We need to inject the control plane ACL configuration into the cluster's JSON
         # because it is not returned from the cluster GET endopint
-        cluster["control_plane"]["acl"] = self._safe_get_cluster_acl(cluster)
+        cluster_json["control_plane"]["acl"] = self._safe_get_cluster_acl(cluster)
 
         self.results["cluster"] = cluster_json
 

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -180,14 +180,12 @@ class LinodeLKEClusterInfo(LinodeModuleBase):
         acl = None
 
         try:
-            acl = cluster.control_plane_acl
+            acl = cluster.control_plane_acl.dict
         except ApiError as err:
             if err.status not in (400, 404):
                 raise err
 
-        self.results["cluster"]["control_plane"]["acl"] = (
-            None if acl is None else acl.dict
-        )
+        self.results["cluster"]["control_plane"]["acl"] = acl
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for LKE cluster info module"""

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -185,7 +185,9 @@ class LinodeLKEClusterInfo(LinodeModuleBase):
             if err.status not in (400, 404):
                 raise err
 
-        self.results["cluster"]["control_plane"]["acl"] = acl
+        self.results["cluster"]["control_plane"]["acl"] = (
+            None if acl is None else acl.dict
+        )
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for LKE cluster info module"""

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -1,0 +1,132 @@
+- name: lke_cluster_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Resolve the latest K8s version
+      linode.cloud.lke_version_list: {}
+      register: get_lke_versions
+
+    - set_fact:
+        kube_version: "{{ get_lke_versions.lke_versions[0].id }}"
+
+    - name: Create a Linode LKE cluster
+      linode.cloud.lke_cluster:
+        label: "ansible-test-{{ r }}"
+        region: us-mia
+        k8s_version: "{{ kube_version }}"
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        acl:
+          enabled: true
+          addresses:
+            ipv4:
+              - 0.0.0.0/0
+            ipv6:
+              - 2001:db8:1234:abcd::/64
+        skip_polling: true
+        state: present
+      register: create_cluster
+
+    - name: Assert LKE cluster is created
+      assert:
+        that:
+          - create_cluster.cluster.k8s_version == kube_version
+          - create_cluster.cluster.region == "us-mia"
+          - create_cluster.cluster.control_plane.acl.enabled
+          - create_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "0.0.0.0/0"
+          - create_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
+          - create_cluster.node_pools[0].type == "g6-standard-1"
+          - create_cluster.node_pools[0].count == 1
+
+    - name: Update the ACL configuration for the LKE cluster
+      linode.cloud.lke_cluster:
+        label: "ansible-test-{{ r }}"
+        region: us-mia
+        k8s_version: "{{ kube_version }}"
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        acl:
+          enabled: true
+          addresses:
+            ipv4:
+              - 10.0.0.5/32
+            ipv6: []
+        skip_polling: true
+        state: present
+      register: update_cluster
+
+    - name: Assert LKE cluster is updated
+      assert:
+        that:
+          - update_cluster.changed
+          - update_cluster.cluster.k8s_version == kube_version
+          - update_cluster.cluster.region == "us-mia"
+          - update_cluster.cluster.control_plane.acl.enabled
+          - update_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6 == None
+
+
+    - name: Don't change the cluster
+      linode.cloud.lke_cluster:
+        label: "ansible-test-{{ r }}"
+        region: us-mia
+        k8s_version: "{{ kube_version }}"
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        acl:
+          enabled: true
+          addresses:
+            ipv4:
+              - 10.0.0.5/32
+            ipv6: []
+        skip_polling: true
+        state: present
+      register: unchanged_cluster
+
+    - name: Assert LKE cluster is unchanged
+      assert:
+        that:
+          - not unchanged_cluster.cluster.changed
+          - unchanged_cluster.cluster.control_plane.acl.enabled
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.1/32"
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 == None
+
+
+    - name: Disable ACLs on the cluster
+      linode.cloud.lke_cluster:
+        label: "ansible-test-{{ r }}"
+        region: us-mia
+        k8s_version: "{{ kube_version }}"
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        acl:
+          enabled: false
+        skip_polling: true
+        state: present
+      register: acl_disabled_cluster
+
+    - name: Assert ACLs have been disabled on this cluster
+      assert:
+        that:
+          - acl_disabled_cluster.cluster.changed
+          - not acl_disabled_cluster.cluster.control_plane.acl.enabled
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the LKE cluster
+          linode.cloud.lke_cluster:
+            label: "{{ create_cluster.cluster.label }}"
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: "{{ ua_prefix }}"
+    LINODE_API_TOKEN: "{{ api_token }}"
+    LINODE_API_URL: "{{ api_url }}"
+    LINODE_API_VERSION: "{{ api_version }}"
+    LINODE_CA: "{{ ca_file or '' }}"
+

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -90,9 +90,9 @@
     - name: Assert LKE cluster is unchanged
       assert:
         that:
-          - not unchanged_cluster.cluster.changed
+          - not unchanged_cluster.changed
           - unchanged_cluster.cluster.control_plane.acl.enabled
-          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.1/32"
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
           - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 == None
 
 
@@ -113,7 +113,7 @@
     - name: Assert ACLs have been disabled on this cluster
       assert:
         that:
-          - acl_disabled_cluster.cluster.changed
+          - acl_disabled_cluster.changed
           - not acl_disabled_cluster.cluster.control_plane.acl.enabled
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

This pull request adds support for configuring the ACL for an LKE cluster's control plane using the `lke_cluster` module.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally, run `make install`, and configured your Linode account according to the description of TPT-2676.

### Integration Testing

```
make TEST_ARGS="-v lke_cluster_basic" test
make TEST_ARGS="-v lke_cluster_acl" test
make TEST_ARGS="-v lke_cluster_info_ro" test
```

### Limited Access Integration Testing

1. Configure your Linode account to NOT have access to LKE ACLs.
2. Run the following integration tests:

```
make TEST_ARGS="-v lke_cluster_basic" test
make TEST_ARGS="-v lke_cluster_info_ro" test
```

### Manual Testing

1. In an Ansible Collection sandbox environment (e.g. dx-devenv), run the following playbook in verbose mode:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Resolve all available K8s versions
      linode.cloud.lke_version_list: {}
      register: get_lke_versions

    - set_fact:
        lke_versions: '{{ get_lke_versions.lke_versions|sort(attribute="id") }}'

    - name: Create a Linode LKE cluster
      linode.cloud.lke_cluster:
        label: "lke-acl-test"
        region: us-mia
        k8s_version: "{{ lke_versions[0].id }}"
        node_pools:
          - type: g6-standard-1
            count: 1
        acl:
          enabled: true
          addresses:
            ipv4:
              - 0.0.0.0/0
            ipv6:
              - 2001:db8:1234:abcd::/64
        skip_polling: true
        state: present

    - name: Get info about the cluster
      linode.cloud.lke_cluster_info:
        label: "lke-acl-test"
```

2. Ensure the playbook runs successfully and the resulting cluster's ACL configuration matches the expected ACL configuration.
3. Make arbitrary changes to the ACL configuration in this playbook.
4. Re-run the playbook and ensure all functionality works as expected.

