### PR TITLE
Add `swap_size` to instance_spec config

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -149,6 +149,7 @@ Manage Linode Instances, Configs, and Disks.
 | `auto_disk_resize` | <center>`bool`</center> | <center>Optional</center> | Whether implicitly created disks should be resized during a type change operation.  **(Default: `False`)** |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to this object. Tags are for organizational purposes only.  **(Updatable)** |
 | [`placement_group` (sub-options)](#placement_group) | <center>`dict`</center> | <center>Optional</center> | A Placement Group to create this Linode under.   |
+| `swap_size` | <center>`int`</center> | <center>Optional</center> | When deploying from an Image, this field is optional, otherwise it is ignored. This is used to set the swap disk size for the newly-created Linode.   |
 
 ### configs
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -523,6 +523,13 @@ linode_instance_spec = {
         suboptions=linode_instance_placement_group_spec,
         description=["A Placement Group to create this Linode under."],
     ),
+    "swap_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "When deploying from an Image, this field is optional, otherwise it is ignored. "
+            "This is used to set the swap disk size for the newly-created Linode."
+        ],
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(

--- a/tests/integration/targets/instance_booted/tasks/main.yaml
+++ b/tests/integration/targets/instance_booted/tasks/main.yaml
@@ -12,6 +12,7 @@
         root_pass: Fn$$oobar123
         private_ip: true
         booted: true
+        swap_size: 512
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create


### PR DESCRIPTION
## 📝 Description

`swap_size` was a missing attributes. Adding it to the linode_instance_spec and allow user to specify it when creating a Linode. 

## ✔️ How to Test

```
make TEST_ARGS="-v instance_booted" test
```

Manual Test:
1. In a sandbox environment, i.e. dx-devenv, run the following playbook:
```yaml
    - name: Create a booted Linode instance
      linode.cloud.instance:
        label: ansible-test-instance
        region: us-ord
        type: g6-standard-1
        image: linode/ubuntu22.04
        root_pass: Fn$$oobar123
        private_ip: true
        booted: true
        swap_size: 512
        state: present
```
2. Observe that the linode instance is created successfully. (swap_size won't be returned in the response though.)
