### PR TITLE
ref: Migrate `profile_info` to use common info module

### DIFF
--- a/docs/modules/profile_info.md
+++ b/docs/modules/profile_info.md
@@ -22,7 +22,7 @@ Get info about a Linode Profile.
 
 ## Return Values
 
-- `profile` - The profile info in JSON serialized form.
+- `profile` - The returned Profile.
 
     - Sample Response:
         ```json

--- a/plugins/modules/profile_info.py
+++ b/plugins/modules/profile_info.py
@@ -1,49 +1,30 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to retrieve information about the current Linode profile."""
+"""This module contains all of the functionality for Linode Profile info."""
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.profile_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleResult,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 
-spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-}
-
-
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Profile."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = InfoModule(
     examples=docs.specdoc_examples,
-    return_values={
-        "profile": SpecReturnValue(
-            description="The profile info in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-profile",
-            type=FieldType.dict,
-            sample=docs.result_profile_samples,
-        )
-    },
+    primary_result=InfoModuleResult(
+        display_name="Profile",
+        field_name="profile",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-profile",
+        samples=docs.result_profile_samples,
+        get=lambda client, params: client.profile()._raw_json,
+    ),
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -52,33 +33,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode Profile"""
-
-    def __init__(self) -> None:
-        self.required_one_of: List[str] = []
-        self.results = {"profile": None}
-
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for volume info module"""
-
-        self.results["profile"] = self.client.profile()._raw_json
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the profile_info module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrate `profile_info` to use common info module. Also make some necessary change to the base info module because profile_info doesn't require any attribute or parameter to call. 


## ✔️ How to Test

```make TEST_ARGS="-v profile_info" test ```

Manual test:
1. In a sandbox environment, run the following script to get the info of current profile:
```yaml
- name: test
  hosts: localhost
  tasks:
    - name: Get profile_info about current profile
      linode.cloud.profile_info:
      register: profile
```
2. Observe that profile info the successfully returned.
