### PR TITLE
doc: Replace all Linode API docs URLs with their TechDocs equivalents

### DIFF
--- a/docs/modules/account_info.md
+++ b/docs/modules/account_info.md
@@ -68,6 +68,6 @@ Get info about a Linode Account.
           "zip": "19102-1234"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#account-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-account) for a list of returned fields
 
 

--- a/docs/modules/api_request.md
+++ b/docs/modules/api_request.md
@@ -2,7 +2,7 @@
 
 Make an arbitrary Linode API request.
 
-The Linode API documentation can be found here: https://www.linode.com/docs/api
+The Linode API documentation can be found here: https://techdocs.akamai.com/linode-api/reference
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -43,7 +43,7 @@ The Linode API documentation can be found here: https://www.linode.com/docs/api
 | `method` | <center>`str`</center> | <center>**Required**</center> | The HTTP method of the request or response.  **(Choices: `POST`, `PUT`, `GET`, `DELETE`)** |
 | `body` | <center>`dict`</center> | <center>Optional</center> | The body of the request. This is a YAML structure that will be marshalled to JSON.  **(Conflicts With: `body_json`)** |
 | `body_json` | <center>`str`</center> | <center>Optional</center> | The body of the request in JSON format.  **(Conflicts With: `body`)** |
-| `filters` | <center>`dict`</center> | <center>Optional</center> | A YAML structure corresponding to the X-Filter request header. See: https://www.linode.com/docs/api/#filtering-and-sorting   |
+| `filters` | <center>`dict`</center> | <center>Optional</center> | A YAML structure corresponding to the X-Filter request header. See: https://techdocs.akamai.com/linode-api/reference   |
 
 ## Return Values
 

--- a/docs/modules/database_engine_list.md
+++ b/docs/modules/database_engine_list.md
@@ -41,7 +41,7 @@ List and filter on Managed Database engine types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/databases/#managed-database-engines-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-databases-engines   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -58,6 +58,6 @@ List and filter on Managed Database engine types.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-database-engines-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-engines) for a list of returned fields
 
 

--- a/docs/modules/database_list.md
+++ b/docs/modules/database_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Managed Databases.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/databases/#managed-databases-list-all__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-databases-engines   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -82,6 +82,6 @@ List and filter on Linode Managed Databases.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-databases-list-all__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-instances) for a list of returned fields
 
 

--- a/docs/modules/database_mysql.md
+++ b/docs/modules/database_mysql.md
@@ -116,7 +116,7 @@ Manage a Linode MySQL database.
           "version": "8.0.30"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance) for a list of returned fields
 
 
 - `backups` - The database backups in JSON serialized form.
@@ -132,7 +132,7 @@ Manage a Linode MySQL database.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-backup-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backup) for a list of returned fields
 
 
 - `ssl_cert` - The SSL CA certificate for an accessible Managed MySQL Database.
@@ -143,7 +143,7 @@ Manage a Linode MySQL database.
           "ca_certificate": "LS0tLS1CRUdJ...=="
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-ssl-certificate-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-ssl) for a list of returned fields
 
 
 - `credentials` - The root username and password for an accessible Managed MySQL Database.
@@ -155,6 +155,6 @@ Manage a Linode MySQL database.
           "username": "linroot"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-credentials-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) for a list of returned fields
 
 

--- a/docs/modules/database_mysql_info.md
+++ b/docs/modules/database_mysql_info.md
@@ -72,7 +72,7 @@ Get info about a Linode MySQL Managed Database.
           "version": "8.0.30"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance) for a list of returned fields
 
 
 - `backups` - The database backups in JSON serialized form.
@@ -88,7 +88,7 @@ Get info about a Linode MySQL Managed Database.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-backup-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backup) for a list of returned fields
 
 
 - `ssl_cert` - The SSL CA certificate for an accessible Managed MySQL Database.
@@ -99,7 +99,7 @@ Get info about a Linode MySQL Managed Database.
           "ca_certificate": "LS0tLS1CRUdJ...=="
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-ssl-certificate-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-ssl) for a list of returned fields
 
 
 - `credentials` - The root username and password for an accessible Managed MySQL Database.
@@ -111,6 +111,6 @@ Get info about a Linode MySQL Managed Database.
           "username": "linroot"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-mysql-database-credentials-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials) for a list of returned fields
 
 

--- a/docs/modules/database_postgresql.md
+++ b/docs/modules/database_postgresql.md
@@ -119,7 +119,7 @@ Manage a Linode PostgreSQL database.
           "version": "14.6"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance) for a list of returned fields
 
 
 - `backups` - The database backups in JSON serialized form.
@@ -135,7 +135,7 @@ Manage a Linode PostgreSQL database.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-backups-list) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups) for a list of returned fields
 
 
 - `ssl_cert` - The SSL CA certificate for an accessible Managed PostgreSQL Database.
@@ -146,7 +146,7 @@ Manage a Linode PostgreSQL database.
           "ca_certificate": "LS0tLS1CRUdJ...=="
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-ssl-certificate-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-instance-ssl) for a list of returned fields
 
 
 - `credentials` - The root username and password for an accessible Managed PostgreSQL Database.
@@ -158,6 +158,6 @@ Manage a Linode PostgreSQL database.
           "username": "linroot"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-credentials-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) for a list of returned fields
 
 

--- a/docs/modules/database_postgresql_info.md
+++ b/docs/modules/database_postgresql_info.md
@@ -73,7 +73,7 @@ Get info about a Linode PostgreSQL Managed Database.
           "version": "14.6"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance) for a list of returned fields
 
 
 - `backups` - The database backups in JSON serialized form.
@@ -89,7 +89,7 @@ Get info about a Linode PostgreSQL Managed Database.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-backups-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups) for a list of returned fields
 
 
 - `ssl_cert` - The SSL CA certificate for an accessible Managed PostgreSQL Database.
@@ -100,7 +100,7 @@ Get info about a Linode PostgreSQL Managed Database.
           "ca_certificate": "LS0tLS1CRUdJ...=="
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-ssl-certificate-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgresql-instance-ssl) for a list of returned fields
 
 
 - `credentials` - The root username and password for an accessible Managed PostgreSQL Database.
@@ -112,6 +112,6 @@ Get info about a Linode PostgreSQL Managed Database.
           "username": "linroot"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/databases/#managed-postgresql-database-credentials-view__request-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-credentials) for a list of returned fields
 
 

--- a/docs/modules/domain.md
+++ b/docs/modules/domain.md
@@ -74,7 +74,7 @@ Manage Linode Domains.
           "type": "master"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain) for a list of returned fields
 
 
 - `records` - The domain record in JSON serialized form.
@@ -99,7 +99,7 @@ Manage Linode Domains.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-record-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
 
 
 - `zone_file` - The zone file for the last rendered zone for the specified domain.
@@ -121,6 +121,6 @@ Manage Linode Domains.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-zone-file-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-zone) for a list of returned fields
 
 

--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -60,7 +60,7 @@ Get info about a Linode Domain.
           "type": "master"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain) for a list of returned fields
 
 
 - `records` - The domain record in JSON serialized form.
@@ -85,7 +85,7 @@ Get info about a Linode Domain.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-record-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
 
 
 - `zone_file` - The zone file for the last rendered zone for the specified domain.
@@ -107,6 +107,6 @@ Get info about a Linode Domain.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-zone-file-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-zone) for a list of returned fields
 
 

--- a/docs/modules/domain_list.md
+++ b/docs/modules/domain_list.md
@@ -41,7 +41,7 @@ List and filter on Domains.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/domains/#domains-list__responses#domains-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-domains   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -72,6 +72,6 @@ List and filter on Domains.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domains-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domains) for a list of returned fields
 
 

--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -86,6 +86,6 @@ NOTE: Domain records are identified by their name, target, and type.
           "weight": 50
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-record-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
 
 

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -62,6 +62,6 @@ Get info about a Linode Domain Record.
           "weight": 50
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/domains/#domain-record-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
 
 

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -49,7 +49,7 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/account/#events-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-events   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -87,6 +87,6 @@ List and filter on Linode events.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#events-list__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-events) for a list of returned fields
 
 

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -93,7 +93,7 @@ Manage Linode Firewalls.
 | `action` | <center>`str`</center> | <center>**Required**</center> | Controls whether traffic is accepted or dropped by this rule.  **(Choices: `ACCEPT`, `DROP`)** |
 | [`addresses` (sub-options)](#addresses) | <center>`dict`</center> | <center>Optional</center> | Allowed IPv4 or IPv6 addresses.   |
 | `description` | <center>`str`</center> | <center>Optional</center> | A description for this rule.   |
-| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See https://www.linode.com/docs/api/networking/#firewall-create   |
+| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See https://techdocs.akamai.com/linode-api/reference/post-firewalls   |
 | `protocol` | <center>`str`</center> | <center>Optional</center> | The type of network traffic to allow.   |
 
 ### addresses
@@ -111,7 +111,7 @@ Manage Linode Firewalls.
 | `action` | <center>`str`</center> | <center>**Required**</center> | Controls whether traffic is accepted or dropped by this rule.  **(Choices: `ACCEPT`, `DROP`)** |
 | [`addresses` (sub-options)](#addresses) | <center>`dict`</center> | <center>Optional</center> | Allowed IPv4 or IPv6 addresses.   |
 | `description` | <center>`str`</center> | <center>Optional</center> | A description for this rule.   |
-| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See https://www.linode.com/docs/api/networking/#firewall-create   |
+| `ports` | <center>`str`</center> | <center>Optional</center> | A string representing the port or ports on which traffic will be allowed. See https://techdocs.akamai.com/linode-api/reference/post-firewalls   |
 | `protocol` | <center>`str`</center> | <center>Optional</center> | The type of network traffic to allow.   |
 
 ## Return Values
@@ -170,7 +170,7 @@ Manage Linode Firewalls.
           "updated": "2018-01-02T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewall-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall) for a list of returned fields
 
 
 - `devices` - A list of Firewall devices JSON serialized form.
@@ -191,6 +191,6 @@ Manage Linode Firewalls.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewall-device-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall-device) for a list of returned fields
 
 

--- a/docs/modules/firewall_device.md
+++ b/docs/modules/firewall_device.md
@@ -68,6 +68,6 @@ Manage Linode Firewall Devices.
           "updated": "2018-01-02T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewall-device-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall-device) for a list of returned fields
 
 

--- a/docs/modules/firewall_info.md
+++ b/docs/modules/firewall_info.md
@@ -90,7 +90,7 @@ Get info about a Linode Firewall.
           "updated": "2018-01-02T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewall-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall) for a list of returned fields
 
 
 - `devices` - A list of Firewall devices JSON serialized form.
@@ -111,6 +111,6 @@ Get info about a Linode Firewall.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewall-device-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall-device) for a list of returned fields
 
 

--- a/docs/modules/firewall_list.md
+++ b/docs/modules/firewall_list.md
@@ -41,7 +41,7 @@ List and filter on Firewalls.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/networking/#firewalls-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-ips   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -102,6 +102,6 @@ List and filter on Firewalls.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#firewalls-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewalls) for a list of returned fields
 
 

--- a/docs/modules/image.md
+++ b/docs/modules/image.md
@@ -79,6 +79,6 @@ Manage a Linode Image.
           "vendor": "Debian"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#image-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-image) for a list of returned fields
 
 

--- a/docs/modules/image_info.md
+++ b/docs/modules/image_info.md
@@ -58,6 +58,6 @@ Get info about a Linode Image.
           "vendor": "Debian"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#image-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-image) for a list of returned fields
 
 

--- a/docs/modules/image_list.md
+++ b/docs/modules/image_list.md
@@ -49,7 +49,7 @@ List and filter on Images.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://www.linode.com/docs/api/images/#images-list__responses).   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-images).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -77,6 +77,6 @@ List and filter on Images.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/images/#images-list__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-images) for a list of returned fields
 
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -128,15 +128,15 @@ Manage Linode Instances, Configs, and Disks.
 | `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.  **(Conflicts With: `disks`,`configs`)** |
 | `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
-| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
+| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of a Firewall this Linode to assign this Linode to.   |
 | `private_ip` | <center>`bool`</center> | <center>Optional</center> | If true, the created Linode will have private networking enabled.   |
 | `group` | <center>`str`</center> | <center>Optional</center> | The group that the instance should be marked under. Please note, that group labelling is deprecated but still supported. The encouraged method for marking instances is to use tags.  **(Updatable)** |
 | `boot_config_label` | <center>`str`</center> | <center>Optional</center> | The label of the config to boot from.   |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of Instance configs to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create).  **(Updatable; Conflicts With: `image`,`interfaces`)** |
 | [`disks` (sub-options)](#disks) | <center>`list`</center> | <center>Optional</center> | A list of Disks to create on the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#disk-create).  **(Updatable; Conflicts With: `image`,`interfaces`)** |
-| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema).  **(Conflicts With: `disks`,`configs`)** |
+| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/post-linode-instance).  **(Conflicts With: `disks`,`configs`)** |
 | `booted` | <center>`bool`</center> | <center>Optional</center> | Whether the new Instance should be booted. This will default to True if the Instance is deployed from an Image or Backup.   |
 | `backup_id` | <center>`int`</center> | <center>Optional</center> | The id of the Backup to restore to the new Instance. May not be provided if "image" is given.   |
 | [`metadata` (sub-options)](#metadata) | <center>`dict`</center> | <center>Optional</center> | Fields relating to the Linode Metadata service.   |
@@ -163,7 +163,7 @@ Manage Linode Instances, Configs, and Disks.
 | `root_device` | <center>`str`</center> | <center>Optional</center> | The root device to boot.  **(Updatable)** |
 | `run_level` | <center>`str`</center> | <center>Optional</center> | Defines the state of your Linode after booting.  **(Updatable)** |
 | `virt_mode` | <center>`str`</center> | <center>Optional</center> | Controls the virtualization mode.  **(Choices: `paravirt`, `fullvirt`; Updatable)** |
-| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-create__request-body-schema).  **(Updatable)** |
+| [`interfaces` (sub-options)](#interfaces) | <center>`list`</center> | <center>Optional</center> | A list of network interfaces to apply to the Linode. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config).  **(Updatable)** |
 
 ### devices
 
@@ -275,8 +275,8 @@ Manage Linode Instances, Configs, and Disks.
 | `filesystem` | <center>`str`</center> | <center>Optional</center> | The filesystem to create this disk with.   |
 | `image` | <center>`str`</center> | <center>Optional</center> | An Image ID to deploy the Disk from.   |
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The root user’s password on the newly-created Linode.   |
-| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
-| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).   |
+| `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
+| `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 
 ### metadata
 
@@ -355,7 +355,7 @@ Manage Linode Instances, Configs, and Disks.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linode-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) for a list of returned fields
 
 
 - `configs` - A list of configs tied to this Linode Instance.
@@ -423,7 +423,7 @@ Manage Linode Instances, Configs, and Disks.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-config) for a list of returned fields
 
 
 - `disks` - A list of disks tied to this Linode Instance.
@@ -442,7 +442,7 @@ Manage Linode Instances, Configs, and Disks.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#disk-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-disk) for a list of returned fields
 
 
 - `networking` - Networking information about this Linode Instance.
@@ -537,6 +537,6 @@ Manage Linode Instances, Configs, and Disks.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-ips) for a list of returned fields
 
 

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -91,7 +91,7 @@ Get info about a Linode Instance.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linode-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) for a list of returned fields
 
 
 - `configs` - The returned Configs.
@@ -159,7 +159,7 @@ Get info about a Linode Instance.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#configuration-profile-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-config) for a list of returned fields
 
 
 - `disks` - The returned Disks.
@@ -178,7 +178,7 @@ Get info about a Linode Instance.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#disk-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-disk) for a list of returned fields
 
 
 - `networking` - The returned Networking Configuration.
@@ -273,6 +273,6 @@ Get info about a Linode Instance.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#networking-information-list__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-ips) for a list of returned fields
 
 

--- a/docs/modules/instance_list.md
+++ b/docs/modules/instance_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Instances.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/linode-instances/#linodes-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-instances   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -98,6 +98,6 @@ List and filter on Linode Instances.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-instances/#linodes-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-instances) for a list of returned fields
 
 

--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: linode.com/docs/api/linode-types/#types-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-types   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -101,6 +101,6 @@ List and filter on Linode Instance Types.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-types/#types-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-types) for a list of returned fields
 
 

--- a/docs/modules/ip_info.md
+++ b/docs/modules/ip_info.md
@@ -50,6 +50,6 @@ Get info about a Linode IP.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#ip-address-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-ip) for a list of returned fields
 
 

--- a/docs/modules/ip_rdns.md
+++ b/docs/modules/ip_rdns.md
@@ -63,6 +63,6 @@ Manage a Linode IP address's rDNS.
           }
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#ip-address-rdns-update) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-ipv6-range) for a list of returned fields
 
 

--- a/docs/modules/ip_share.md
+++ b/docs/modules/ip_share.md
@@ -45,6 +45,6 @@ Manage the Linode shared IPs.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#ip-addresses-share__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/post-share-ips) for a list of returned fields
 
 

--- a/docs/modules/ipv6_range_info.md
+++ b/docs/modules/ipv6_range_info.md
@@ -43,6 +43,6 @@ Get info about a Linode IPv6 range.
           "region": "us-east"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#ipv6-range-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-ipv6-range) for a list of returned fields
 
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -125,7 +125,7 @@ Manage Linode LKE clusters.
           "updated": "2019-09-13T21:24:16Z"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubernetes-cluster-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster) for a list of returned fields
 
 
 - `node_pools` - A list of node pools in JSON serialized form.
@@ -162,15 +162,15 @@ Manage Linode LKE clusters.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#node-pools-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-pools) for a list of returned fields
 
 
 - `kubeconfig` - The Base64-encoded kubeconfig used to access this cluster. 
 NOTE: This value may be unavailable if `skip_polling` is true.
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubeconfig-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-kubeconfig) for a list of returned fields
 
 
 - `dashboard_url` - The Cluster Dashboard access URL.
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubernetes-cluster-dashboard-url-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-dashboard) for a list of returned fields
 
 

--- a/docs/modules/lke_cluster_info.md
+++ b/docs/modules/lke_cluster_info.md
@@ -63,7 +63,7 @@ Get info about a Linode LKE cluster.
           "updated": "2019-09-13T21:24:16Z"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubernetes-cluster-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster) for a list of returned fields
 
 
 - `node_pools` - A list of node pools in JSON serialized form.
@@ -100,15 +100,15 @@ Get info about a Linode LKE cluster.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#node-pools-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-pools) for a list of returned fields
 
 
 - `kubeconfig` - The Base64-encoded kubeconfig used to access this cluster. 
 NOTE: This value may be unavailable if the cluster is not fully provisioned.
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubeconfig-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-kubeconfig) for a list of returned fields
 
 
 - `dashboard_url` - The Cluster Dashboard access URL.
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubernetes-cluster-dashboard-url-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-dashboard) for a list of returned fields
 
 

--- a/docs/modules/lke_node_pool.md
+++ b/docs/modules/lke_node_pool.md
@@ -111,6 +111,6 @@ Manage Linode LKE cluster node pools.
           "type": "g6-standard-4"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#node-pool-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-node-pool) for a list of returned fields
 
 

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -39,6 +39,6 @@ List Kubernetes versions available for deployment to a Kubernetes cluster.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-kubernetes-engine-lke/#kubernetes-versions-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-versions) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -109,7 +109,7 @@ Manage a Linode NodeBalancer.
           "updated": "2018-03-01T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer) for a list of returned fields
 
 
 - `configs` - A list of configs applied to the NodeBalancer.
@@ -144,7 +144,7 @@ Manage a Linode NodeBalancer.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#config-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config) for a list of returned fields
 
 
 - `nodes` - A list of configs applied to the NodeBalancer.
@@ -164,7 +164,7 @@ Manage a Linode NodeBalancer.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node) for a list of returned fields
 
 
 - `firewalls` - A list IDs for firewalls attached to this NodeBalancer.
@@ -176,6 +176,6 @@ Manage a Linode NodeBalancer.
           5678
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#firewalls-list) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -61,7 +61,7 @@ Get info about a Linode NodeBalancer.
           "updated": "2018-03-01T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer) for a list of returned fields
 
 
 - `configs` - A list of configs applied to the NodeBalancer.
@@ -96,7 +96,7 @@ Get info about a Linode NodeBalancer.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#config-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config) for a list of returned fields
 
 
 - `nodes` - A list of configs applied to the NodeBalancer.
@@ -116,7 +116,7 @@ Get info about a Linode NodeBalancer.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node) for a list of returned fields
 
 
 - `firewalls` - A list IDs for firewalls attached to this NodeBalancer.
@@ -128,6 +128,6 @@ Get info about a Linode NodeBalancer.
           5678
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#firewalls-list) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_list.md
+++ b/docs/modules/nodebalancer_list.md
@@ -41,7 +41,7 @@ List and filter on Nodebalancers.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/nodebalancers/#nodebalancers-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-node-balancers   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -73,6 +73,6 @@ List and filter on Nodebalancers.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#nodebalancers-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancers) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_node.md
+++ b/docs/modules/nodebalancer_node.md
@@ -78,6 +78,6 @@ Manage Linode NodeBalancer Nodes.
           "weight": 10
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#node-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_stats.md
+++ b/docs/modules/nodebalancer_stats.md
@@ -57,6 +57,6 @@ View a Linode NodeBalancers Stats.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/nodebalancers/#nodebalancer-statistics-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-stats) for a list of returned fields
 
 

--- a/docs/modules/object_cluster_info.md
+++ b/docs/modules/object_cluster_info.md
@@ -54,6 +54,6 @@ Get info about a Linode Object Storage Cluster.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/object-storage/#cluster-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-cluster) for a list of returned fields
 
 

--- a/docs/modules/object_cluster_list.md
+++ b/docs/modules/object_cluster_list.md
@@ -43,7 +43,7 @@ List and filter on Object Storage Clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/object-storage/#clusters-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -62,6 +62,6 @@ List and filter on Object Storage Clusters.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/object-storage/#clusters-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters) for a list of returned fields
 
 

--- a/docs/modules/object_keys.md
+++ b/docs/modules/object_keys.md
@@ -104,6 +104,6 @@ Manage Linode Object Storage Keys.
           "secret_key": "[REDACTED]"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/object-storage/#object-storage-key-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-key) for a list of returned fields
 
 

--- a/docs/modules/profile_info.md
+++ b/docs/modules/profile_info.md
@@ -51,6 +51,6 @@ Get info about a Linode Profile.
           "verified_phone_number": "+5555555555"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#profile-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-profile) for a list of returned fields
 
 

--- a/docs/modules/region_list.md
+++ b/docs/modules/region_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Regions.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/regions/#regions-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-regions   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -77,6 +77,6 @@ List and filter on Linode Regions.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/regions/#regions-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-regions) for a list of returned fields
 
 

--- a/docs/modules/ssh_key.md
+++ b/docs/modules/ssh_key.md
@@ -50,6 +50,6 @@ Manage a Linode SSH key.
           "ssh_key": "ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#ssh-key-add__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key) for a list of returned fields
 
 

--- a/docs/modules/ssh_key_info.md
+++ b/docs/modules/ssh_key_info.md
@@ -47,6 +47,6 @@ Get info about the Linode SSH public key.
           "ssh_key": "ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#ssh-key-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-ssh-key) for a list of returned fields
 
 

--- a/docs/modules/ssh_key_list.md
+++ b/docs/modules/ssh_key_list.md
@@ -61,7 +61,7 @@ List and filter on SSH keys in the Linode profile.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/profile/#ssh-keys-list   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-profile   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -79,6 +79,6 @@ List and filter on SSH keys in the Linode profile.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#ssh-keys-list) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-ssh-keys) for a list of returned fields
 
 

--- a/docs/modules/stackscript.md
+++ b/docs/modules/stackscript.md
@@ -83,6 +83,6 @@ Manage a Linode StackScript.
           "username": "myuser"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/stackscripts/#stackscript-create__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/post-add-stack-script) for a list of returned fields
 
 

--- a/docs/modules/stackscript_list.md
+++ b/docs/modules/stackscript_list.md
@@ -49,7 +49,7 @@ List and filter on Linode stackscripts.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-stack-scripts   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -90,6 +90,6 @@ List and filter on Linode stackscripts.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts) for a list of returned fields
 
 

--- a/docs/modules/token.md
+++ b/docs/modules/token.md
@@ -64,6 +64,6 @@ NOTE: The full Personal Access Token is only returned when a new token has been 
           "token": "abcdefghijklmnop"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#personal-access-token-create__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/post-personal-access-token) for a list of returned fields
 
 

--- a/docs/modules/token_info.md
+++ b/docs/modules/token_info.md
@@ -49,6 +49,6 @@ Get info about a Linode Personal Access Token.
           "token": "abcdefghijklmnop"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#personal-access-token-create__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/post-personal-access-token) for a list of returned fields
 
 

--- a/docs/modules/token_list.md
+++ b/docs/modules/token_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Account tokens.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/profile/#personal-access-tokens-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-profile   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -61,6 +61,6 @@ List and filter on Linode Account tokens.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/profile/#personal-access-tokens-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-personal-access-tokens) for a list of returned fields
 
 

--- a/docs/modules/type_info.md
+++ b/docs/modules/type_info.md
@@ -59,6 +59,6 @@ Get info about a Linode Type.
             "vcpus": 2
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-types/#type-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-type) for a list of returned fields
 
 

--- a/docs/modules/type_list.md
+++ b/docs/modules/type_list.md
@@ -42,7 +42,7 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/linode-types/#types-list__response-samples   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-types   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -78,6 +78,6 @@ List and filter on Linode Instance Types.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/linode-types/#types-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-types) for a list of returned fields
 
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -106,7 +106,7 @@ Manage a Linode User.
           "username": "example_user"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#user-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-user) for a list of returned fields
 
 
 - `grants` - The grants info in JSON serialized form.
@@ -179,6 +179,6 @@ Manage a Linode User.
           ]
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#users-grants-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for a list of returned fields
 
 

--- a/docs/modules/user_info.md
+++ b/docs/modules/user_info.md
@@ -45,7 +45,7 @@ Get info about a Linode User.
           "username": "example_user"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#user-view) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-user) for a list of returned fields
 
 
 - `grants` - The grants info in JSON serialized form.
@@ -118,6 +118,6 @@ Get info about a Linode User.
           ]
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#users-grants-view__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-user-grants) for a list of returned fields
 
 

--- a/docs/modules/user_list.md
+++ b/docs/modules/user_list.md
@@ -47,6 +47,6 @@ List Users.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/account/#users-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-account) for a list of returned fields
 
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -46,6 +46,6 @@ Get info about a Linode VLAN.
           "region": "ap-west"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#vlans-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-vlans) for a list of returned fields
 
 

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -46,7 +46,7 @@ List and filter on Linode VLANs.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/networking/#vlans-list__response-samples   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-vlans   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -67,6 +67,6 @@ List and filter on Linode VLANs.
            }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/networking/#vlans-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-vlans) for a list of returned fields
 
 

--- a/docs/modules/volume.md
+++ b/docs/modules/volume.md
@@ -103,6 +103,6 @@ Manage a Linode Volume.
           "updated": "2018-01-01T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/volumes/#volume-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-volume) for a list of returned fields
 
 

--- a/docs/modules/volume_info.md
+++ b/docs/modules/volume_info.md
@@ -56,6 +56,6 @@ Get info about a Linode Volume.
           "updated": "2018-01-01T00:01:01"
         }
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/volumes/#volume-view__responses) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-volume) for a list of returned fields
 
 

--- a/docs/modules/volume_list.md
+++ b/docs/modules/volume_list.md
@@ -41,7 +41,7 @@ List and filter on Linode Volumes.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://www.linode.com/docs/api/volumes/#volumes-list__responses   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-volumes   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -70,6 +70,6 @@ List and filter on Linode Volumes.
             }
         ]
         ```
-    - See the [Linode API response documentation](https://www.linode.com/docs/api/volumes/#volumes-list__response-samples) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-volumes) for a list of returned fields
 
 

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -37,7 +37,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "account": SpecReturnValue(
             description="The account info in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/account/#account-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-account",
             type=FieldType.dict,
             sample=docs.result_account_samples,
         )

--- a/plugins/modules/api_request.py
+++ b/plugins/modules/api_request.py
@@ -60,7 +60,7 @@ SPEC = {
         type=FieldType.dict,
         description=[
             "A YAML structure corresponding to the X-Filter request header.",
-            "See: https://www.linode.com/docs/api/#filtering-and-sorting",
+            "See: https://techdocs.akamai.com/linode-api/reference",
         ],
     ),
 }
@@ -69,7 +69,7 @@ SPECDOC_META = SpecDocMeta(
     description=[
         "Make an arbitrary Linode API request.",
         "The Linode API documentation can be found here: "
-        "https://www.linode.com/docs/api",
+        "https://techdocs.akamai.com/linode-api/reference",
     ],
     requirements=global_requirements,
     author=global_authors,

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -34,8 +34,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/databases/"
-            "#managed-database-engines-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-databases-engines",
         ],
     ),
     "values": SpecField(
@@ -89,8 +88,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "engines": SpecReturnValue(
             description="The returned database engine types.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-database-engines-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-databases-engines",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_engines_samples,

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -34,8 +34,7 @@ spec_filter = {
             "The name of the field to filter on.",
             (
                 "Valid filterable attributes can be found here: "
-                "https://www.linode.com/docs/api/databases/"
-                "#managed-databases-list-all__responses"
+                "https://techdocs.akamai.com/linode-api/reference/get-databases-engines"
             ),
         ],
     ),
@@ -88,8 +87,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "databases": SpecReturnValue(
             description="The returned database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-databases-list-all__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-databases-instances",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_images_samples,

--- a/plugins/modules/database_mysql.py
+++ b/plugins/modules/database_mysql.py
@@ -141,29 +141,29 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "database": SpecReturnValue(
             description="The database in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance",
             type=FieldType.dict,
             sample=docs.result_database_samples,
         ),
         "backups": SpecReturnValue(
             description="The database backups in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-backup-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-backup",
             type=FieldType.dict,
             sample=docs.result_backups_samples,
         ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed MySQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-ssl-certificate-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-ssl",
             type=FieldType.dict,
             sample=docs.result_ssl_cert_samples,
         ),
         "credentials": SpecReturnValue(
             description="The root username and password for an accessible Managed MySQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-credentials-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-credentials",
             type=FieldType.dict,
             sample=docs.result_credentials_samples,
         ),

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -81,7 +81,8 @@ SPECDOC_META = SpecDocMeta(
         ),
         "credentials": SpecReturnValue(
             description="The root username and password for an accessible Managed MySQL Database.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-credentials",
             type=FieldType.dict,
             sample=docs_parent.result_credentials_samples,
         ),

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -60,30 +60,28 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "database": SpecReturnValue(
             description="The database in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance",
             type=FieldType.dict,
             sample=docs_parent.result_database_samples,
         ),
         "backups": SpecReturnValue(
             description="The database backups in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-backup-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-backup",
             type=FieldType.dict,
             sample=docs_parent.result_backups_samples,
         ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed MySQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-ssl-certificate-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-mysql-instance-ssl",
             type=FieldType.dict,
             sample=docs_parent.result_ssl_cert_samples,
         ),
         "credentials": SpecReturnValue(
             description="The root username and password for an accessible Managed MySQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-mysql-database-credenti"
-            "als-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-credentials",
             type=FieldType.dict,
             sample=docs_parent.result_credentials_samples,
         ),

--- a/plugins/modules/database_postgresql.py
+++ b/plugins/modules/database_postgresql.py
@@ -152,30 +152,30 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "database": SpecReturnValue(
             description="The database in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance",
             type=FieldType.dict,
             sample=docs.result_database_samples,
         ),
         "backups": SpecReturnValue(
             description="The database backups in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/#"
-            "managed-postgresql-database-backups-list",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance-backups",
             type=FieldType.dict,
             sample=docs.result_backups_samples,
         ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed PostgreSQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-ssl-certificate-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgresql-instance-ssl",
             type=FieldType.dict,
             sample=docs.result_ssl_cert_samples,
         ),
         "credentials": SpecReturnValue(
             description="The root username and password for an "
             "accessible Managed PostgreSQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-credentials-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance-credentials",
             type=FieldType.dict,
             sample=docs.result_credentials_samples,
         ),

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -60,30 +60,30 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "database": SpecReturnValue(
             description="The database in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance",
             type=FieldType.dict,
             sample=docs_parent.result_database_samples,
         ),
         "backups": SpecReturnValue(
             description="The database backups in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-backups-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance-backups",
             type=FieldType.dict,
             sample=docs_parent.result_backups_samples,
         ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed PostgreSQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-ssl-certificate-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgresql-instance-ssl",
             type=FieldType.dict,
             sample=docs_parent.result_ssl_cert_samples,
         ),
         "credentials": SpecReturnValue(
             description="The root username and password for an accessible Managed "
             "PostgreSQL Database.",
-            docs_url="https://www.linode.com/docs/api/databases/"
-            "#managed-postgresql-database-credentials-view__request-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/"
+            "get-databases-postgre-sql-instance-credentials",
             type=FieldType.dict,
             sample=docs_parent.result_credentials_samples,
         ),

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -141,19 +141,19 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "domain": SpecReturnValue(
             description="The domain in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
             type=FieldType.dict,
             sample=docs.result_domain_samples,
         ),
         "records": SpecReturnValue(
             description="The domain record in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-record-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
             type=FieldType.list,
             sample=docs.result_records_samples,
         ),
         "zone_file": SpecReturnValue(
             description="The zone file for the last rendered zone for the specified domain.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-zone-file-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-zone",
             type=FieldType.list,
             sample=docs.result_zone_file_samples,
         ),

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -61,19 +61,19 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "domain": SpecReturnValue(
             description="The domain in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
             type=FieldType.dict,
             sample=docs_parent.result_domain_samples,
         ),
         "records": SpecReturnValue(
             description="The domain record in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-record-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
             type=FieldType.list,
             sample=docs_parent.result_records_samples,
         ),
         "zone_file": SpecReturnValue(
             description="The zone file for the last rendered zone for the specified domain.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-zone-file-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-zone",
             type=FieldType.list,
             sample=docs_parent.result_zone_file_samples,
         ),

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -31,8 +31,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/domains/#domains-list__responses"
-            "#domains-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-domains",
         ],
     ),
     "values": SpecField(
@@ -84,8 +83,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "domains": SpecReturnValue(
             description="The returned domains.",
-            docs_url="https://www.linode.com/docs/api/domains/"
-            "#domains-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domains",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_domains_samples,

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -141,7 +141,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "record": SpecReturnValue(
             description="View a single Record on this Domain.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-record-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
             type=FieldType.dict,
             sample=docs.result_record_samples,
         )

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -78,7 +78,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "record": SpecReturnValue(
             description="View a single Record on this Domain.",
-            docs_url="https://www.linode.com/docs/api/domains/#domain-record-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
             type=FieldType.dict,
             sample=docs_parent.result_record_samples,
         )

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -33,7 +33,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/account/#events-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-events",
         ],
     ),
     "values": SpecField(
@@ -84,7 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "events": SpecReturnValue(
             description="The returned events.",
-            docs_url="https://www.linode.com/docs/api/account/#events-list__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-events",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_events_samples,

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -82,7 +82,7 @@ linode_firewall_rule_spec: dict = {
         type=FieldType.string,
         description=[
             "A string representing the port or ports on which traffic will be allowed.",
-            "See https://www.linode.com/docs/api/networking/#firewall-create",
+            "See https://techdocs.akamai.com/linode-api/reference/post-firewalls",
         ],
     ),
     "protocol": SpecField(
@@ -175,13 +175,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "firewall": SpecReturnValue(
             description="The Firewall description in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#firewall-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall",
             type=FieldType.dict,
             sample=docs.result_firewall_samples,
         ),
         "devices": SpecReturnValue(
             description="A list of Firewall devices JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#firewall-device-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall-device",
             type=FieldType.list,
             sample=docs.result_devices_samples,
         ),

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -65,7 +65,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "device": SpecReturnValue(
             description="The Firewall Device in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#firewall-device-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall-device",
             type=FieldType.dict,
             sample=docs.result_device_samples,
         )

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -57,13 +57,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "firewall": SpecReturnValue(
             description="The Firewall description in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#firewall-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall",
             type=FieldType.dict,
             sample=docs_parent.result_firewall_samples,
         ),
         "devices": SpecReturnValue(
             description="A list of Firewall devices JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#firewall-device-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall-device",
             type=FieldType.list,
             sample=docs_parent.result_devices_samples,
         ),

--- a/plugins/modules/firewall_list.py
+++ b/plugins/modules/firewall_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/networking/"
-            "#firewalls-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-ips",
         ],
     ),
     "values": SpecField(
@@ -85,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "firewalls": SpecReturnValue(
             description="The returned firewalls.",
-            docs_url="https://www.linode.com/docs/api/networking/"
-            "#firewalls-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewalls",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_firewalls_samples,

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -100,8 +100,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "image": SpecReturnValue(
             description="The Image in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/images/"
-            "#image-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-image",
             type=FieldType.dict,
             sample=docs.result_image_samples,
         )

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -51,7 +51,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "image": SpecReturnValue(
             description="The image in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/images/#image-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-image",
             type=FieldType.dict,
             sample=docs_parent.result_image_samples,
         )

--- a/plugins/modules/image_list.py
+++ b/plugins/modules/image_list.py
@@ -14,7 +14,7 @@ module = ListModule(
     result_display_name="Images",
     result_field_name="images",
     endpoint_template="/images",
-    result_docs_url="https://www.linode.com/docs/api/images/#images-list__responses",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-images",
     result_samples=docs.result_images_samples,
     examples=docs.specdoc_examples,
 )

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -106,7 +106,8 @@ linode_instance_disk_spec = {
         type=FieldType.integer,
         description=[
             "The ID of the StackScript to use when creating the instance.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).",
         ],
     ),
     "stackscript_data": SpecField(
@@ -115,7 +116,8 @@ linode_instance_disk_spec = {
             "An object containing arguments to any User Defined Fields present in "
             "the StackScript used when creating the instance.",
             "Only valid when a stackscript_id is provided.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).",
         ],
     ),
 }
@@ -287,8 +289,8 @@ linode_instance_config_spec = {
         editable=True,
         description=[
             "A list of network interfaces to apply to the Linode.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances"
-            "/#configuration-profile-create__request-body-schema).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/post-add-linode-config).",
         ],
     ),
 }
@@ -356,7 +358,8 @@ linode_instance_spec = {
         type=FieldType.integer,
         description=[
             "The ID of the StackScript to use when creating the instance.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).",
         ],
     ),
     "stackscript_data": SpecField(
@@ -365,7 +368,8 @@ linode_instance_spec = {
             "An object containing arguments to any User Defined Fields present in "
             "the StackScript used when creating the instance.",
             "Only valid when a stackscript_id is provided.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/stackscripts/).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).",
         ],
     ),
     "firewall_id": SpecField(
@@ -430,8 +434,8 @@ linode_instance_spec = {
         conflicts_with=["disks", "configs"],
         description=[
             "A list of network interfaces to apply to the Linode.",
-            "See the [Linode API documentation](https://www.linode.com/docs/api/linode-instances/"
-            "#linode-create__request-body-schema).",
+            "See the [Linode API documentation]"
+            "(https://techdocs.akamai.com/linode-api/reference/post-linode-instance).",
         ],
     ),
     "booted": SpecField(
@@ -530,27 +534,25 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "instance": SpecReturnValue(
             description="The instance description in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instance",
             type=FieldType.dict,
             sample=docs.result_instance_samples,
         ),
         "configs": SpecReturnValue(
             description="A list of configs tied to this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#configuration-profile-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-config",
             type=FieldType.list,
             sample=docs.result_configs_samples,
         ),
         "disks": SpecReturnValue(
             description="A list of disks tied to this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-disk",
             type=FieldType.list,
             sample=docs.result_disks_samples,
         ),
         "networking": SpecReturnValue(
             description="Networking information about this Linode Instance.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#networking-information-list__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-ips",
             type=FieldType.dict,
             sample=docs.result_networking_samples,
         ),

--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -25,7 +25,7 @@ module = InfoModule(
         display_name="Instance",
         field_name="instance",
         field_type=FieldType.dict,
-        docs_url="https://www.linode.com/docs/api/linode-instances/#linode-view__responses",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instance",
         samples=docs_parent.result_instance_samples,
     ),
     secondary_results=[
@@ -33,8 +33,7 @@ module = InfoModule(
             field_name="configs",
             field_type=FieldType.list,
             display_name="Configs",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#configuration-profile-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-config",
             samples=docs_parent.result_configs_samples,
             get=lambda client, instance, params: paginated_list_to_json(
                 Instance(client, instance.get("id")).configs
@@ -44,7 +43,7 @@ module = InfoModule(
             field_name="disks",
             field_type=FieldType.list,
             display_name="Disks",
-            docs_url="https://www.linode.com/docs/api/linode-instances/#disk-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-disk",
             samples=docs_parent.result_disks_samples,
             get=lambda client, instance, params: paginated_list_to_json(
                 Instance(client, instance.get("id")).disks
@@ -54,8 +53,7 @@ module = InfoModule(
             field_name="networking",
             field_type=FieldType.dict,
             display_name="Networking Configuration",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#networking-information-list__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-ips",
             samples=docs_parent.result_networking_samples,
             get=lambda client, instance, params: client.get(
                 "/linode/instances/{0}/ips".format(instance.get("id"))

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/linode-instances/"
-            "#linodes-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
         ],
     ),
     "values": SpecField(
@@ -85,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "instances": SpecReturnValue(
             description="The returned instances.",
-            docs_url="https://www.linode.com/docs/api/linode-instances/"
-            "#linodes-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_images_samples,

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -34,8 +34,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "linode.com/docs/api/linode-types/"
-            "#types-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-linode-types",
         ],
     ),
     "values": SpecField(
@@ -89,8 +88,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "instance_types": SpecReturnValue(
             description="The returned instance types.",
-            docs_url="https://www.linode.com/docs/api/linode-types/"
-            "#types-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_instance_type_samples,

--- a/plugins/modules/ip_info.py
+++ b/plugins/modules/ip_info.py
@@ -47,7 +47,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "ip": SpecReturnValue(
             description="The IP in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#ip-address-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-ip",
             type=FieldType.dict,
             sample=docs.result_ip_samples,
         )

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -58,7 +58,7 @@ SPECDOC_META = SpecDocMeta(
                 "reverse DNS in JSON serialized form."
             ),
             docs_url=(
-                "https://www.linode.com/docs/api/profile/#ip-address-rdns-update"
+                "https://techdocs.akamai.com/linode-api/reference/get-ipv6-range"
             ),
             type=FieldType.dict,
             sample=ip_docs.result_ip_samples,

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -56,8 +56,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "ip_share_stats": SpecReturnValue(
             description="The Linode IP share info in JSON serialized form",
-            docs_url="https://www.linode.com/docs/api/networking/"
-            + "#ip-addresses-share__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/post-share-ips",
             type=FieldType.dict,
             sample=ip_share_docs.result_ip_share_stats_samples,
         )

--- a/plugins/modules/ipv6_range_info.py
+++ b/plugins/modules/ipv6_range_info.py
@@ -44,8 +44,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "range": SpecReturnValue(
             description="The IPv6 range in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/"
-            "#ipv6-range-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-ipv6-range",
             type=FieldType.dict,
             sample=docs.result_range_samples,
         )

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -210,29 +210,25 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "cluster": SpecReturnValue(
             description="The LKE cluster in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubernetes-cluster-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster",
             type=FieldType.dict,
             sample=docs.result_cluster,
         ),
         "node_pools": SpecReturnValue(
             description="A list of node pools in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#node-pools-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-pools",
             type=FieldType.list,
             sample=docs.result_node_pools,
         ),
         "kubeconfig": SpecReturnValue(
             description="The Base64-encoded kubeconfig used to access this cluster. \n"
             "NOTE: This value may be unavailable if `skip_polling` is true.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubeconfig-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-kubeconfig",
             type=FieldType.string,
         ),
         "dashboard_url": SpecReturnValue(
             description="The Cluster Dashboard access URL.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubernetes-cluster-dashboard-url-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-dashboard",
             type=FieldType.string,
         ),
     },

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -67,15 +67,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "cluster": SpecReturnValue(
             description="The LKE cluster in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubernetes-cluster-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster",
             type=FieldType.dict,
             sample=docs_parent.result_cluster,
         ),
         "node_pools": SpecReturnValue(
             description="A list of node pools in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#node-pools-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-pools",
             type=FieldType.list,
             sample=docs_parent.result_node_pools,
         ),
@@ -83,14 +81,12 @@ SPECDOC_META = SpecDocMeta(
             description="The Base64-encoded kubeconfig used to access this cluster. \n"
             "NOTE: This value may be unavailable if the cluster is not "
             "fully provisioned.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubeconfig-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-kubeconfig",
             type=FieldType.string,
         ),
         "dashboard_url": SpecReturnValue(
             description="The Cluster Dashboard access URL.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubernetes-cluster-dashboard-url-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-cluster-dashboard",
             type=FieldType.string,
         ),
     },

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -151,8 +151,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "node_pool": SpecReturnValue(
             description="The Node Pool in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#node-pool-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-node-pool",
             type=FieldType.dict,
             sample=docs.result_node_pool,
         )

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -54,8 +54,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "lke_versions": SpecReturnValue(
             description="The returned LKE versions.",
-            docs_url="https://www.linode.com/docs/api/linode-kubernetes-engine-lke/"
-            "#kubernetes-versions-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-versions",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_lke_versions_samples,

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -279,25 +279,25 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "node_balancer": SpecReturnValue(
             description="The NodeBalancer in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer",
             type=FieldType.dict,
             sample=docs.result_node_balancer_samples,
         ),
         "configs": SpecReturnValue(
             description="A list of configs applied to the NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#config-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config",
             type=FieldType.list,
             sample=docs.result_configs_samples,
         ),
         "nodes": SpecReturnValue(
             description="A list of configs applied to the NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#node-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node",
             type=FieldType.list,
             sample=docs.result_nodes_samples,
         ),
         "firewalls": SpecReturnValue(
             description="A list IDs for firewalls attached to this NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls",
             type=FieldType.list,
             elements=FieldType.integer,
             sample=docs.result_firewalls_samples,

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -63,25 +63,25 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "node_balancer": SpecReturnValue(
             description="The NodeBalancer in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#nodebalancer-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer",
             type="dict",
             sample=docs_parent.result_node_balancer_samples,
         ),
         "configs": SpecReturnValue(
             description="A list of configs applied to the NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#config-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config",
             type=FieldType.list,
             sample=docs_parent.result_configs_samples,
         ),
         "nodes": SpecReturnValue(
             description="A list of configs applied to the NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#node-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node",
             type=FieldType.list,
             sample=docs_parent.result_nodes_samples,
         ),
         "firewalls": SpecReturnValue(
             description="A list IDs for firewalls attached to this NodeBalancer.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#firewalls-list",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls",
             type=FieldType.list,
             elements=FieldType.integer,
             sample=docs_parent.result_firewalls_samples,

--- a/plugins/modules/nodebalancer_list.py
+++ b/plugins/modules/nodebalancer_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/nodebalancers/"
-            "#nodebalancers-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-node-balancers",
         ],
     ),
     "values": SpecField(
@@ -87,8 +86,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "nodebalancers": SpecReturnValue(
             description="The returned nodebalancers.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/"
-            "#nodebalancers-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancers",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_nodebalancers_samples,

--- a/plugins/modules/nodebalancer_node.py
+++ b/plugins/modules/nodebalancer_node.py
@@ -87,7 +87,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "node": SpecReturnValue(
             description="The NodeBalancer Node in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/#node-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node",
             type=FieldType.dict,
             sample=docs.result_node_samples,
         )

--- a/plugins/modules/nodebalancer_stats.py
+++ b/plugins/modules/nodebalancer_stats.py
@@ -52,8 +52,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "node_balancer_stats": SpecReturnValue(
             description="The NodeBalancer Stats in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/nodebalancers/"
-            + "#nodebalancer-statistics-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-stats",
             type=FieldType.dict,
             sample=docs.result_nodebalancer_stats_samples,
         ),

--- a/plugins/modules/object_cluster_info.py
+++ b/plugins/modules/object_cluster_info.py
@@ -66,7 +66,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "clusters": SpecReturnValue(
             description="The Object Storage clusters in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/object-storage/#cluster-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-cluster",
             type=FieldType.list,
             sample=docs.result_clusters_samples,
         )

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -34,8 +34,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/object-storage/"
-            "#clusters-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets",
         ],
     ),
     "values": SpecField(
@@ -95,8 +94,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "clusters": SpecReturnValue(
             description="The returned object storage clusters.",
-            docs_url="https://www.linode.com/docs/api/object-storage/"
-            "#clusters-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_object_clusters_samples,

--- a/plugins/modules/object_keys.py
+++ b/plugins/modules/object_keys.py
@@ -94,8 +94,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "key": SpecReturnValue(
             description="The Object Storage key in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/object-storage/#object-storage"
-            "-key-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-key",
             type=FieldType.dict,
             sample=docs.result_key_samples,
         )

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -38,7 +38,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "profile": SpecReturnValue(
             description="The profile info in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/profile/#profile-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-profile",
             type=FieldType.dict,
             sample=docs.result_profile_samples,
         )

--- a/plugins/modules/region_list.py
+++ b/plugins/modules/region_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/regions/"
-            "#regions-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-regions",
         ],
     ),
     "values": SpecField(
@@ -85,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "regions": SpecReturnValue(
             description="The returned regions.",
-            docs_url="https://www.linode.com/docs/api/regions/"
-            "#regions-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-regions",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_regions_samples,

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -54,8 +54,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "ssh_key": SpecReturnValue(
             description="The created SSH key in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/profile/"
-            "#ssh-key-add__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/post-add-ssh-key",
             type=FieldType.dict,
             sample=docs.result_ssh_key_samples,
         )

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -50,8 +50,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "ssh_key": SpecReturnValue(
             description="The SSH key in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/profile/"
-            "#ssh-key-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-ssh-key",
             type=FieldType.dict,
             sample=docs.ssh_key_info_response_sample,
         )

--- a/plugins/modules/ssh_key_list.py
+++ b/plugins/modules/ssh_key_list.py
@@ -34,8 +34,7 @@ spec_filter = {
             "The name of the field to filter on.",
             (
                 "Valid filterable attributes can be found here: "
-                "https://www.linode.com/docs/api/profile/"
-                "#ssh-keys-list"
+                "https://techdocs.akamai.com/linode-api/reference/get-profile"
             ),
         ],
     ),
@@ -88,7 +87,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "ssh_keys": SpecReturnValue(
             description="The returned SSH keys.",
-            docs_url="https://www.linode.com/docs/api/profile/#ssh-keys-list",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-ssh-keys",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_ssh_key_list_samples,

--- a/plugins/modules/stackscript.py
+++ b/plugins/modules/stackscript.py
@@ -84,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "stackscript": SpecReturnValue(
             description="The StackScript in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/stackscripts/"
-            "#stackscript-create__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/post-add-stack-script",
             type=FieldType.dict,
             sample=docs.result_stackscript_samples,
         )

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -34,7 +34,7 @@ spec_filter = {
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
             # pylint: disable-next=line-too-long
-            "https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples",
+            "https://techdocs.akamai.com/linode-api/reference/get-stack-scripts",
         ],
     ),
     "values": SpecField(
@@ -86,7 +86,7 @@ SPECDOC_META = SpecDocMeta(
         "stackscripts": SpecReturnValue(
             description="The returned stackscripts.",
             # pylint: disable-next=line-too-long
-            docs_url="https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-stack-scripts",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_stackscripts_samples,

--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -59,8 +59,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "token": SpecReturnValue(
             description="The token in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/profile/"
-            "#personal-access-token-create__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/post-personal-access-token",
             type=FieldType.dict,
             sample=docs.result_token_samples,
         )

--- a/plugins/modules/token_info.py
+++ b/plugins/modules/token_info.py
@@ -51,8 +51,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "token": SpecReturnValue(
             description="The token in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/profile/"
-            "#personal-access-token-create__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/post-personal-access-token",
             type=FieldType.dict,
             sample=docs_parent.result_token_samples,
         )

--- a/plugins/modules/token_list.py
+++ b/plugins/modules/token_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/profile/"
-            "#personal-access-tokens-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-profile",
         ],
     ),
     "values": SpecField(
@@ -85,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "tokens": SpecReturnValue(
             description="The returned tokens.",
-            docs_url="https://www.linode.com/docs/api/profile/"
-            "#personal-access-tokens-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-personal-access-tokens",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_tokens_samples,

--- a/plugins/modules/type_info.py
+++ b/plugins/modules/type_info.py
@@ -34,7 +34,7 @@ module = InfoModule(
         field_name="type",
         field_type=FieldType.dict,
         display_name="Type",
-        docs_url="https://www.linode.com/docs/api/linode-types/#type-view",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-type",
         samples=docs.result_type_samples,
     ),
     attributes=[

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -33,7 +33,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/linode-types/#types-list__response-samples",
+            "https://techdocs.akamai.com/linode-api/reference/get-linode-types",
         ],
     ),
     "values": SpecField(
@@ -87,7 +87,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "types": SpecReturnValue(
             description="The returned Instance Types.",
-            docs_url="https://www.linode.com/docs/api/linode-types/#types-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_type_samples,

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -216,14 +216,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "user": SpecReturnValue(
             description="The user in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/account/#user-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-user",
             type=FieldType.dict,
             sample=docs.result_user_samples,
         ),
         "grants": SpecReturnValue(
             description="The grants info in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/account/"
-            "#users-grants-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-user-grants",
             type=FieldType.dict,
             sample=docs.result_grants_samples,
         ),

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -43,13 +43,13 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "user": SpecReturnValue(
             description="The user info in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/account/#user-view",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-user",
             type=FieldType.dict,
             sample=docs.result_user_samples,
         ),
         "grants": SpecReturnValue(
             description="The grants info in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/account/#users-grants-view__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-user-grants",
             type=FieldType.dict,
             sample=docs.result_grants_samples,
         ),

--- a/plugins/modules/user_list.py
+++ b/plugins/modules/user_list.py
@@ -53,8 +53,7 @@ SPECDOC_META = SpecDocMeta(
         "users": SpecReturnValue(
             description="The returned users.",
             docs_url=(
-                "https://www.linode.com/docs/api/account/"
-                "#users-list__response-samples"
+                "https://techdocs.akamai.com/linode-api/reference/get-account"
             ),
             type=FieldType.list,
             elements=FieldType.dict,

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -44,7 +44,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "vlan": SpecReturnValue(
             description="The VLAN in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/networking/#vlans-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
             type=FieldType.dict,
             sample=docs.result_vlan_samples,
         )

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -34,7 +34,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/networking/#vlans-list__response-samples",
+            "https://techdocs.akamai.com/linode-api/reference/get-vlans",
         ],
     ),
     "values": SpecField(
@@ -88,7 +88,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "vlans": SpecReturnValue(
             description="The returned VLANs.",
-            docs_url="https://www.linode.com/docs/api/networking/#vlans-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_vlan_samples,

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -109,7 +109,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "volume": SpecReturnValue(
             description="The volume in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/volumes/#volume-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-volume",
             type=FieldType.dict,
             sample=docs.result_volume_samples,
         )

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -59,7 +59,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "volume": SpecReturnValue(
             description="The volume in JSON serialized form.",
-            docs_url="https://www.linode.com/docs/api/volumes/#volume-view__responses",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-volume",
             type=FieldType.dict,
             sample=docs_parent.result_volume_samples,
         ),

--- a/plugins/modules/volume_list.py
+++ b/plugins/modules/volume_list.py
@@ -32,8 +32,7 @@ spec_filter = {
         description=[
             "The name of the field to filter on.",
             "Valid filterable attributes can be found here: "
-            "https://www.linode.com/docs/api/volumes/"
-            "#volumes-list__responses",
+            "https://techdocs.akamai.com/linode-api/reference/get-volumes",
         ],
     ),
     "values": SpecField(
@@ -85,8 +84,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         "volumes": SpecReturnValue(
             description="The returned volumes.",
-            docs_url="https://www.linode.com/docs/api/volumes/"
-            "#volumes-list__response-samples",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-volumes",
             type=FieldType.list,
             elements=FieldType.dict,
             sample=docs.result_volumes_samples,

--- a/scripts/render_galaxy.py
+++ b/scripts/render_galaxy.py
@@ -4,15 +4,19 @@ import jinja2
 
 
 def main() -> None:
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader('template'))
-    tpl = env.get_template('galaxy.template.yml')
-    output = tpl.render({
-        'collection_version': sys.argv[1].removeprefix('v') if len(sys.argv) > 1 else '0.0.0'
-    })
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader("template"))
+    tpl = env.get_template("galaxy.template.yml")
+    output = tpl.render(
+        {
+            "collection_version": (
+                sys.argv[1].removeprefix("v") if len(sys.argv) > 1 else "0.0.0"
+            )
+        }
+    )
 
-    with open('galaxy.yml', 'w') as f:
+    with open("galaxy.yml", "w") as f:
         f.write(output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/render_readme.py
+++ b/scripts/render_readme.py
@@ -17,12 +17,12 @@ def get_ansible_root(base_dir):
         path = path.parent
 
     # Check if ansible_collections is contained in base directory
-    if 'ansible_collections' in os.listdir(str(path)):
+    if "ansible_collections" in os.listdir(str(path)):
         return str(path.absolute())
 
     # Check if base directory is a child of ansible_collections
-    while path.name != 'ansible_collections':
-        if path.name == '':
+    while path.name != "ansible_collections":
+        if path.name == "":
             return None
 
         path = path.parent
@@ -36,9 +36,11 @@ def add_ansible_collection_path():
     ansible_root = get_ansible_root(target_path)
 
     if ansible_root is None:
-        print('WARNING: The current directory is not at or '
-              'below an Ansible collection: {...}/ansible_collections/{'
-              'namespace}/{collection}/')
+        print(
+            "WARNING: The current directory is not at or "
+            "below an Ansible collection: {...}/ansible_collections/{"
+            "namespace}/{collection}/"
+        )
         return
 
     sys.path.append(ansible_root)
@@ -59,60 +61,73 @@ def get_module_metadata(module_file):
     module = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(module)
 
-    description = getattr(module, 'SPECDOC_META').description
+    description = getattr(module, "SPECDOC_META").description
     if isinstance(description, list):
         description = description[0]
 
     return {
-        'name': name,
-        'description': description,
+        "name": name,
+        "description": description,
     }
 
 
 def list_modules_metadata(filter_func: Callable[[str], bool]):
     result = []
 
-    for dirpath, _, filenames in os.walk('plugins/modules'):
-        for f in sorted([f for f in filenames
-                         if f.endswith('.py') and filter_func(f)]):
-            result.append(get_module_metadata(os.path.abspath(os.path.join(dirpath, f))))
+    for dirpath, _, filenames in os.walk("plugins/modules"):
+        for f in sorted(
+            [f for f in filenames if f.endswith(".py") and filter_func(f)]
+        ):
+            result.append(
+                get_module_metadata(os.path.abspath(os.path.join(dirpath, f)))
+            )
 
     return result
 
 
 def list_modules():
-    return list_modules_metadata(lambda f: not contains_one_of(f, {'_info.py', '_list.py'}))
+    return list_modules_metadata(
+        lambda f: not contains_one_of(f, {"_info.py", "_list.py"})
+    )
 
 
 def list_info_modules():
-    return list_modules_metadata(lambda f: '_info.py' in f)
+    return list_modules_metadata(lambda f: "_info.py" in f)
 
 
 def list_list_modules():
-    return list_modules_metadata(lambda f: '_list.py' in f)
+    return list_modules_metadata(lambda f: "_list.py" in f)
 
 
 def list_inventory():
-    return sorted(['.'.join(f.split('.')[:-1]) for f in os.listdir('plugins/inventory') if '.py' in f])
+    return sorted(
+        [
+            ".".join(f.split(".")[:-1])
+            for f in os.listdir("plugins/inventory")
+            if ".py" in f
+        ]
+    )
 
 
 def main() -> None:
     add_ansible_collection_path()
 
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader('template'))
-    tpl = env.get_template('README.template.md')
-    output = tpl.render({
-        'collection_version': sys.argv[1] if len(sys.argv) > 1 else 'main',
-        'is_release': len(sys.argv) > 1,
-        'modules': list_modules(),
-        'info_modules': list_info_modules(),
-        'list_modules': list_list_modules(),
-        'inventory': list_inventory()
-    })
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader("template"))
+    tpl = env.get_template("README.template.md")
+    output = tpl.render(
+        {
+            "collection_version": sys.argv[1] if len(sys.argv) > 1 else "main",
+            "is_release": len(sys.argv) > 1,
+            "modules": list_modules(),
+            "info_modules": list_info_modules(),
+            "list_modules": list_list_modules(),
+            "inventory": list_inventory(),
+        }
+    )
 
-    with open('README.md', 'w') as f:
+    with open("README.md", "w") as f:
         f.write(output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/unit/base.py
+++ b/tests/unit/base.py
@@ -1,9 +1,13 @@
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import LinodeModuleBase
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+
 
 class TestModuleBase(LinodeModuleBase):
     """
     Test module that represents an instance of LinodeModuleBase.
     """
+
     def __init__(self):
         self._client = None
         pass

--- a/tests/unit/module_utils/test_linode_common.py
+++ b/tests/unit/module_utils/test_linode_common.py
@@ -3,19 +3,22 @@ import os
 
 from ansible_collections.linode.cloud.tests.unit.base import TestModuleBase
 
-class TestLinodeModuleBase():
+
+class TestLinodeModuleBase:
 
     def test_module_ca_path_override(self):
-        os.environ['LINODE_CA'] = "env_ca"
+        os.environ["LINODE_CA"] = "env_ca"
 
         mock_module = TestModuleBase()
-        mock_module.module = SimpleNamespace(params={
-            "api_token":"testing", 
-            "api_version": None,
-            "api_url":"/", 
-            "ua_prefix": None, 
-            "ca_path":"foobar"
-        })
+        mock_module.module = SimpleNamespace(
+            params={
+                "api_token": "testing",
+                "api_version": None,
+                "api_url": "/",
+                "ua_prefix": None,
+                "ca_path": "foobar",
+            }
+        )
 
         client = mock_module.client
         assert client.ca_path == "foobar"

--- a/tests/unit/module_utils/test_linode_common_info.py
+++ b/tests/unit/module_utils/test_linode_common_info.py
@@ -1,10 +1,17 @@
 import pytest
 
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import InfoModule, InfoModuleResult, \
-    InfoModuleParam, InfoModuleAttr
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleResult,
+    InfoModuleParam,
+    InfoModuleAttr,
+)
 from ansible_specdoc.objects import FieldType
 
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import global_requirements, global_authors
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_requirements,
+    global_authors,
+)
 
 
 class TestLinodeInfoModule:
@@ -17,7 +24,7 @@ class TestLinodeInfoModule:
                 field_type=FieldType.dict,
                 display_name="Foo",
                 docs_url="https://linode.com/",
-                samples=['{"foo": "bar"}', '{"foo": "foo"}']
+                samples=['{"foo": "bar"}', '{"foo": "foo"}'],
             ),
             secondary_results=[
                 InfoModuleResult(
@@ -26,14 +33,14 @@ class TestLinodeInfoModule:
                     display_name="Bar",
                     docs_url="https://foo.linode.com/",
                     samples=['{"foo": "bar"}', '{"foo": "foo"}'],
-                    get=lambda *args: "wow"
+                    get=lambda *args: "wow",
                 ),
             ],
             params=[
                 InfoModuleParam(
                     name="parent_id",
                     display_name="Parent",
-                    type=FieldType.integer
+                    type=FieldType.integer,
                 )
             ],
             attributes=[
@@ -41,10 +48,10 @@ class TestLinodeInfoModule:
                     name="attr",
                     display_name="Attr",
                     type=FieldType.string,
-                    get=lambda *args: ["cool"]
+                    get=lambda *args: ["cool"],
                 )
             ],
-            examples=["foo"]
+            examples=["foo"],
         )
 
     def test_init(self, mock_module):
@@ -53,16 +60,17 @@ class TestLinodeInfoModule:
     def test_generate_spec(self, mock_module):
         spec = mock_module.spec
 
-        assert spec.description == [
-            "Get info about a Linode Foo."
-        ]
+        assert spec.description == ["Get info about a Linode Foo."]
         assert spec.requirements == global_requirements
         assert spec.author == global_authors
 
         parent_id_field = spec.options.get("parent_id")
         assert parent_id_field.type == FieldType.integer
         assert parent_id_field.required
-        assert parent_id_field.description == "The ID of the Parent for this resource."
+        assert (
+            parent_id_field.description
+            == "The ID of the Parent for this resource."
+        )
 
         attr_field = spec.options.get("attr")
         assert attr_field.type == FieldType.string
@@ -90,7 +98,7 @@ class TestLinodeInfoModule:
                 name="attr_2",
                 display_name="Attr 2",
                 type=FieldType.string,
-                get=lambda *args: ["cool"]
+                get=lambda *args: ["cool"],
             )
         )
 

--- a/tests/unit/module_utils/test_linode_database_shared.py
+++ b/tests/unit/module_utils/test_linode_database_shared.py
@@ -1,9 +1,13 @@
 from linode_api4 import ApiError
 import pytest
-from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import validate_allow_list, validate_shared_db_input, call_protected_provisioning
+from ansible_collections.linode.cloud.plugins.module_utils.linode_database_shared import (
+    validate_allow_list,
+    validate_shared_db_input,
+    call_protected_provisioning,
+)
 
 
-class TestLinodeDatabaseShared():
+class TestLinodeDatabaseShared:
 
     def test_validate_allow_list_valid_cidr(self):
         # Valid CIDR format
@@ -12,7 +16,12 @@ class TestLinodeDatabaseShared():
 
     def test_validate_allow_list_invalid_cidr(self):
         # Invalid CIDR format
-        allow_list = {"192.168.0.1/24", "10.0.0.0", "172.16.0.0/12", "200.100.50.25"}
+        allow_list = {
+            "192.168.0.1/24",
+            "10.0.0.0",
+            "172.16.0.0/12",
+            "200.100.50.25",
+        }
         with pytest.raises(ValueError):
             validate_allow_list(allow_list)
 
@@ -38,6 +47,6 @@ class TestLinodeDatabaseShared():
         # Simulate an ApiError with status other than 400
         def mock_provisioning_function():
             raise ApiError(status=404, message="Not found")
-        
+
         with pytest.raises(ApiError):
             call_protected_provisioning(mock_provisioning_function)

--- a/tests/unit/module_utils/test_linode_helper.py
+++ b/tests/unit/module_utils/test_linode_helper.py
@@ -7,7 +7,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
 )
 
 
-class TestLinodeHelper():
+class TestLinodeHelper:
 
     def test_dict_select_spec(self):
         target = {
@@ -77,4 +77,6 @@ class TestLinodeHelper():
         try:
             validate_required(required_fields, params)
         except Exception as e:
-            pytest.fail(f"validate_required raised an unexpected exception: {e}")
+            pytest.fail(
+                f"validate_required raised an unexpected exception: {e}"
+            )


### PR DESCRIPTION
## 📝 Description

This pull request swaps out all references to the legacy [Linode API docs](https://linode.com/docs/api) for their [TechDocs counterparts](https://techdocs.akamai.com/linode-api/reference/api).

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally

### Validate that all legacy URLs have been removed

1. Run the following to detect any instances of `linode.com/docs/api` in the project:

```
find . -type f -name '*.py' | xargs grep -rni 'linode.com/docs/api'
```

2. Ensure no results are found.
