### PR TITLE
new: Support tagging in image module; Migrate `image_info` to use InfoModule

### DIFF
--- a/docs/modules/image.md
+++ b/docs/modules/image.md
@@ -20,6 +20,8 @@ Manage a Linode Image.
     label: my-image
     description: Created using Ansible!
     disk_id: 12345
+    tags: 
+        - test
     state: present
 ```
 
@@ -29,6 +31,8 @@ Manage a Linode Image.
     label: my-image
     description: Created using Ansible!
     source_file: myimage.img.gz
+    tags: 
+        - test
     state: present
 ```
 
@@ -54,6 +58,7 @@ Manage a Linode Image.
 | `source_file` | <center>`str`</center> | <center>Optional</center> | An image file to create this image with.  **(Conflicts With: `disk_id`)** |
 | `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the image to have status `available` before returning.  **(Default: `True`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for an image to have status `available`.  **(Default: `600`)** |
+| `tags` | <center>`list`</center> | <center>Optional</center> | A list of customized tags of this new Image.  **(Updatable)** |
 
 ## Return Values
 
@@ -64,19 +69,31 @@ Manage a Linode Image.
         {
           "capabilities": [],
           "created": "2021-08-14T22:44:02",
-          "created_by": "linode",
+          "created_by": "my-account",
           "deprecated": false,
           "description": "Example Image description.",
           "eol": "2026-07-01T04:00:00",
           "expiry": null,
-          "id": "linode/debian11",
+          "id": "private/123",
           "is_public": true,
-          "label": "Debian 11",
+          "label": "my-image",
           "size": 2500,
           "status": null,
           "type": "manual",
           "updated": "2021-08-14T22:44:02",
-          "vendor": "Debian"
+          "vendor": "Debian",
+          "tags": ["test"],
+          "total_size": 5000,
+          "regions": [
+            {
+                "region": "us-east",
+                "status": "available"
+            },
+            {
+                "region": "us-central",
+                "status": "pending"
+            }
+          ]
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#image-view__response-samples) for a list of returned fields

--- a/docs/modules/image_info.md
+++ b/docs/modules/image_info.md
@@ -31,31 +31,43 @@ Get info about a Linode Image.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the image.  **(Conflicts With: `label`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the image.  **(Conflicts With: `id`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Image to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`str`</center> | <center>Optional</center> | The ID of the Image to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 
-- `image` - The image in JSON serialized form.
+- `image` - The returned Image.
 
     - Sample Response:
         ```json
         {
           "capabilities": [],
           "created": "2021-08-14T22:44:02",
-          "created_by": "linode",
+          "created_by": "my-account",
           "deprecated": false,
           "description": "Example Image description.",
           "eol": "2026-07-01T04:00:00",
           "expiry": null,
-          "id": "linode/debian11",
+          "id": "private/123",
           "is_public": true,
-          "label": "Debian 11",
+          "label": "my-image",
           "size": 2500,
           "status": null,
           "type": "manual",
           "updated": "2021-08-14T22:44:02",
-          "vendor": "Debian"
+          "vendor": "Debian",
+          "tags": ["test"],
+          "total_size": 5000,
+          "regions": [
+            {
+                "region": "us-east",
+                "status": "available"
+            },
+            {
+                "region": "us-central",
+                "status": "pending"
+            }
+          ]
         }
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#image-view__responses) for a list of returned fields

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -61,20 +61,31 @@ List and filter on Images.
         [
            {
               "created":"2021-08-14T22:44:02",
-              "created_by":"linode",
+              "created_by":"my-account",
               "deprecated":false,
               "description":"Example Image description.",
               "eol":"2026-07-01T04:00:00",
               "expiry":null,
-              "id":"linode/debian11",
-              "is_public":true,
-              "label":"Debian 11",
+              "id":"private/123",
+              "is_public":false,
+              "label":"test",
               "size":2500,
               "status":null,
               "type":"manual",
               "updated":"2021-08-14T22:44:02",
-              "vendor":"Debian"
-           }
+              "vendor":"Debian",
+              "tags": ["test"],
+              "total_size": 5000,
+              "regions": [
+                {
+                    "region": "us-east",
+                    "status": "available"
+                },
+                {
+                    "region": "us-central",
+                    "status": "pending"
+                }]
+               }
         ]
         ```
     - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#images-list__responses) for a list of returned fields

--- a/plugins/module_utils/doc_fragments/image.py
+++ b/plugins/module_utils/doc_fragments/image.py
@@ -6,12 +6,16 @@ specdoc_examples = ['''
     label: my-image
     description: Created using Ansible!
     disk_id: 12345
+    tags: 
+        - test
     state: present''', '''
 - name: Create a basic image from a file
   linode.cloud.image:
     label: my-image
     description: Created using Ansible!
     source_file: myimage.img.gz
+    tags: 
+        - test
     state: present''', '''
 - name: Delete an image
   linode.cloud.image:
@@ -21,17 +25,29 @@ specdoc_examples = ['''
 result_image_samples = ['''{
   "capabilities": [],
   "created": "2021-08-14T22:44:02",
-  "created_by": "linode",
+  "created_by": "my-account",
   "deprecated": false,
   "description": "Example Image description.",
   "eol": "2026-07-01T04:00:00",
   "expiry": null,
-  "id": "linode/debian11",
+  "id": "private/123",
   "is_public": true,
-  "label": "Debian 11",
+  "label": "my-image",
   "size": 2500,
   "status": null,
   "type": "manual",
   "updated": "2021-08-14T22:44:02",
-  "vendor": "Debian"
+  "vendor": "Debian",
+  "tags": ["test"],
+  "total_size": 5000,
+  "regions": [
+    {
+        "region": "us-east",
+        "status": "available"
+    },
+    {
+        "region": "us-central",
+        "status": "pending"
+    }
+  ]
 }''']

--- a/plugins/module_utils/doc_fragments/image_list.py
+++ b/plugins/module_utils/doc_fragments/image_list.py
@@ -17,18 +17,29 @@ specdoc_examples = ['''
 result_images_samples = ['''[
    {
       "created":"2021-08-14T22:44:02",
-      "created_by":"linode",
+      "created_by":"my-account",
       "deprecated":false,
       "description":"Example Image description.",
       "eol":"2026-07-01T04:00:00",
       "expiry":null,
-      "id":"linode/debian11",
-      "is_public":true,
-      "label":"Debian 11",
+      "id":"private/123",
+      "is_public":false,
+      "label":"test",
       "size":2500,
       "status":null,
       "type":"manual",
       "updated":"2021-08-14T22:44:02",
-      "vendor":"Debian"
-   }
+      "vendor":"Debian",
+      "tags": ["test"],
+      "total_size": 5000,
+      "regions": [
+        {
+            "region": "us-east",
+            "status": "available"
+        },
+        {
+            "region": "us-central",
+            "status": "pending"
+        }]
+       }
 ]''']

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -89,6 +89,14 @@ SPEC = {
             "have status `available`."
         ],
     ),
+    "tags": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        editable=True,
+        description=[
+            "A list of customized tags of this new Image."
+        ],
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(
@@ -108,7 +116,7 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-MUTABLE_FIELDS = {"description"}
+MUTABLE_FIELDS = {"description", "tags"}
 
 
 class Module(LinodeModuleBase):
@@ -164,6 +172,7 @@ class Module(LinodeModuleBase):
         label = self.module.params.get("label")
         description = self.module.params.get("description")
         cloud_init = self.module.params.get("cloud_init")
+        tags = self.module.params.get("tags")
 
         try:
             return self.client.images.create(
@@ -171,6 +180,7 @@ class Module(LinodeModuleBase):
                 label=label,
                 description=description,
                 cloud_init=cloud_init,
+                tags=tags,
             )
         except Exception as exception:
             return self.fail(
@@ -183,6 +193,7 @@ class Module(LinodeModuleBase):
         region = self.module.params.get("region")
         source_file = self.module.params.get("source_file")
         cloud_init = self.module.params.get("cloud_init")
+        tags = self.module.params.get("tags")
 
         if not os.path.exists(source_file):
             return self.fail(
@@ -192,7 +203,7 @@ class Module(LinodeModuleBase):
         # Create an image upload
         try:
             image, upload_to = self.client.images.create_upload(
-                label, region, description=description, cloud_init=cloud_init
+                label, region, description=description, cloud_init=cloud_init, tags=tags,
             )
         except Exception as exception:
             return self.fail(

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -93,9 +93,7 @@ SPEC = {
         type=FieldType.list,
         element_type=FieldType.string,
         editable=True,
-        description=[
-            "A list of customized tags of this new Image."
-        ],
+        description=["A list of customized tags of this new Image."],
     ),
 }
 
@@ -203,7 +201,11 @@ class Module(LinodeModuleBase):
         # Create an image upload
         try:
             image, upload_to = self.client.images.create_upload(
-                label, region, description=description, cloud_init=cloud_init, tags=tags,
+                label,
+                region,
+                description=description,
+                cloud_init=cloud_init,
+                tags=tags,
             )
         except Exception as exception:
             return self.fail(

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -5,111 +5,52 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.image_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    filter_null_values,
+    paginated_list_to_json,
+    safe_find,
 )
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import Image
 
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "id": SpecField(
-        type=FieldType.string,
-        description=["The ID of the image."],
-        conflicts_with=["label"],
-    ),
-    "label": SpecField(
-        type=FieldType.string,
-        description=["The label of the image."],
-        conflicts_with=["id"],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Image."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = InfoModule(
     examples=docs.specdoc_examples,
-    return_values={
-        "image": SpecReturnValue(
-            description="The image in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/images/#image-view__responses",
-            type=FieldType.dict,
-            sample=docs_parent.result_image_samples,
-        )
-    },
+    primary_result=InfoModuleResult(
+        display_name="Image",
+        field_name="image",
+        field_type=FieldType.dict,
+        docs_url="https://www.linode.com/docs/api/images/#image-view__responses",
+        samples=docs_parent.result_image_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            name="id",
+            display_name="ID",
+            type=FieldType.string,
+            get=lambda client, params: client.load(
+                Image, params.get("id")
+            )._raw_json,
+        ),
+        InfoModuleAttr(
+            name="label",
+            display_name="label",
+            type=FieldType.string,
+            get=lambda client, params: safe_find(
+                client.images,
+                Image.label == params.get("label"),
+                raise_not_found=True,
+            )._raw_json,
+        ),
+    ],
 )
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode user"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results = {"image": None}
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=[("id", "label")],
-            mutually_exclusive=[("id", "label")],
-        )
-
-    def _get_image_by_label(self, label: str) -> Optional[Image]:
-        try:
-            return self.client.images(Image.label == label)[0]
-        except IndexError:
-            return self.fail(
-                msg="failed to get image with label {0}: "
-                "image does not exist".format(label)
-            )
-        except Exception as exception:
-            return self.fail(
-                msg="failed to get image {0}: {1}".format(label, exception)
-            )
-
-    def _get_image_by_id(self, image_id: int) -> Image:
-        return self._get_resource_by_id(Image, image_id)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for user info module"""
-
-        params = filter_null_values(self.module.params)
-
-        if "id" in params:
-            self.results["image"] = self._get_image_by_id(
-                params.get("id")
-            )._raw_json
-
-        if "label" in params:
-            self.results["image"] = self._get_image_by_label(
-                params.get("label")
-            )._raw_json
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
+SPECDOC_META = module.spec
 
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -13,7 +13,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
     InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    paginated_list_to_json,
     safe_find,
 )
 from ansible_specdoc.objects import FieldType

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-linode_api4>=5.17.0
+# TODO: Revert before merging to dev
+# linode-api4>=5.17.0
+git+https://github.com/linode/linode_api4-python@proj/image-gen2
+
 polling>=0.3.2
 types-requests==2.32.0.20240602
 ansible-specdoc>=0.0.14

--- a/scripts/create_e2e_cloud_firewall.yaml
+++ b/scripts/create_e2e_cloud_firewall.yaml
@@ -3,7 +3,6 @@
   gather_facts: yes
 
   vars:
-    linode_api_token: "{{ lookup('env', 'LINODE_TOKEN') | default(lookup('env', 'LINODE_API_TOKEN')) }}"
     firewall_label: "e2e-firewall-{{ lookup('password', '/dev/null length=6 chars=ascii_letters') }}"
 
   tasks:
@@ -64,3 +63,9 @@
         path: "../tests/integration/integration_config.yml"
         line: "firewall_id: {{ firewall_id }}"
         insertafter: EOF
+
+  environment:
+    LINODE_API_TOKEN: "{{ lookup('env', 'LINODE_TOKEN') | default(lookup('env', 'LINODE_API_TOKEN')) }}"
+    LINODE_API_URL: "{{ lookup('env', 'TEST_API_URL', default='https://api.linode.com/') }}"
+    LINODE_API_VERSION: "{{ lookup('env', 'TEST_API_VERSION', default='v4beta') }}"
+    LINODE_CA: "{{ lookup('env', 'TEST_API_CA') }}"

--- a/scripts/delete_e2e_cloud_firewall.yaml
+++ b/scripts/delete_e2e_cloud_firewall.yaml
@@ -34,3 +34,9 @@
     - name: Display Deletion Info
       debug:
         var: delete_firewall
+
+  environment:
+    LINODE_API_TOKEN: "{{ lookup('env', 'LINODE_TOKEN') | default(lookup('env', 'LINODE_API_TOKEN')) }}"
+    LINODE_API_URL: "{{ lookup('env', 'TEST_API_URL', default='https://api.linode.com/') }}"
+    LINODE_API_VERSION: "{{ lookup('env', 'TEST_API_VERSION', default='v4beta') }}"
+    LINODE_CA: "{{ lookup('env', 'TEST_API_CA') }}"

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -6,7 +6,8 @@
     - name: Create an instance to image
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'
-        region: us-ord
+        # change the region for alpha testing
+        region: us-east
         type: g6-standard-1
         image: linode/alpine3.19
         state: present
@@ -19,6 +20,9 @@
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'cool'
         cloud_init: true
+        tags:
+          - 'test-tag'
+          - 'image-gen2'
         state: present
       register: image_create
 
@@ -28,6 +32,8 @@
           - image_create.image.status == 'available'
           - image_create.image.description == 'cool'
           - image_create.image.capabilities[0] == 'cloud-init'
+          - image_create.image.tags | length == 2
+          - image_create.image.size == image_create.image.total_size
 
     - name: Get image_info by ID
       linode.cloud.image_info:
@@ -58,6 +64,8 @@
         label: 'ansible-test-{{ r }}'
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'cool2'
+        tags:
+          - 'test'
         state: present
       register: image_update
 
@@ -66,12 +74,15 @@
         that:
           - image_update.image.status == 'available'
           - image_update.image.description == 'cool2'
+          - image_update.image.tags[0] == 'test'
 
     - name: Overwrite the image
       linode.cloud.image:
         label: 'ansible-test-{{ r }}'
         disk_id: '{{ instance_create.disks.0.id }}'
         description: 'yooo'
+        tags:
+          - 'new-tag'
         recreate: yes
         wait: no
         state: present
@@ -83,6 +94,7 @@
           - image_recreate.changed
           - image_recreate.image.id != image_create.image.id
           - image_recreate.image.description == 'yooo'
+          - image_recreate.image.tags[0] == 'new-tag'
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

Allow creating and updating image with tags. Expose new fields: `tags`, `total_size`. (`regions` will be implemented in a separated PR since it's not functional yet).

Migrated `image_info` to adapt InfoModule.

Also changed the doc example a bit to return private images. It makes more sense for those to have the regions field. 

## ✔️ How to Test

Set up the environment to test against alpha:
```
export TEST_API_CA=$PWD/cacert.pem
export TEST_API_URL=https://.../
export LINODE_TOKEN=...
export TEST_API_VERSION=v4
```

Run the integration test:
```
make TEST_ARGS="-v image_basic" test
```

Manual test:
1. In a sandbox environment, i.e. dx-devenv, run the following script
```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create an instance to imagize
      linode.cloud.instance:
        label: 'my-test-instance'
        region: us-east
        type: g6-standard-1
        image: linode/alpine3.19
        state: present
      register: instance_create

    - name: Create an image from the instance
      linode.cloud.image:
        label: 'my-image-gen2'
        disk_id: '{{ instance_create.disks.0.id }}'
        description: 'my-image'
        cloud_init: true
        tags:
          - 'test'
          - 'image-gen2'
        state: present
      register: image_create
```
2. Observe that image is created successfully
3. Update the image
```yaml
    - name: Update the image
      linode.cloud.image:
        label: '{{ image_create.image.label }}'
        disk_id: '{{ instance_create.disks.0.id }}'
        description: 'cool-image'
        tags:
          - 'test-image-gen2'
        state: present
      register: image_update
```
4. Observe the image is updated
5. Clean up the resources
```yaml
    - name:  Delete image
      linode.cloud.image:
        label: '{{ image_create.image.label }}'
        state: absent
  
    - name: Delete instance
      linode.cloud.instance:
        label: '{{ instance_create.instance.label }}'
        state: absent
```