### PR TITLE
ref: PG affinity_type, is_strict -> placement_group_type, placement_group_policy

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -350,8 +350,8 @@ Manage Linode Instances, Configs, and Disks.
           "placement_group": {
             "id": 123,
             "label": "test",
-            "affinity_type": "anti_affinity:local",
-            "is_strict": true
+            "placement_group_type": "anti_affinity:local",
+            "placement_group_policy": "strict"
           }
         }
         ```

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -86,8 +86,8 @@ Get info about a Linode Instance.
           "placement_group": {
             "id": 123,
             "label": "test",
-            "affinity_type": "anti_affinity:local",
-            "is_strict": true
+            "placement_group_type": "anti_affinity:local",
+            "placement_group_policy": "strict"
           }
         }
         ```

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -59,7 +59,7 @@ NOTE: Placement Groups may not currently be available to all users.
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region that the placement group is in.   |
 | `placement_group_type` | <center>`str`</center> | <center>Optional</center> | The type of this placement group.   |
-| `placement_group_policy` | <center>`bool`</center> | <center>Optional</center> | The policy for assigning Linodes to this placement group.  **(Choices: `flexible`, `strict`)** |
+| `placement_group_policy` | <center>`str`</center> | <center>Optional</center> | The policy for assigning Linodes to this placement group.  **(Choices: `flexible`, `strict`)** |
 
 ## Return Values
 

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -21,8 +21,8 @@ NOTE: Placement Groups may not currently be available to all users.
   linode.cloud.placement_group:
     label: my-pg
     region: us-east
-    affinity_type: anti_affinity:local
-    is_strict: True
+    placement_group_type: anti_affinity:local
+    placement_group_policy: flexible
     state: present
 ```
 
@@ -58,8 +58,8 @@ NOTE: Placement Groups may not currently be available to all users.
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique ID of the placement group.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region that the placement group is in.   |
-| `affinity_type` | <center>`str`</center> | <center>Optional</center> | The affinity policy for Linodes in a placement group.   |
-| `is_strict` | <center>`bool`</center> | <center>Optional</center> | Whether Linodes must be able to become compliant during assignment.  **(Default: `False`)** |
+| `placement_group_type` | <center>`str`</center> | <center>Optional</center> | The type of this placement group.   |
+| `placement_group_policy` | <center>`bool`</center> | <center>Optional</center> | The policy for assigning Linodes to this placement group.  **(Choices: `flexible`, `strict`)** |
 
 ## Return Values
 
@@ -71,8 +71,8 @@ NOTE: Placement Groups may not currently be available to all users.
           "id": 123,
           "label": "my-pg",
           "region": "eu-west",
-          "affinity_type": "anti_affinity:local",
-          "is_strict": true,
+          "placement_group_type": "anti_affinity:local",
+          "placement_group_policy": "flexible",
           "is_compliant": true,
           "members": [
             {

--- a/docs/modules/placement_group_info.md
+++ b/docs/modules/placement_group_info.md
@@ -42,8 +42,8 @@ Get info about a Linode Placement Group.
           "id": 123,
           "label": "test",
           "region": "eu-west",
-          "affinity_type": "anti_affinity:local",
-          "is_strict": true,
+          "placement_group_type": "anti_affinity:local",
+          "placement_group_policy": "strict",
           "is_compliant": true,
           "members": [
             {

--- a/docs/modules/placement_group_list.md
+++ b/docs/modules/placement_group_list.md
@@ -50,8 +50,8 @@ List and filter on Placement Groups.
               "id": 123,
               "label": "test",
               "region": "eu-west",
-              "affinity_type": "anti_affinity:local",
-              "is_strict": true,
+              "placement_group_type": "anti_affinity:local",
+              "placement_group_policy": "strict",
               "is_compliant": true,
               "members": [
                 {

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -132,8 +132,8 @@ result_instance_samples = ['''{
   "placement_group": {
     "id": 123,
     "label": "test",
-    "affinity_type": "anti_affinity:local",
-    "is_strict": true
+    "placement_group_type": "anti_affinity:local",
+    "placement_group_policy": "strict"
   }
 }''']
 

--- a/plugins/module_utils/doc_fragments/placement_group.py
+++ b/plugins/module_utils/doc_fragments/placement_group.py
@@ -5,8 +5,8 @@ specdoc_examples = ['''
   linode.cloud.placement_group:
     label: my-pg
     region: us-east
-    affinity_type: anti_affinity:local
-    is_strict: True
+    placement_group_type: anti_affinity:local
+    placement_group_policy: flexible
     state: present''', '''
 - name: Update a Linode placement group label
   linode.cloud.placement_group:
@@ -28,8 +28,8 @@ result_placement_group_samples = ['''{
   "id": 123,
   "label": "my-pg",
   "region": "eu-west",
-  "affinity_type": "anti_affinity:local",
-  "is_strict": true,
+  "placement_group_type": "anti_affinity:local",
+  "placement_group_policy": "flexible",
   "is_compliant": true,
   "members": [
     {

--- a/plugins/module_utils/doc_fragments/placement_group_info.py
+++ b/plugins/module_utils/doc_fragments/placement_group_info.py
@@ -5,8 +5,8 @@ result_placement_group_samples = ['''
   "id": 123,
   "label": "test",
   "region": "eu-west",
-  "affinity_type": "anti_affinity:local",
-  "is_strict": true,
+  "placement_group_type": "anti_affinity:local",
+  "placement_group_policy": "strict",
   "is_compliant": true,
   "members": [
     {

--- a/plugins/module_utils/doc_fragments/placement_group_list.py
+++ b/plugins/module_utils/doc_fragments/placement_group_list.py
@@ -10,8 +10,8 @@ result_placement_groups_samples = ['''[
       "id": 123,
       "label": "test",
       "region": "eu-west",
-      "affinity_type": "anti_affinity:local",
-      "is_strict": true,
+      "placement_group_type": "anti_affinity:local",
+      "placement_group_policy": "strict",
       "is_compliant": true,
       "members": [
         {

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -44,16 +44,16 @@ placement_group_spec = {
         type=FieldType.string,
         description=["The region that the placement group is in."],
     ),
-    "affinity_type": SpecField(
+    "placement_group_type": SpecField(
         type=FieldType.string,
-        description=["The affinity policy for Linodes in a placement group."],
+        description=["The type of this placement group."],
     ),
-    "is_strict": SpecField(
-        type=FieldType.bool,
-        default=False,
+    "placement_group_policy": SpecField(
+        type=FieldType.string,
         description=[
-            "Whether Linodes must be able to become compliant during assignment."
+            "The policy for assigning Linodes to this placement group."
         ],
+        choices=["flexible", "strict"],
     ),
 }
 
@@ -76,7 +76,12 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-CREATE_FIELDS = {"label", "region", "affinity_type", "is_strict"}
+CREATE_FIELDS = {
+    "label",
+    "region",
+    "placement_group_type",
+    "placement_group_policy",
+}
 # Fields that can be updated on an existing placement group
 MUTABLE_FIELDS = {"label"}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-linode_api4>=5.17.0
+# TODO: Revert before merging to dev
+# linode-api4>=5.17.0
+git+https://github.com/lgarber-akamai/linode_api4-python@ref/placement-group-changes
+
+
 polling>=0.3.2
 types-requests==2.32.0.20240622
 ansible-specdoc>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-# TODO: Revert before merging to dev
-# linode-api4>=5.18.0
-git+https://github.com/lgarber-akamai/linode_api4-python@ref/placement-group-changes
-
+linode-api4>=5.19.0
 polling>=0.3.2
 types-requests==2.32.0.20240712
 ansible-specdoc>=0.0.15

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -13,7 +13,7 @@
     - name: Create a Linode instance without a root password
       linode.cloud.instance:
         label: 'ansible-test-nopass-{{ r }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
@@ -32,7 +32,7 @@
     - name: Create a Linode instance with additional ips and without a root password
       linode.cloud.instance:
         label: 'ansible-test-additional-ips-nopass-{{ r }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
@@ -53,7 +53,7 @@
     - name: Update the instance region and type
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         group: funny
         type: g6-standard-2
         image: linode/ubuntu22.04
@@ -66,7 +66,7 @@
     - name: Update label with invalid string
       linode.cloud.instance:
         label: '!!Invalid!!'
-        region: us-ord
+        region: '{{ pg_region }}'
         group: funny
         type: g6-standard-2
         image: linode/ubuntu22.04
@@ -79,7 +79,7 @@
     - name: Attempt to add additional ips to an instance
       linode.cloud.instance:
         label: '{{ create_additional_ips.instance.label }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
@@ -95,7 +95,7 @@
     - name: Attempt to remove additional ips from an instance
       linode.cloud.instance:
         label: '{{ create_additional_ips.instance.label }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
@@ -108,7 +108,7 @@
     - name: Update the instance
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
-        region: us-ord
+        region: '{{ pg_region }}'
         group: funny
         type: g6-standard-1
         image: linode/ubuntu22.04
@@ -130,7 +130,7 @@
       assert:
         that:
           - info_id.instance.ipv4|length > 1
-          - info_id.instance.region == 'us-ord'
+          - info_id.instance.region == pg_region
           - info_id.configs|length == 1
           - info_id.networking.ipv4.public[0].address != None
 
@@ -143,14 +143,15 @@
       assert:
         that:
           - info_label.instance.ipv4|length > 1
-          - info_label.instance.region == 'us-ord'
+          - info_label.instance.region == pg_region
           - info_label.configs|length == 1
 
     - name: Create a Linode placement group
       linode.cloud.placement_group:
         label: 'ansible-test-{{ r }}'
         region: '{{ pg_region }}'
-        affinity_type: anti_affinity:local
+        placement_group_type: anti_affinity:local
+        placement_group_policy: flexible
         state: present
       register: pg_created
 

--- a/tests/integration/targets/placement_group_assign/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_assign/tasks/main.yaml
@@ -14,7 +14,8 @@
       linode.cloud.placement_group:
         label: 'ansible-test-{{ r }}'
         region: '{{ region }}'
-        affinity_type: anti_affinity:local
+        placement_group_type: anti_affinity:local
+        placement_group_policy: flexible
         state: present
       register: pg_created
 

--- a/tests/integration/targets/placement_group_basic/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_basic/tasks/main.yaml
@@ -14,7 +14,8 @@
       linode.cloud.placement_group:
         label: 'ansible-test-{{ r }}'
         region: '{{ region }}'
-        affinity_type: anti_affinity:local
+        placement_group_type: anti_affinity:local
+        placement_group_policy: flexible
         state: present
       register: pg_created
 
@@ -22,8 +23,8 @@
       assert:
         that:
           - pg_created.placement_group.region == region
-          - pg_created.placement_group.affinity_type == 'anti_affinity:local'
-          - pg_created.placement_group.is_strict == false
+          - pg_created.placement_group.placement_group_type == 'anti_affinity:local'
+          - pg_created.placement_group.placement_group_policy == 'flexible'
 
     - name: Update a Linode placement group label
       linode.cloud.placement_group:

--- a/tests/integration/targets/placement_group_info/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_info/tasks/main.yaml
@@ -14,8 +14,8 @@
       linode.cloud.placement_group:
         label: 'ansible-test-{{ r }}'
         region: '{{ region }}'
-        affinity_type: anti_affinity:local
-        is_strict: True
+        placement_group_type: anti_affinity:local
+        placement_group_policy: strict
         state: present
       register: pg_created
 
@@ -29,8 +29,8 @@
         that:
           - pg_created.placement_group.label == pg.placement_group.label
           - pg_created.placement_group.region == pg.placement_group.region
-          - pg_created.placement_group.affinity_type == pg.placement_group.affinity_type
-          - pg_created.placement_group.is_strict == pg.placement_group.is_strict
+          - pg_created.placement_group.placement_group_type == pg.placement_group.placement_group_type
+          - pg_created.placement_group.placement_group_policy == pg.placement_group.placement_group_policy
 
     - name: Delete a placement group by id
       linode.cloud.placement_group:

--- a/tests/integration/targets/placement_group_list/tasks/main.yaml
+++ b/tests/integration/targets/placement_group_list/tasks/main.yaml
@@ -14,8 +14,8 @@
       linode.cloud.placement_group:
         label: 'ansible-test-{{ r }}'
         region: '{{ region }}'
-        affinity_type: anti_affinity:local
-        is_strict: True
+        placement_group_type: anti_affinity:local
+        placement_group_policy: strict
         state: present
       register: pg_created
 
@@ -31,8 +31,8 @@
         that:
           - pg_list.placement_groups[0].label == pg_created.placement_group.label
           - pg_list.placement_groups[0].region == pg_created.placement_group.region
-          - pg_list.placement_groups[0].affinity_type == pg_created.placement_group.affinity_type
-          - pg_list.placement_groups[0].is_strict == pg_created.placement_group.is_strict
+          - pg_list.placement_groups[0].placement_group_type == pg_created.placement_group.placement_group_type
+          - pg_list.placement_groups[0].placement_group_policy == pg_created.placement_group.placement_group_policy
 
     - name: Delete a placement group
       linode.cloud.placement_group:


### PR DESCRIPTION
## 📝 Description

This pull request implements the following upcoming breaking changes for the VM Placement GA:

* affinity_type -> placement_group_type
* is_strict -> placement_group_policy

**NOTE: We will need communication around this breaking change in the release notes.**

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and have pointed your local environment at an API instance where PGs are available:

```
export TEST_API_URL=https://.../
export TEST_API_CA=$PWD/cacert.pem
export LINODE_TOKEN=...

# Exports for dx-devenv sandbox
export LINODE_API_URL=$TEST_API_URL
export LINODE_CA=$TEST_API_CA
export LINODE_API_TOKEN=$LINODE_TOKEN
```

### Integration Testing

```bash
make TEST_ARGS="-v placement_group_assign placement_group_basic placement_group_info placement_group_list" test

# NOTE: This test is expected to fail in certain environments due to an unrelated issue, see TPT-3060 for more info.
make TEST_ARGS="-v instance_basic" test
```

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:

```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a Linode placement group
      linode.cloud.placement_group:
        label: my-ansible-test-pg
        region: us-east
        placement_group_type: anti_affinity:local
        placement_group_policy: flexible
        state: present
      register: pg_created

    - name: Get a Linode placement group info
      linode.cloud.placement_group_info:
        id: '{{ pg_created.placement_group.id }}'
      register: pg

    - name: Update a Linode placement group label
      linode.cloud.placement_group:
        id: '{{ pg.placement_group.id }}'
        label: '{{ pg.placement_group.label }}-updated'
        placement_group_type: anti_affinity:local
        placement_group_policy: flexible
        state: present
      register: pg_updated

    - name: List Linode placement groups for the current account
      linode.cloud.placement_group_list:
        filters:
          - name: label
            values: ['{{ pg_updated.placement_group.label }}']
      register: pg_list
```

2. Observe no error is raised.

3. Create an instance under the placement group
```yaml
    - name: Create a Linode instance under a placement group
      linode.cloud.instance:
        label: 'ansible-test-pg-{{ r }}'
        type: g6-nanode-1
        region: us-east
        placement_group:
          id: '{{ pg_updated.placement_group.id }}'
          compliant_only: false
        state: present
      register: instance_pg
```

4. Observe that the instance is created successfully.

5. Clean up the resources created.
```yaml
    - name: Delete a Linode instance
      linode.cloud.instance:
        label: '{{ instance_pg.instance.label }}'
        state: absent
      register: delete_instance_pg

    - name: Delete a placement group
      linode.cloud.placement_group:
        label: '{{ pg_updated.placement_group.label }}'
        state: absent
      register: pg_deleted
```
