### PR TITLE
fix: Fix grants AttributeError; migrate user_info to base InfoModule;

### DIFF
--- a/docs/modules/user_info.md
+++ b/docs/modules/user_info.md
@@ -25,11 +25,11 @@ Get info about a Linode User.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `username` | <center>`str`</center> | <center>**Required**</center> | The username of the user.   |
+| `username` | <center>`str`</center> | <center>**Required**</center> | The Username of the User to resolve.   |
 
 ## Return Values
 
-- `user` - The user info in JSON serialized form.
+- `user` - The returned User.
 
     - Sample Response:
         ```json
@@ -48,7 +48,7 @@ Get info about a Linode User.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-user) for a list of returned fields
 
 
-- `grants` - The grants info in JSON serialized form.
+- `grants` - The returned Grants.
 
     - Sample Response:
         ```json

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -5,56 +5,52 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.user_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import User
 
-spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "username": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=["The username of the user."],
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="user",
+        field_type=FieldType.dict,
+        display_name="User",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-user",
+        samples=docs.result_user_samples,
     ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode User."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
-    examples=docs.specdoc_examples,
-    return_values={
-        "user": SpecReturnValue(
-            description="The user info in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-user",
-            type=FieldType.dict,
-            sample=docs.result_user_samples,
-        ),
-        "grants": SpecReturnValue(
-            description="The grants info in JSON serialized form.",
+    secondary_results=[
+        InfoModuleResult(
+            field_name="grants",
+            field_type=FieldType.dict,
+            display_name="Grants",
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-user-grants",
-            type=FieldType.dict,
-            sample=docs.result_grants_samples,
-        ),
-    },
+            samples=docs.result_grants_samples,
+            get=lambda client, user, params: client.get(
+                # We can't use the UserGrants type here because
+                # it does not serialize directly to JSON or store
+                # the API response JSON.
+                f"/account/users/{user['username']}/grants"
+            ),
+        )
+    ],
+    attributes=[
+        InfoModuleAttr(
+            name="username",
+            display_name="Username",
+            type=FieldType.string,
+            get=lambda client, params: client.load(
+                User, params.get("username")
+            )._raw_json,
+        )
+    ],
+    examples=docs.specdoc_examples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -63,39 +59,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode user"""
-
-    def __init__(self) -> None:
-        self.required_one_of: List[str] = []
-        self.results = {"user": None}
-
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for user info module"""
-
-        user = self.client.account.users(
-            User.username == self.module.params.get("username")
-        )
-        grants = user.grants
-
-        self.results["user"] = user._raw_json
-        self.results["grants"] = grants._raw_json
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/tests/integration/targets/user_info/tasks/main.yaml
+++ b/tests/integration/targets/user_info/tasks/main.yaml
@@ -1,52 +1,50 @@
 - name: user_info
   block:
-    - debug:
-       msg: Skipping for now...(https://jira.linode.com/browse/TPT-2939)
-#    - set_fact:
-#        r: "{{ 1000000000 | random }}"
-#
-#    - name: Create Linode User
-#      linode.cloud.user:
-#        username: 'ansible-test-{{ r }}'
-#        email: 'ansible-test-{{ r }}@linode.com'
-#        state: present
-#      register: create
-#
-#    - name: Assert user created
-#      assert:
-#        that:
-#          - create.user.email is not none
-#          - create.user.restricted == true
-#
-#    - name: Print username for the created user
-#      debug:
-#        msg: "The username is: {{ create.user.username }}"
-#
-#    - name: Get info about a user
-#      linode.cloud.user_info:
-#        username: "{{ create.user.username }}"
-#      register: user_info
-#
-#    - name: Assert user_info for the created user
-#      assert:
-#        that:
-#          - user_info_valid | default(false)
-#          - user_info.user.email is defined
-#          - user_info.user.email | length > 0
-#      when: user_info_valid | default(false)
-#    
-#  always:
-#    - ignore_errors: yes
-#      block:
-#        - name: Delete a Linode User
-#          linode.cloud.user:
-#            username: '{{ create.user.username }}'
-#            state: absent
-#
-#  environment:
-#    LINODE_UA_PREFIX: '{{ ua_prefix }}'
-#    LINODE_API_TOKEN: '{{ api_token }}'
-#    LINODE_API_URL: '{{ api_url }}'
-#    LINODE_API_VERSION: '{{ api_version }}'
-#    LINODE_CA: '{{ ca_file or "" }}'
-#
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create Linode User
+      linode.cloud.user:
+        username: 'ansible-test-{{ r }}'
+        email: 'ansible-test-{{ r }}@linode.com'
+        state: present
+      register: create
+
+    - name: Assert user created
+      assert:
+        that:
+          - create.user.email is not none
+          - create.user.restricted == true
+
+    - name: Print username for the created user
+      debug:
+        msg: "The username is: {{ create.user.username }}"
+
+    - name: Get info about a user
+      linode.cloud.user_info:
+        username: "{{ create.user.username }}"
+      register: user_info
+
+    - name: Assert user_info for the created user
+      assert:
+        that:
+          - user_info_valid | default(false)
+          - user_info.user.email is defined
+          - user_info.user.email | length > 0
+      when: user_info_valid | default(false)
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode User
+          linode.cloud.user:
+            username: '{{ create.user.username }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+


### PR DESCRIPTION
## 📝 Description

This pull request resolves the following error that was being raised when attempting to use the `linode.cloud.user_info` module:

```
AttributeError: 'PaginatedList' object has no attribute 'grants'
```

Because we had already planned to migrate user_info to the `InfoModule` base (which replaces the old result gathering logic) I decided to quickly do it as a part of this PR. If anyone would rather me handle it in a separate PR definitely let me know 🙂 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Tests

```
make TEST_ARGS="-v user_info" test
```

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - set_fact:
        id: "{{ 1000000000 | random }}"

    - name: Create Linode User
      linode.cloud.user:
        username: 'test-user-{{ id }}'
        email: 'test-user-{{ id }}@linode.com'
        state: present
      register: user_create

    - name: Get info about the user
      linode.cloud.user_info:
        username: '{{ user_create.user.username }}'
      register: user_info

    - name: Remove the user
      linode.cloud.user:
        username: '{{ user_create.user.username }}'
        state: absent

    - name: Pretty-print the user's info
      debug:
        var: user_info
```

2. Ensure the playbook succeeds.
3. Ensure the `user` and `grants` is shown in the output of the last task.