### PR TITLE
fix: Create SRV domain_record

### DIFF
--- a/docs/modules/domain_record.md
+++ b/docs/modules/domain_record.md
@@ -27,6 +27,20 @@ NOTE: Domain records are identified by their name, target, and type.
 ```
 
 ```yaml
+- name: Create an SRV domain record
+  linode.cloud.domain_record:
+    domain: my-domain.com
+    service: srv-service
+    protocol: tcp
+    type: 'SRV'
+    target: host.example.com
+    port: 443
+    priority: 0
+    weight: 1
+    state: present
+```
+
+```yaml
 - name: Delete a domain record
   linode.cloud.domain_record:
     domain: my-domain.com
@@ -53,7 +67,7 @@ NOTE: Domain records are identified by their name, target, and type.
 | `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain.   |
 | `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain.   |
 | `record_id` | <center>`int`</center> | <center>Optional</center> | The id of the record to modify.  **(Conflicts With: `name`)** |
-| `name` | <center>`str`</center> | <center>Optional</center> | The name of this Record. NOTE: If the name of the record ends with the domain, it will be dropped from the resulting record's name.  **(Conflicts With: `record_id`)** |
+| `name` | <center>`str`</center> | <center>Optional</center> | The name of this Record. NOTE: If the name of the record ends with the domain, it will be dropped from the resulting record's name. Unused for SRV record. Use the service property to set the service name for this record.  **(Conflicts With: `record_id`)** |
 | `port` | <center>`int`</center> | <center>Optional</center> | The port this Record points to. Only valid and required for SRV record requests.  **(Updatable)** |
 | `priority` | <center>`int`</center> | <center>Optional</center> | The priority of the target host for this Record. Lower values are preferred. Only valid for MX and SRV record requests. Required for SRV record requests.  **(Updatable)** |
 | `protocol` | <center>`str`</center> | <center>Optional</center> | The protocol this Record’s service communicates with. An underscore (_) is prepended automatically to the submitted value for this property.  **(Updatable)** |

--- a/plugins/module_utils/doc_fragments/domain_record.py
+++ b/plugins/module_utils/doc_fragments/domain_record.py
@@ -8,6 +8,17 @@ specdoc_examples = ['''
     type: 'A'
     target: '127.0.0.1'
     state: present''', '''
+- name: Create an SRV domain record
+  linode.cloud.domain_record:
+    domain: my-domain.com
+    service: srv-service
+    protocol: tcp
+    type: 'SRV'
+    target: host.example.com
+    port: 443
+    priority: 0
+    weight: 1
+    state: present''', '''
 - name: Delete a domain record
   linode.cloud.domain_record:
     domain: my-domain.com

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -173,10 +173,9 @@ class LinodeDomainRecord(LinodeModuleBase):
         self.module_arg_spec = SPECDOC_META.ansible_spec
         self.required_one_of: List[List[str]] = [
             ["domain", "domain_id"],
-            ["name", "record_id"],
+            [("name", "type"), "record_id"],
         ]
         self.mutually_exclusive: List[List[str]] = [["name", "record_id"]]
-        self.required_together: List[List[str]] = [["name", "type"]]
         self.results = {"changed": False, "actions": [], "record": None}
 
         self._domain: Optional[Domain] = None

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -47,7 +47,9 @@ linode_domain_record_spec = {
         description=[
             "The name of this Record.",
             "NOTE: If the name of the record ends with the domain, "
-            "it will be dropped from the resulting record's name.",
+            "it will be dropped from the resulting record's name. "
+            "Unused for SRV record. "
+            "Use the service property to set the service name for this record.",
         ],
     ),
     "port": SpecField(
@@ -173,7 +175,7 @@ class LinodeDomainRecord(LinodeModuleBase):
         self.module_arg_spec = SPECDOC_META.ansible_spec
         self.required_one_of: List[List[str]] = [
             ["domain", "domain_id"],
-            [("name", "type"), "record_id"],
+            ["name", "record_id", "service"],
         ]
         self.mutually_exclusive: List[List[str]] = [["name", "record_id"]]
         self.results = {"changed": False, "actions": [], "record": None}
@@ -185,7 +187,6 @@ class LinodeDomainRecord(LinodeModuleBase):
             module_arg_spec=self.module_arg_spec,
             required_one_of=self.required_one_of,
             mutually_exclusive=self.mutually_exclusive,
-            required_together=self.required_together,
         )
 
     def _find_record(
@@ -266,10 +267,13 @@ class LinodeDomainRecord(LinodeModuleBase):
         params = self.module.params
         record_type = params.pop("type")
         record_name = params.get("name")
+        record_service = params.get("service")
 
         try:
             self.register_action(
-                "Created domain record {0}".format(record_name)
+                "Created domain record type {0}: name is {1}; service is {2}".format(
+                    record_type, record_name, record_service
+                )
             )
             return self._domain.record_create(record_type, **params)
         except Exception as exception:
@@ -305,7 +309,9 @@ class LinodeDomainRecord(LinodeModuleBase):
                 "record with id {0} does not exist".format(record_id)
             )
 
-        if self._record is None and record_name is not None:
+        if self._record is None and (
+            record_name is not None or params.get("service") is not None
+        ):
             self._record = self._create_record()
 
         self._update_record()

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -38,6 +38,24 @@
           - record_create.record.ttl_sec == 3600
           - record_create.record.weight == 55
 
+    - name: Create a Service records
+      linode.cloud.domain_record:
+        domain: '{{ domain_create.domain.domain }}'
+        state: present
+        service: carddavs
+        protocol: tcp
+        type: "SRV"
+        target: host.example.com
+        port: 443
+        priority: 0
+        weight: 1
+      register: srv_create
+
+    - name: Assert SRV record is created
+      assert:
+        that:
+          - srv_create.record.type == 'SRV'
+
     - name: Update domain_record
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -38,24 +38,6 @@
           - record_create.record.ttl_sec == 3600
           - record_create.record.weight == 55
 
-    - name: Create a Service records
-      linode.cloud.domain_record:
-        domain: '{{ domain_create.domain.domain }}'
-        state: present
-        service: carddavs
-        protocol: tcp
-        type: "SRV"
-        target: host.example.com
-        port: 443
-        priority: 0
-        weight: 1
-      register: srv_create
-
-    - name: Assert SRV record is created
-      assert:
-        that:
-          - srv_create.record.type == 'SRV'
-
     - name: Update domain_record
       linode.cloud.domain_record:
         domain: '{{ domain_create.domain.domain }}'
@@ -164,6 +146,24 @@
           - record_dupe_update.record.ttl_sec == 300
           - record_dupe_update.record.weight == 55
 
+    - name: Create an SRV domain record
+      linode.cloud.domain_record:
+        domain: '{{ domain_create.domain.domain }}'
+        service: carddavs
+        protocol: tcp
+        type: "SRV"
+        target: host.example.com
+        port: 443
+        priority: 0
+        weight: 1
+        state: present
+      register: srv_create
+
+    - name: Assert SRV record is created
+      assert:
+        that:
+          - srv_create.record.type == 'SRV'
+
     - name: Get domain_info
       linode.cloud.domain_info:
         domain: '{{ domain_create.domain.domain }}'
@@ -172,7 +172,7 @@
     - name: Assert domain_info response
       assert:
         that:
-          - domain_info.records|length == 3
+          - domain_info.records|length == 4
 
     - name: Create domain_record containing FQDN
       linode.cloud.domain_record:
@@ -261,7 +261,20 @@
           assert:
             that:
               - record_dupe_delete.changed
-              - record_dupe_delete.record.id == record_dupe_delete.record.id
+              - record_dupe_delete.record.id == record_dupe_create.record.id
+
+        - name: Delete SRV domain_record
+          linode.cloud.domain_record:
+            domain: '{{ domain_create.domain.domain }}'
+            record_id: '{{ srv_create.record.id }}'
+            state: absent
+          register: srv_record_delete
+
+        - name: Assert SRV domain_record is deleted
+          assert:
+            that:
+              - srv_record_delete.changed
+              - srv_record_delete.record.id == srv_create.record.id
 
         - name: Delete domain
           linode.cloud.domain:            


### PR DESCRIPTION
## 📝 Description

Fix a bug that `name` is required together with `type` in the domain_record. For SRV domain record, `service` instead of `name` is used in domain record creation. 

Addressed #521.

## ✔️ How to Test

```
make TEST_ARGS="-v domain_record" test
```

Manual test:
1. In a sandbox environment, run the following script to create a domain and a SRV domain_record under it.
```yaml
- name: test
  hosts: localhost
  tasks:
    - name: Create domain
      linode.cloud.domain:
        domain: 'host.example.com'
        soa_email: 'realemail@example.com'
        type: 'master'
        state: present
      register: domain_create

    - name: Create an SRV domain record
      linode.cloud.domain_record:
        domain: '{{ domain_create.domain.domain }}'
        service: carddavs
        protocol: tcp
        type: 'SRV'
        target: host.example.com
        port: 443
        priority: 0
        weight: 1
        state: present
```
2. Observe that the domain_record is created successfully
