### PR TITLE
new: Support for Multicluster OBJ in object_keys module

### DIFF
--- a/docs/modules/object_keys.md
+++ b/docs/modules/object_keys.md
@@ -47,14 +47,16 @@ Manage Linode Object Storage Keys.
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The unique label to give this key.   |
 | [`access` (sub-options)](#access) | <center>`list`</center> | <center>Optional</center> | A list of access permissions to give the key.   |
+| `regions` | <center>`list`</center> | <center>Optional</center> | A list of regions to scope this key to.  **(Updatable)** |
 
 ### access
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `cluster` | <center>`str`</center> | <center>**Required**</center> | The id of the cluster that the provided bucket exists under.   |
 | `bucket_name` | <center>`str`</center> | <center>**Required**</center> | The name of the bucket to set the key's permissions for.   |
 | `permissions` | <center>`str`</center> | <center>**Required**</center> | The permissions to give the key.  **(Choices: `read_only`, `write_only`, `read_write`)** |
+| `region` | <center>`str`</center> | <center>Optional</center> | The region of the cluster that the provided bucket exists under.  **(Conflicts With: `cluster`)** |
+| `cluster` | <center>`str`</center> | <center>Optional</center> | The id of the cluster that the provided bucket exists under.  **(Conflicts With: `region`)** |
 
 ## Return Values
 

--- a/docs/modules/object_keys.md
+++ b/docs/modules/object_keys.md
@@ -22,11 +22,21 @@ Manage Linode Object Storage Keys.
 ```
 
 ```yaml
-- name: Create a limited Object Storage key
+- name: Create an Object Storage key limited to specific regions
+  linode.cloud.object_keys:
+    label: 'my-region-limited-key'
+    regions:
+        - us-mia
+        - us-ord
+    state: present
+```
+
+```yaml
+- name: Create an Object Storage key limited to specific buckets
   linode.cloud.object_keys:
     label: 'my-limited-key'
     access:
-      - cluster: us-east-1
+      - cluster: us-mia
         bucket_name: my-bucket
         permissions: read_write
     state: present
@@ -65,18 +75,33 @@ Manage Linode Object Storage Keys.
     - Sample Response:
         ```json
         {
-          "access_key": "ACCESSKEY",
+          "access_key": "redacted",
           "bucket_access": [
             {
-              "bucket_name": "example-bucket",
-              "cluster": "ap-south-1",
-              "permissions": "read_only"
+              "bucket_name": "my-bucket",
+              "cluster": "us-iad-1",
+              "permissions": "read_write",
+              "region": "us-iad"
             }
           ],
-          "id": 123,
+          "id": 12345,
           "label": "my-key",
           "limited": true,
-          "secret_key": "SECRETKEY"
+          "regions": [
+            {
+              "id": "us-iad",
+              "s3_endpoint": "us-iad-1.linodeobjects.com"
+            },
+            {
+              "id": "us-ord",
+              "s3_endpoint": "us-ord-1.linodeobjects.com"
+            },
+            {
+              "id": "us-sea",
+              "s3_endpoint": "us-sea-1.linodeobjects.com"
+            }
+          ],
+          "secret_key": "[REDACTED]"
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/object-storage/#object-storage-key-view__responses) for a list of returned fields

--- a/plugins/module_utils/doc_fragments/object_keys.py
+++ b/plugins/module_utils/doc_fragments/object_keys.py
@@ -5,11 +5,18 @@ specdoc_examples = ['''
   linode.cloud.object_keys:
     label: 'my-fullaccess-key'
     state: present''', '''
-- name: Create a limited Object Storage key
+- name: Create an Object Storage key limited to specific regions
+  linode.cloud.object_keys:
+    label: 'my-region-limited-key'
+    regions:
+        - us-mia
+        - us-ord
+    state: present''', '''
+- name: Create an Object Storage key limited to specific buckets
   linode.cloud.object_keys:
     label: 'my-limited-key'
     access:
-      - cluster: us-east-1
+      - cluster: us-mia
         bucket_name: my-bucket
         permissions: read_write
     state: present''', '''
@@ -19,16 +26,31 @@ specdoc_examples = ['''
     state: absent''']
 
 result_key_samples = ['''{
-  "access_key": "ACCESSKEY",
+  "access_key": "redacted",
   "bucket_access": [
     {
-      "bucket_name": "example-bucket",
-      "cluster": "ap-south-1",
-      "permissions": "read_only"
+      "bucket_name": "my-bucket",
+      "cluster": "us-iad-1",
+      "permissions": "read_write",
+      "region": "us-iad"
     }
   ],
-  "id": 123,
+  "id": 12345,
   "label": "my-key",
   "limited": true,
-  "secret_key": "SECRETKEY"
+  "regions": [
+    {
+      "id": "us-iad",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"
+    },
+    {
+      "id": "us-ord",
+      "s3_endpoint": "us-ord-1.linodeobjects.com"
+    },
+    {
+      "id": "us-sea",
+      "s3_endpoint": "us-sea-1.linodeobjects.com"
+    }
+  ],
+  "secret_key": "[REDACTED]"
 }''']

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -218,7 +218,7 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
 
     def _attempt_update_key(
         self, key: ObjectStorageKeys, params: Dict[str, Any]
-    ):
+    ) -> None:
         """
         Attempts to update the given OBJ key.
         """
@@ -260,7 +260,7 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
 
         params = self.module.params
         label: str = params.get("label")
-        access: dict = params.get("access")
+        access: List[Dict[str, Any]] = params.get("access")
         regions: List[str] = params.get("regions")
 
         self._key = self._get_key_by_label(label)

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -192,7 +192,10 @@ class LinodeObjectStorageKeys(LinodeModuleBase):
             )
             self.register_action("Created key {0}".format(label))
 
-        self._attempt_update_key(self._key, params)
+            # NOTE: If the key is refreshed at all after creation,
+            # make sure you preserve the secret_key :)
+        else:
+            self._attempt_update_key(self._key, params)
 
         self.results["key"] = self._key._raw_json
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-linode_api4>=5.17.0
+# TODO: Revert before merging to dev
+# linode-api4>=5.17.0
+git+https://github.com/zliang-akamai/linode_api4-python@zhiwei/bucket-key-update
+
 polling>=0.3.2
 types-requests==2.32.0.20240602
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # TODO(Multicluster OBJ): Revert before merging to dev
 # linode-api4>=5.17.0
-git+https://github.com/zliang-akamai/linode_api4-python@zhiwei/bucket-key-update
+git+https://github.com/linode/linode_api4-python@proj/multicluster-obj
 
 polling>=0.3.2
 types-requests==2.32.0.20240622

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -58,10 +58,10 @@
 
     - name: Create an S3 bucket using the key
       amazon.aws.s3_bucket:
-        s3_url: 'https://{{ update.key.regions[0].s3_endpoint }}/'
-        aws_access_key: '{{ create.key.access_key }}'
-        aws_secret_key: '{{ create.key.secret_key }}'
-        name: 'test-ansible-bucket-{{ r }}'
+        s3_url: "https://{{ update.key.regions[0].s3_endpoint }}/"
+        aws_access_key: "{{ create.key.access_key }}"
+        aws_secret_key: "{{ create.key.secret_key }}"
+        name: "test-ansible-bucket-{{ r }}"
         state: present
       register: create_bucket
 
@@ -141,9 +141,9 @@
       block:
         - name: Delete the OBJ bucket
           amazon.aws.s3_bucket:
-            s3_url: 'https://{{ update.key.regions[0].s3_endpoint }}//'
-            aws_access_key: '{{ create.key.access_key }}'
-            aws_secret_key: '{{ create.key.secret_key }}'
+            s3_url: "https://{{ update.key.regions[0].s3_endpoint }}//"
+            aws_access_key: "{{ create.key.access_key }}"
+            aws_secret_key: "{{ create.key.secret_key }}"
             name: "{{ create_bucket.name }}"
             state: absent
           register: delete_bucket
@@ -159,8 +159,8 @@
             state: absent
 
   environment:
-    LINODE_UA_PREFIX: '{{ ua_prefix }}'
-    LINODE_API_TOKEN: '{{ api_token }}'
-    LINODE_API_URL: '{{ api_url }}'
-    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_UA_PREFIX: "{{ ua_prefix }}"
+    LINODE_API_TOKEN: "{{ api_token }}"
+    LINODE_API_URL: "{{ api_url }}"
+    LINODE_API_VERSION: "{{ api_version }}"
     LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -55,34 +55,104 @@
           - update.changed
           - update.key.regions | length == 1
           - update.key.regions[0].id == "us-ord"
-#    - name: Create an OBJ key with access restrictions
-#      linode.cloud.object_keys:
-#        label: 'test-ansible-key-access-{{ r }}'
-#        access:
-#          - cluster: us-ord-1
-#            bucket_name: '{{ create_bucket.name }}'
-#            permissions: read_write
-#          - cluster: us-ord-1
-#            bucket_name: '{{ create_bucket.name }}'
-#            permissions: read_only
-#        state: present
-#      register: create_access
-#
-#    - name: Assert key created and access is valid
-#      assert:
-#        that:
-#          - create_access.changed
-#          - 'not "REDACTED" in create_access.key.secret_key'
-#          - create_access.key.bucket_access[0].cluster == 'us-ord-1'
-#          - create_access.key.bucket_access[0].bucket_name == create_bucket.name
-#          - create_access.key.bucket_access[0].permissions == 'read_write'
-#          - create_access.key.bucket_access[1].cluster == 'us-ord-1'
-#          - create_access.key.bucket_access[1].bucket_name == create_bucket.name
-#          - create_access.key.bucket_access[1].permissions == 'read_only'
+
+    - name: Create an S3 bucket using the key
+      amazon.aws.s3_bucket:
+        s3_url: 'https://{{ update.key.regions[0].s3_endpoint }}/'
+        aws_access_key: '{{ create.key.access_key }}'
+        aws_secret_key: '{{ create.key.secret_key }}'
+        name: 'test-ansible-bucket-{{ r }}'
+        state: present
+      register: create_bucket
+
+    - name: Assert bucket was created
+      assert:
+        that:
+          - create_bucket.changed
+
+    - name: Create an OBJ key scoped to the new bucket
+      linode.cloud.object_keys:
+        label: "test-ansible-key-scoped-{{ r }}"
+        regions:
+          - us-mia
+        access:
+          - region: "{{ update.key.regions[0].id }}"
+            bucket_name: "{{ create_bucket.name }}"
+            permissions: read_write
+        state: present
+      register: create_scoped
+
+    - name: Assert the scoped key was created
+      assert:
+        that:
+          - create_scoped.changed
+          - create_scoped.key.bucket_access[0].region == update.key.regions[0].id
+          - create_scoped.key.bucket_access[0].bucket_name == create_bucket.name
+          - create_scoped.key.bucket_access[0].permissions == "read_write"
+          - create_scoped.key.regions[0].id in ("us-ord", "us-mia")
+          - create_scoped.key.regions[1].id in ("us-ord", "us-mia")
+
+    - name: Refresh the scoped key
+      linode.cloud.object_keys:
+        label: "{{ create_scoped.key.label }}"
+        regions:
+          - us-mia
+        access:
+          - cluster: "{{ update.key.regions[0].id }}-1"
+            bucket_name: "{{ create_bucket.name }}"
+            permissions: read_write
+        state: present
+      register: refresh_scoped
+
+    - name: Assert the scoped key was not changed
+      assert:
+        that:
+          - not refresh_scoped.changed
+
+    - name: Refresh the scoped key (region -> cluster in access grant)
+      linode.cloud.object_keys:
+        label: "{{ create_scoped.key.label }}"
+        regions:
+          - us-mia
+        access:
+          - cluster: "{{ update.key.regions[0].id }}-1"
+            bucket_name: "{{ create_bucket.name }}"
+            permissions: read_write
+        state: present
+      register: refresh_scoped
+
+    - name: Assert the scoped key was not changed
+      assert:
+        that:
+          - not refresh_scoped.changed
+
+    - name: Update the scoped key; expect failure
+      linode.cloud.object_keys:
+        label: "{{ create_scoped.key.label }}"
+        regions:
+          - us-mia
+        access: []
+        state: present
+      register: update_scoped
+      failed_when: "'`access` is not an updatable field' not in update_scoped.msg"
 
   always:
     - ignore_errors: yes
       block:
+        - name: Delete the OBJ bucket
+          amazon.aws.s3_bucket:
+            s3_url: 'https://{{ update.key.regions[0].s3_endpoint }}//'
+            aws_access_key: '{{ create.key.access_key }}'
+            aws_secret_key: '{{ create.key.secret_key }}'
+            name: "{{ create_bucket.name }}"
+            state: absent
+          register: delete_bucket
+
+        - name: Delete the scoped OBJ key
+          linode.cloud.object_keys:
+            label: "{{ create_scoped.key.label }}"
+            state: absent
+
         - name: Delete the OBJ key
           linode.cloud.object_keys:
             label: "{{ create.key.label }}"

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -34,9 +34,27 @@
     - name: Assert OBJ key was not updated
       assert:
         that:
-          # - not refresh.changed
+          - not refresh.changed
           - "'REDACTED' in refresh.key.secret_key"
+          - refresh.key.regions[0].id in ("us-mia", "us-iad")
+          - refresh.key.regions[0].s3_endpoint != None
+          - refresh.key.regions[1].id in ("us-mia", "us-iad")
+          - refresh.key.regions[1].s3_endpoint != None
 
+    - name: Update the regions for the OBJ key
+      linode.cloud.object_keys:
+        label: "{{ create.key.label }}"
+        regions:
+          - us-ord
+        state: present
+      register: update
+
+    - name: Assert OBJ key was updated
+      assert:
+        that:
+          - update.changed
+          - update.key.regions | length == 1
+          - update.key.regions[0].id == "us-ord"
 #    - name: Create an OBJ key with access restrictions
 #      linode.cloud.object_keys:
 #        label: 'test-ansible-key-access-{{ r }}'

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -1,0 +1,78 @@
+- name: object_keys_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create an OBJ key
+      linode.cloud.object_keys:
+        label: "test-ansible-key-{{ r }}"
+        regions:
+          - us-mia
+          - us-iad
+        state: present
+      register: create
+
+    - name: Assert OBJ key was created successfully
+      assert:
+        that:
+          - create.changed
+          - "not 'REDACTED' in create.key.secret_key"
+          - create.key.regions[0].id in ("us-mia", "us-iad")
+          - create.key.regions[0].s3_endpoint != None
+          - create.key.regions[1].id in ("us-mia", "us-iad")
+          - create.key.regions[1].s3_endpoint != None
+
+    - name: Refresh the OBJ key
+      linode.cloud.object_keys:
+        label: "{{ create.key.label }}"
+        regions:
+          - us-mia
+          - us-iad
+        state: present
+      register: refresh
+
+    - name: Assert OBJ key was not updated
+      assert:
+        that:
+          # - not refresh.changed
+          - "'REDACTED' in refresh.key.secret_key"
+
+#    - name: Create an OBJ key with access restrictions
+#      linode.cloud.object_keys:
+#        label: 'test-ansible-key-access-{{ r }}'
+#        access:
+#          - cluster: us-ord-1
+#            bucket_name: '{{ create_bucket.name }}'
+#            permissions: read_write
+#          - cluster: us-ord-1
+#            bucket_name: '{{ create_bucket.name }}'
+#            permissions: read_only
+#        state: present
+#      register: create_access
+#
+#    - name: Assert key created and access is valid
+#      assert:
+#        that:
+#          - create_access.changed
+#          - 'not "REDACTED" in create_access.key.secret_key'
+#          - create_access.key.bucket_access[0].cluster == 'us-ord-1'
+#          - create_access.key.bucket_access[0].bucket_name == create_bucket.name
+#          - create_access.key.bucket_access[0].permissions == 'read_write'
+#          - create_access.key.bucket_access[1].cluster == 'us-ord-1'
+#          - create_access.key.bucket_access[1].bucket_name == create_bucket.name
+#          - create_access.key.bucket_access[1].permissions == 'read_only'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the OBJ key
+          linode.cloud.object_keys:
+            label: "{{ create.key.label }}"
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This pull request implements all of the changes to the `object_keys` module for Multicluster OBJ, including:

* New `regions` field
* New `bucket_access.*.region` field
* New update & change validation logic
* New `object_keys_basic` integration test

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make TEST_ARGS="-v object_keys_basic object_basic" test
```

### Manual Testing

1. In an Ansible collection sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
  - set_fact:
      r: "{{ 1000000000 | random }}"

  - name: Create an OBJ key
    linode.cloud.object_keys:
      label: "ansible-test-{{ r }}"
      regions:
        - us-mia
        - us-iad
      state: present
    register: create

  - name: Create an S3 bucket using the key
    amazon.aws.s3_bucket:
      s3_url: "https://{{ create.key.regions[0].s3_endpoint }}/"
      aws_access_key: "{{ create.key.access_key }}"
      aws_secret_key: "{{ create.key.secret_key }}"
      name: "ansible-test-{{ r }}"
      state: present
    register: create_bucket

  - name: Create an OBJ key scoped to the new bucket
    linode.cloud.object_keys:
      label: "ansible-test-scoped-{{ r }}"
      regions:
        - us-ord
      access:
        - region: "{{ create.key.regions[0].id }}"
          bucket_name: "{{ create_bucket.name }}"
          permissions: read_write
      state: present

  - name: Update the regions of the new key
    linode.cloud.object_keys:
      label: "ansible-test-scoped-{{ r }}"
      regions:
        - us-ord
        - us-sea
      access:
        - region: "{{ create.key.regions[0].id }}"
          bucket_name: "{{ create_bucket.name }}"
          permissions: read_write
      state: present
```

2. Ensure the playbook runs successfully.
3. Ensure all output JSON matches the expected changes/behavior.