### PR TITLE
test: Improve E2E test firewall creation and teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,26 +62,42 @@ gendocs:
 #	ansible-test integration $(TEST_ARGS) --tags never
 integration-test: create-integration-config create-e2e-firewall
 	@echo "Running Integration Test(s)..."
-	ansible-test integration $(TEST_ARGS)
+	OUTPUT=$$(ansible-test integration $(TEST_ARGS) 2>&1); \
+	TEST_EXIT_CODE=$$?; \
+	echo "$$OUTPUT" \
+	@echo "Running Cleanup for E2E firewall..." \
+	make delete-e2e-firewall; \
+	if [ $$TEST_EXIT_CODE -ne 0 ]; then \
+		echo "Integration tests failed, check RECAP above for more details..."; \
+	fi; \
+	exit $$TEST_EXIT_CODE
 
 create-e2e-firewall:
 	@echo "Running create e2e firewall playbook..."
-	@if ansible-playbook e2e_scripts/cloud_security_scripts/cloud_e2e_firewall/ansible_linode/create_e2e_cloud_firewall.yaml > /dev/null; then \
-		echo "Successfully created e2e firewall"; \
-	else \
-		echo "Failed to create e2e firewall. Please update the cloud firewall scripts using `git submodule update --init` if yaml file doesn't exist"; \
+	@OUTPUT=$$(ansible-playbook e2e_scripts/cloud_security_scripts/cloud_e2e_firewall/ansible_linode/create_e2e_cloud_firewall.yaml 2>&1); \
+	FAILED_COUNT=$$(echo "$$OUTPUT" | grep "failed=" | awk -F 'failed=' '{print $$2}' | awk '{print $$1}'); \
+	if [ "$$FAILED_COUNT" -gt 0 ]; then \
+		echo "Playbook execution failed:"; \
+		echo "$$OUTPUT"; \
 		exit 1; \
+	else \
+		echo "E2E Cloud firewall created successfully."; \
 	fi
+
 
 delete-e2e-firewall:
 	@echo "Running delete e2e firewall playbook..."
-	@if ansible-playbook e2e_scripts/cloud_security_scripts/cloud_e2e_firewall/ansible_linode/delete_e2e_cloud_firewall.yaml  > /dev/null; then \
-		echo "Successfully deleted e2e firewall"; \
+	@OUTPUT=$$(ansible-playbook e2e_scripts/cloud_security_scripts/cloud_e2e_firewall/ansible_linode/delete_e2e_cloud_firewall.yaml 2>&1); \
+	FAILED_COUNT=$$(echo "$$OUTPUT" | grep "failed=" | awk -F 'failed=' '{print $$2}' | awk '{print $$1}'); \
+	if [ "$$FAILED_COUNT" -gt 0 ]; then \
+		echo "Playbook execution failed:"; \
+		echo "$$OUTPUT"; \
+		exit 1; \
 	else \
-		echo "Failed to delete e2e firewall"; \
-    fi
+		echo "E2E Cloud firewall deleted successfully."; \
+	fi
 
-test: integration-test delete-e2e-firewall
+test: integration-test
 
 testall:
 	./scripts/test_all.sh


### PR DESCRIPTION
## 📝 Description

Here are some improvements around creation and deletion of E2E Test Firewall:
- Now it will show the entire PLAY RECAP when there is failure in any of the playbook steps
- Firewall will be teardown regardless of the test result but it will still return the correct exit code at the end

## ✔️ How to Test
`git submodule update --init` may be required if submodule directory isn't downloaded locally

Verifying error handling when firewall creation fails:
1. export wrong LINODE_TOKEN
2. `make create-e2e-firewall`

Verifying proper teardown when test execution fails:
1. Make a test to fail with any reason (e.g. change some assertion arbitrarily)
2. Run the test e.g. ` make TEST_ARGS="-v domain_basic" test`
3. Test returns failure and cloud firewall is teared down 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**