### PR TITLE
Inject documentation before release using `ansible-specdoc`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: install ansible dependencies
         run: ansible-galaxy collection install amazon.aws:==6.0.1
 
+      - name: inject docs using specdoc
+        run: make inject
+
       - name: publish the collection
         run: make publish
         env:

--- a/Makefile
+++ b/Makefile
@@ -108,5 +108,5 @@ endif
 
 inject:
 	@echo "Injecting documentation into source files"
-	for f in `ls ./plugins/modules/*.py`; do echo $$f; ansible-specdoc -j -i $$f; done
+	for f in `ls ./plugins/modules/*.py`; do ansible-specdoc -j -i $$f; done
 

--- a/Makefile
+++ b/Makefile
@@ -108,4 +108,5 @@ endif
 
 inject:
 	@echo "Injecting documentation into source files"
-	ansible-specdoc -j -i ./plugins/modules/*.py
+	for f in `ls ./plugins/modules/*.py`; do echo $$f; ansible-specdoc -j -i $$f; done
+

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,7 @@ endif
 	@echo "api_url: $(TEST_API_URL)" >> $(INTEGRATION_CONFIG)
 	@echo "api_version: $(TEST_API_VERSION)" >> $(INTEGRATION_CONFIG)
 	@echo "ca_file: $(TEST_API_CA)" >> $(INTEGRATION_CONFIG)
+
+inject:
+	@echo "Injecting documentation into source files"
+	ansible-specdoc -j -i ./plugins/modules/*.py

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ endif
 inject:
 	@echo "Injecting documentation into source files"
 	for f in `ls ./plugins/modules/*.py`; do ansible-specdoc -j -i $$f; done
+	ansible-test sanity --test ansible-doc
 
 inject-clean:
 	@echo "Removing injected documentation from source files"

--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,6 @@ inject:
 	@echo "Injecting documentation into source files"
 	for f in `ls ./plugins/modules/*.py`; do ansible-specdoc -j -i $$f; done
 
+inject-clean:
+	@echo "Removing injected documentation from source files"
+	for f in `ls ./plugins/modules/*.py`; do ansible-specdoc -jc -i $$f; done

--- a/docs/modules/ipv6_range_info.md
+++ b/docs/modules/ipv6_range_info.md
@@ -17,7 +17,7 @@ Get info about a Linode IPv6 range.
 ```yaml
 - name: Get info about an IPv6 range
   linode.cloud.ipv6_range_info:
-    range: 2600:3c01::
+    range: "2600:3c01::"
 ```
 
 

--- a/plugins/module_utils/doc_fragments/ipv6_range_info.py
+++ b/plugins/module_utils/doc_fragments/ipv6_range_info.py
@@ -3,7 +3,7 @@
 specdoc_examples = ['''
 - name: Get info about an IPv6 range
   linode.cloud.ipv6_range_info:
-    range: 2600:3c01::''']
+    range: "2600:3c01::"''']
 
 
 result_range_samples = ['''{

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -40,11 +40,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -40,12 +40,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/account_availability_info.py
+++ b/plugins/modules/account_availability_info.py
@@ -40,5 +40,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -24,11 +24,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -24,5 +24,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/account_availability_list.py
+++ b/plugins/modules/account_availability_list.py
@@ -24,12 +24,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -44,12 +44,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Account"""

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -44,11 +44,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -44,6 +44,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Account"""

--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -87,12 +87,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for running arbitrary Linode API requests"""

--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -87,6 +87,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for running arbitrary Linode API requests"""

--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -87,11 +87,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -44,12 +44,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -44,11 +44,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/child_account_info.py
+++ b/plugins/modules/child_account_info.py
@@ -44,5 +44,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/child_account_list.py
+++ b/plugins/modules/child_account_list.py
@@ -29,12 +29,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/child_account_list.py
+++ b/plugins/modules/child_account_list.py
@@ -29,5 +29,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/child_account_list.py
+++ b/plugins/modules/child_account_list.py
@@ -29,11 +29,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -98,11 +98,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -98,6 +98,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Managed Database engine types"""

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -98,12 +98,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Managed Database engine types"""

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -97,11 +97,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -97,12 +97,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode databases"""

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -97,6 +97,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode databases"""

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -172,6 +172,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Databases"""

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -172,11 +172,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -172,12 +172,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Databases"""

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -90,11 +90,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -90,12 +90,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -90,6 +90,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -184,12 +184,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Databases"""

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -184,6 +184,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Databases"""

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -184,11 +184,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"allow_list", "updates"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -90,11 +90,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -90,6 +90,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode PostgreSQL database"""

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -90,12 +90,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode PostgreSQL database"""

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -175,6 +175,12 @@ MUTABLE_FIELDS: Set[str] = {
     "group",
 }
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeDomain(LinodeModuleBase):
     """Module for creating and destroying Linode Domains"""

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -175,11 +175,11 @@ MUTABLE_FIELDS: Set[str] = {
     "group",
 }
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -175,12 +175,13 @@ MUTABLE_FIELDS: Set[str] = {
     "group",
 }
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeDomain(LinodeModuleBase):
     """Module for creating and destroying Linode Domains"""

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -82,6 +82,12 @@ SPECDOC_META = SpecDocMeta(
 
 linode_domain_valid_filters = ["id", "domain"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeDomainInfo(LinodeModuleBase):
     """Module for getting info about a Linode Domain"""

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -82,11 +82,11 @@ SPECDOC_META = SpecDocMeta(
 
 linode_domain_valid_filters = ["id", "domain"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -82,12 +82,13 @@ SPECDOC_META = SpecDocMeta(
 
 linode_domain_valid_filters = ["id", "domain"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeDomainInfo(LinodeModuleBase):
     """Module for getting info about a Linode Domain"""

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -93,11 +93,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -93,12 +93,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of domains"""

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -93,6 +93,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of domains"""

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -158,11 +158,11 @@ MUTABLE_FIELDS: Set[str] = {
     "weight",
 }
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -158,6 +158,12 @@ MUTABLE_FIELDS: Set[str] = {
     "weight",
 }
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeDomainRecord(LinodeModuleBase):
     """Module for creating and destroying Linode Domain records"""

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -158,12 +158,13 @@ MUTABLE_FIELDS: Set[str] = {
     "weight",
 }
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeDomainRecord(LinodeModuleBase):
     """Module for creating and destroying Linode Domain records"""

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -85,6 +85,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeDomainRecordInfo(LinodeModuleBase):
     """Module for getting info about a Linode Domain record"""

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -85,12 +85,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeDomainRecordInfo(LinodeModuleBase):
     """Module for getting info about a Linode Domain record"""

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -85,11 +85,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -92,12 +92,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode events"""

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -92,6 +92,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode events"""

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -92,11 +92,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -191,11 +191,11 @@ SPECDOC_META = SpecDocMeta(
 # Fields that can be updated on an existing Firewall
 MUTABLE_FIELDS: List[str] = ["status", "tags"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -191,12 +191,13 @@ SPECDOC_META = SpecDocMeta(
 # Fields that can be updated on an existing Firewall
 MUTABLE_FIELDS: List[str] = ["status", "tags"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeFirewall(LinodeModuleBase):
     """Module for creating and destroying Linode Firewalls"""

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -191,6 +191,12 @@ SPECDOC_META = SpecDocMeta(
 # Fields that can be updated on an existing Firewall
 MUTABLE_FIELDS: List[str] = ["status", "tags"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeFirewall(LinodeModuleBase):
     """Module for creating and destroying Linode Firewalls"""

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -72,12 +72,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeFirewallDevice(LinodeModuleBase):
     """Module for managing Linode Firewall devices"""

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -72,6 +72,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeFirewallDevice(LinodeModuleBase):
     """Module for managing Linode Firewall devices"""

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -72,11 +72,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -72,11 +72,11 @@ SPECDOC_META = SpecDocMeta(
 
 linode_firewall_valid_filters = ["id", "label"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -72,12 +72,13 @@ SPECDOC_META = SpecDocMeta(
 
 linode_firewall_valid_filters = ["id", "label"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeFirewallInfo(LinodeModuleBase):
     """Module for viewing info about a Linode Firewall"""

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -72,6 +72,12 @@ SPECDOC_META = SpecDocMeta(
 
 linode_firewall_valid_filters = ["id", "label"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeFirewallInfo(LinodeModuleBase):
     """Module for viewing info about a Linode Firewall"""

--- a/plugins/modules/firewall_list.py
+++ b/plugins/modules/firewall_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/firewall_list.py
+++ b/plugins/modules/firewall_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Firewalls"""

--- a/plugins/modules/firewall_list.py
+++ b/plugins/modules/firewall_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Firewalls"""

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -110,6 +110,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Images"""

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -110,12 +110,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Images"""

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -110,11 +110,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -58,11 +58,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -58,12 +58,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -58,6 +58,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -21,11 +21,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -21,12 +21,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -21,5 +21,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -570,6 +570,12 @@ linode_instance_config_mutable = {
     "interfaces",
 }
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeInstance(LinodeModuleBase):
     """Module for creating and destroying Linode Instances"""

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -570,12 +570,13 @@ linode_instance_config_mutable = {
     "interfaces",
 }
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeInstance(LinodeModuleBase):
     """Module for creating and destroying Linode Instances"""

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -570,11 +570,11 @@ linode_instance_config_mutable = {
     "interfaces",
 }
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -86,11 +86,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -86,5 +86,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -86,12 +86,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode instances"""

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode instances"""

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -98,11 +98,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -98,12 +98,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode instance types"""

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -98,6 +98,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode instance types"""

--- a/plugins/modules/ip_assign.py
+++ b/plugins/modules/ip_assign.py
@@ -69,11 +69,11 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ip_assign.py
+++ b/plugins/modules/ip_assign.py
@@ -69,12 +69,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for assigning IPs to Linodes in a given Region"""

--- a/plugins/modules/ip_assign.py
+++ b/plugins/modules/ip_assign.py
@@ -69,6 +69,12 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for assigning IPs to Linodes in a given Region"""

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -54,11 +54,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -54,6 +54,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -54,12 +54,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -66,6 +66,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class ReverseDNSModule(LinodeModuleBase):
     """Module for updating Linode IP address's reverse DNS value"""

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -66,12 +66,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class ReverseDNSModule(LinodeModuleBase):
     """Module for updating Linode IP address's reverse DNS value"""

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -66,11 +66,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -64,11 +64,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -64,12 +64,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class IPShareModule(LinodeModuleBase):
     """Module for configuring Linode shared IPs."""

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -64,6 +64,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class IPShareModule(LinodeModuleBase):
     """Module for configuring Linode shared IPs."""

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -52,11 +52,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -51,12 +51,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode IPv6 range"""

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -44,7 +44,8 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "range": SpecReturnValue(
             description="The IPv6 range in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#ipv6-range-view__response-samples",
+            docs_url="https://www.linode.com/docs/api/networking/"
+            "#ipv6-range-view__response-samples",
             type=FieldType.dict,
             sample=docs.result_range_samples,
         )

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -44,8 +44,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "range": SpecReturnValue(
             description="The IPv6 range in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/"
-            "#ipv6-range-view__response-samples",
+            docs_url="https://www.linode.com/docs/api/networking/#ipv6-range-view__response-samples",
             type=FieldType.dict,
             sample=docs.result_range_samples,
         )

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -52,6 +52,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode IPv6 range"""

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -252,12 +252,13 @@ CREATE_FIELDS: Set[str] = {
     "high_availability",
 }
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeLKECluster(LinodeModuleBase):
     """Module for creating and destroying Linode LKE clusters"""

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -252,11 +252,11 @@ CREATE_FIELDS: Set[str] = {
     "high_availability",
 }
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -252,6 +252,12 @@ CREATE_FIELDS: Set[str] = {
     "high_availability",
 }
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeLKECluster(LinodeModuleBase):
     """Module for creating and destroying Linode LKE clusters"""

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -98,6 +98,12 @@ SPECDOC_META = SpecDocMeta(
 
 VALID_FILTERS = ["id", "label"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeLKEClusterInfo(LinodeModuleBase):
     """Module for getting info about a Linode Volume"""

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -98,12 +98,13 @@ SPECDOC_META = SpecDocMeta(
 
 VALID_FILTERS = ["id", "label"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeLKEClusterInfo(LinodeModuleBase):
     """Module for getting info about a Linode Volume"""

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -98,11 +98,11 @@ SPECDOC_META = SpecDocMeta(
 
 VALID_FILTERS = ["id", "label"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -159,11 +159,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -159,6 +159,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeLKENodePool(LinodeModuleBase):
     """Module for managing Linode Firewall devices"""

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -159,12 +159,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeLKENodePool(LinodeModuleBase):
     """Module for managing Linode Firewall devices"""

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -63,6 +63,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Kubernetes versions"""

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -63,12 +63,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Kubernetes versions"""

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -63,11 +63,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -307,11 +307,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"client_conn_throttle", "tags"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -307,12 +307,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"client_conn_throttle", "tags"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeNodeBalancer(LinodeModuleBase):
     """Configuration class for Linode NodeBalancer resource"""

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -307,6 +307,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"client_conn_throttle", "tags"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeNodeBalancer(LinodeModuleBase):
     """Configuration class for Linode NodeBalancer resource"""

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -91,11 +91,11 @@ SPECDOC_META = SpecDocMeta(
 
 linode_nodebalancer_valid_filters = ["id", "label"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -91,6 +91,12 @@ SPECDOC_META = SpecDocMeta(
 
 linode_nodebalancer_valid_filters = ["id", "label"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeNodeBalancerInfo(LinodeModuleBase):
     """Module for getting info about a Linode NodeBalancer"""

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -91,12 +91,13 @@ SPECDOC_META = SpecDocMeta(
 
 linode_nodebalancer_valid_filters = ["id", "label"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeNodeBalancerInfo(LinodeModuleBase):
     """Module for getting info about a Linode NodeBalancer"""

--- a/plugins/modules/nodebalancer_list.py
+++ b/plugins/modules/nodebalancer_list.py
@@ -96,6 +96,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode Nodebalancers"""

--- a/plugins/modules/nodebalancer_list.py
+++ b/plugins/modules/nodebalancer_list.py
@@ -96,11 +96,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/nodebalancer_list.py
+++ b/plugins/modules/nodebalancer_list.py
@@ -96,12 +96,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode Nodebalancers"""

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -96,11 +96,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"address", "mode", "weight"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 
@@ -219,75 +219,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-DOCUMENTATION = """
-author:
-- Luke Murphy (@decentral1se)
-- Charles Kenney (@charliekenney23)
-- Phillip Campbell (@phillc)
-- Lena Garber (@lbgarber)
-- Jacob Riddle (@jriddle)
-description:
-- Manage Linode NodeBalancer Nodes.
-module: nodebalancer_node
-options:
-  address:
-    description: The private IP Address where this backend can be reached. This must
-      be a private IP address.
-    required: false
-    type: str
-  config_id:
-    description: The ID of the NodeBalancer Config that contains this node.
-    required: true
-    type: int
-  label:
-    description: The label for this node. This is used to identify nodes within a
-      config.
-    required: true
-    type: str
-  mode:
-    choices:
-    - accept
-    - reject
-    - drain
-    - backup
-    description: The mode this NodeBalancer should use when sending traffic to this
-      backend.
-    required: false
-    type: str
-  nodebalancer_id:
-    description: The ID of the NodeBalancer that contains this node.
-    required: true
-    type: int
-  state:
-    choices:
-    - present
-    - absent
-    description: Whether the NodeBalancer node should be present or absent.
-    required: true
-    type: str
-  weight:
-    description: Nodes with a higher weight will receive more traffic.
-    required: false
-    type: int
-requirements:
-- python >= 3
-"""
-
-RETURN = """
-node:The NodeBalancer Node in JSON serialized form.
-  description: 
-  linode_api_docs: "https://www.linode.com/docs/api/nodebalancers/#node-view__responses"
-  returned: always
-  type: dict
-  sample: {
-  "address": "123.123.123.123:80",
-  "config_id": 12345,
-  "id": 12345,
-  "label": "mynode",
-  "mode": "accept",
-  "nodebalancer_id": 12345,
-  "status": "Unknown",
-  "weight": 10
-}
-"""

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -96,12 +96,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"address", "mode", "weight"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeNodeBalancerNode(LinodeModuleBase):
     """Module for managing Linode NodeBalancer nodes"""

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -96,6 +96,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS: Set[str] = {"address", "mode", "weight"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeNodeBalancerNode(LinodeModuleBase):
     """Module for managing Linode NodeBalancer nodes"""

--- a/plugins/modules/nodebalancer_stats.py
+++ b/plugins/modules/nodebalancer_stats.py
@@ -60,12 +60,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a NodeBalancer's Statistics"""

--- a/plugins/modules/nodebalancer_stats.py
+++ b/plugins/modules/nodebalancer_stats.py
@@ -60,11 +60,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/nodebalancer_stats.py
+++ b/plugins/modules/nodebalancer_stats.py
@@ -60,6 +60,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a NodeBalancer's Statistics"""

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -74,6 +74,12 @@ FILTERABLE_FIELDS = [
     "static_site_domain",
 ]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeObjectStorageClustersInfo(LinodeModuleBase):
     """Module for getting info about a Linode Object Storage Cluster"""

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -74,12 +74,13 @@ FILTERABLE_FIELDS = [
     "static_site_domain",
 ]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeObjectStorageClustersInfo(LinodeModuleBase):
     """Module for getting info about a Linode Object Storage Cluster"""

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -74,11 +74,11 @@ FILTERABLE_FIELDS = [
     "static_site_domain",
 ]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -98,11 +98,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -98,6 +98,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Object Storage Clusters"""

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -98,12 +98,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Object Storage Clusters"""

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -82,6 +82,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeObjectStorageKeys(LinodeModuleBase):
     """Module for creating and destroying Linode Object Storage Keys"""

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -82,11 +82,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -82,12 +82,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeObjectStorageKeys(LinodeModuleBase):
     """Module for creating and destroying Linode Object Storage Keys"""

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -80,11 +80,11 @@ CREATE_FIELDS = {"label", "region", "affinity_type", "is_strict"}
 # Fields that can be updated on an existing placement group
 MUTABLE_FIELDS = {"label"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -80,12 +80,13 @@ CREATE_FIELDS = {"label", "region", "affinity_type", "is_strict"}
 # Fields that can be updated on an existing placement group
 MUTABLE_FIELDS = {"label"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Placement Group"""

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -80,6 +80,12 @@ CREATE_FIELDS = {"label", "region", "affinity_type", "is_strict"}
 # Fields that can be updated on an existing placement group
 MUTABLE_FIELDS = {"label"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Placement Group"""

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -54,12 +54,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Placement Group Assignment"""

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -54,11 +54,11 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -54,6 +54,12 @@ SPECDOC_META = SpecDocMeta(
     return_values={},
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Placement Group Assignment"""

--- a/plugins/modules/placement_group_info.py
+++ b/plugins/modules/placement_group_info.py
@@ -40,11 +40,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/placement_group_info.py
+++ b/plugins/modules/placement_group_info.py
@@ -40,12 +40,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/placement_group_info.py
+++ b/plugins/modules/placement_group_info.py
@@ -40,5 +40,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/placement_group_list.py
+++ b/plugins/modules/placement_group_list.py
@@ -24,11 +24,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/placement_group_list.py
+++ b/plugins/modules/placement_group_list.py
@@ -24,5 +24,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/placement_group_list.py
+++ b/plugins/modules/placement_group_list.py
@@ -24,12 +24,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -45,12 +45,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Profile"""

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -45,11 +45,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -45,6 +45,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Profile"""

--- a/plugins/modules/region_list.py
+++ b/plugins/modules/region_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode regions"""

--- a/plugins/modules/region_list.py
+++ b/plugins/modules/region_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/region_list.py
+++ b/plugins/modules/region_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode regions"""

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -64,11 +64,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"label"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -64,6 +64,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"label"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class SSHKeyModule(LinodeModuleBase):
     """Module for creating and destroying Linode SSH keys"""

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -64,12 +64,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"label"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class SSHKeyModule(LinodeModuleBase):
     """Module for creating and destroying Linode SSH keys"""

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -58,11 +58,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -58,12 +58,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeSSHKeyInfo(LinodeModuleBase):
     """Module for getting Linode SSH public key"""

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -58,6 +58,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeSSHKeyInfo(LinodeModuleBase):
     """Module for getting Linode SSH public key"""

--- a/plugins/modules/ssh_key_list.py
+++ b/plugins/modules/ssh_key_list.py
@@ -96,11 +96,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/ssh_key_list.py
+++ b/plugins/modules/ssh_key_list.py
@@ -96,6 +96,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class SSHKeyListModule(LinodeModuleBase):
     """Module for getting a list of SSH keys in the Linode profile"""

--- a/plugins/modules/ssh_key_list.py
+++ b/plugins/modules/ssh_key_list.py
@@ -96,12 +96,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class SSHKeyListModule(LinodeModuleBase):
     """Module for getting a list of SSH keys in the Linode profile"""

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description", "images", "is_public", "rev_note", "script"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode StackScripts"""

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description", "images", "is_public", "rev_note", "script"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode StackScripts"""

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"description", "images", "is_public", "rev_note", "script"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -51,11 +51,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -51,12 +51,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/stackscript_info.py
+++ b/plugins/modules/stackscript_info.py
@@ -51,5 +51,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode stackscripts"""

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode stackscripts"""

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -67,11 +67,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -67,12 +67,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Tokens"""

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -67,6 +67,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Tokens"""

--- a/plugins/modules/token_info.py
+++ b/plugins/modules/token_info.py
@@ -59,12 +59,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode token"""

--- a/plugins/modules/token_info.py
+++ b/plugins/modules/token_info.py
@@ -59,6 +59,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode token"""

--- a/plugins/modules/token_info.py
+++ b/plugins/modules/token_info.py
@@ -59,11 +59,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/token_list.py
+++ b/plugins/modules/token_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/token_list.py
+++ b/plugins/modules/token_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode Account tokens"""

--- a/plugins/modules/token_list.py
+++ b/plugins/modules/token_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode Account tokens"""

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -50,12 +50,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -50,11 +50,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -50,5 +50,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -95,11 +95,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -95,6 +95,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Instance Types"""

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -95,12 +95,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode Instance Types"""

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -232,6 +232,12 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"restricted"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Users"""

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -232,11 +232,11 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"restricted"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -232,12 +232,13 @@ SPECDOC_META = SpecDocMeta(
 
 MUTABLE_FIELDS = {"restricted"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode Users"""

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -56,6 +56,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -56,11 +56,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -56,12 +56,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode user"""

--- a/plugins/modules/user_list.py
+++ b/plugins/modules/user_list.py
@@ -63,6 +63,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Users"""

--- a/plugins/modules/user_list.py
+++ b/plugins/modules/user_list.py
@@ -63,12 +63,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Users"""

--- a/plugins/modules/user_list.py
+++ b/plugins/modules/user_list.py
@@ -63,11 +63,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -51,6 +51,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeVLANInfo(LinodeModuleBase):
     """Module for getting info about a Linode VLAN"""

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -51,12 +51,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeVLANInfo(LinodeModuleBase):
     """Module for getting info about a Linode VLAN"""

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -51,11 +51,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -96,6 +96,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode VLANs"""

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -96,11 +96,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -96,12 +96,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting info about a Linode VLANs"""

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -116,11 +116,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -116,12 +116,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeVolume(LinodeModuleBase):
     """Module for creating and destroying Linode Volumes"""

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -116,6 +116,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeVolume(LinodeModuleBase):
     """Module for creating and destroying Linode Volumes"""

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -68,12 +68,13 @@ SPECDOC_META = SpecDocMeta(
 
 linode_volume_valid_filters = ["id", "label"]
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class LinodeVolumeInfo(LinodeModuleBase):
     """Module for getting info about a Linode Volume"""

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -68,6 +68,12 @@ SPECDOC_META = SpecDocMeta(
 
 linode_volume_valid_filters = ["id", "label"]
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class LinodeVolumeInfo(LinodeModuleBase):
     """Module for getting info about a Linode Volume"""

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -68,11 +68,11 @@ SPECDOC_META = SpecDocMeta(
 
 linode_volume_valid_filters = ["id", "label"]
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/volume_list.py
+++ b/plugins/modules/volume_list.py
@@ -94,11 +94,11 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/volume_list.py
+++ b/plugins/modules/volume_list.py
@@ -94,12 +94,13 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode volumes"""

--- a/plugins/modules/volume_list.py
+++ b/plugins/modules/volume_list.py
@@ -94,6 +94,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for getting a list of Linode volumes"""

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -72,6 +72,12 @@ SPECDOC_META = SpecDocMeta(
 CREATE_FIELDS = {"label", "region", "description"}
 MUTABLE_FIELDS = {"description"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode VPCS"""

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -72,11 +72,11 @@ SPECDOC_META = SpecDocMeta(
 CREATE_FIELDS = {"label", "region", "description"}
 MUTABLE_FIELDS = {"description"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -72,12 +72,13 @@ SPECDOC_META = SpecDocMeta(
 CREATE_FIELDS = {"label", "region", "description"}
 MUTABLE_FIELDS = {"description"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode VPCS"""

--- a/plugins/modules/vpc_info.py
+++ b/plugins/modules/vpc_info.py
@@ -52,12 +52,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_info.py
+++ b/plugins/modules/vpc_info.py
@@ -52,5 +52,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_info.py
+++ b/plugins/modules/vpc_info.py
@@ -52,11 +52,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/vpc_ip_list.py
+++ b/plugins/modules/vpc_ip_list.py
@@ -31,11 +31,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/vpc_ip_list.py
+++ b/plugins/modules/vpc_ip_list.py
@@ -31,5 +31,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_ip_list.py
+++ b/plugins/modules/vpc_ip_list.py
@@ -31,12 +31,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -21,11 +21,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -21,12 +21,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_list.py
+++ b/plugins/modules/vpc_list.py
@@ -21,5 +21,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet.py
+++ b/plugins/modules/vpc_subnet.py
@@ -72,12 +72,13 @@ SPECDOC_META = SpecDocMeta(
 
 CREATE_FIELDS = {"label", "ipv4"}
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
+
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode VPCS"""

--- a/plugins/modules/vpc_subnet.py
+++ b/plugins/modules/vpc_subnet.py
@@ -72,11 +72,11 @@ SPECDOC_META = SpecDocMeta(
 
 CREATE_FIELDS = {"label", "ipv4"}
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 

--- a/plugins/modules/vpc_subnet.py
+++ b/plugins/modules/vpc_subnet.py
@@ -72,6 +72,12 @@ SPECDOC_META = SpecDocMeta(
 
 CREATE_FIELDS = {"label", "ipv4"}
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
 
 class Module(LinodeModuleBase):
     """Module for creating and destroying Linode VPCS"""

--- a/plugins/modules/vpc_subnet_info.py
+++ b/plugins/modules/vpc_subnet_info.py
@@ -73,5 +73,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet_info.py
+++ b/plugins/modules/vpc_subnet_info.py
@@ -73,12 +73,12 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet_info.py
+++ b/plugins/modules/vpc_subnet_info.py
@@ -73,11 +73,11 @@ module = InfoModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/vpc_subnet_list.py
+++ b/plugins/modules/vpc_subnet_list.py
@@ -29,12 +29,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet_list.py
+++ b/plugins/modules/vpc_subnet_list.py
@@ -29,5 +29,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpc_subnet_list.py
+++ b/plugins/modules/vpc_subnet_list.py
@@ -29,11 +29,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/plugins/modules/vpcs_ip_list.py
+++ b/plugins/modules/vpcs_ip_list.py
@@ -22,5 +22,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
+DOCUMENTATION = '''
+'''
+EXAMPLES = '''
+'''
+RETURN = '''
+'''
+
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpcs_ip_list.py
+++ b/plugins/modules/vpcs_ip_list.py
@@ -22,12 +22,12 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = '''
-'''
-EXAMPLES = '''
-'''
-RETURN = '''
-'''
+DOCUMENTATION = """
+"""
+EXAMPLES = """
+"""
+RETURN = """
+"""
 
 if __name__ == "__main__":
     module.run()

--- a/plugins/modules/vpcs_ip_list.py
+++ b/plugins/modules/vpcs_ip_list.py
@@ -22,11 +22,11 @@ module = ListModule(
 
 SPECDOC_META = module.spec
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 """
-EXAMPLES = """
+EXAMPLES = r"""
 """
-RETURN = """
+RETURN = r"""
 """
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 linode_api4>=5.17.0
 polling>=0.3.2
 types-requests==2.32.0.20240622
-ansible-specdoc>=0.0.14
+ansible-specdoc>=0.0.15


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Sets up injection step in release workflow to inject documentation into the module python files, required for ansible documentation and ansible_linode v1.0

**NOTE**: We're not entirely sure if this will render correctly in the ansible website, if it doesn't we'll have to disable this step and make an update to ansible-specdoc. Because of this I dont think the initial release including this PR should be v1.0.0 so we dont have to roll it back or jump straight to v1.0.1 like we have in the past.

Requires https://github.com/linode/ansible-specdoc/pull/38

## ✔️ How to Test

1. Use the make shortcut to inject each file
```bash
make deps
make inject
```
2. View a file in the `/plugins/modules/` folder and see the injected documentation.