### PR TITLE
ref: Migrate domain_info and domain_list to the shared base modules

### DIFF
--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -31,12 +31,12 @@ Get info about a Linode Domain.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `id` | <center>`int`</center> | <center>Optional</center> | The unique domain name of the Domain. Optional if `domain` is defined.  **(Conflicts With: `domain`)** |
-| `domain` | <center>`str`</center> | <center>Optional</center> | The unique id of the Domain. Optional if `id` is defined.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Domain to resolve.  **(Conflicts With: `domain`)** |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The domain of the Domain to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 
-- `domain` - The domain in JSON serialized form.
+- `domain` - The returned Domain.
 
     - Sample Response:
         ```json
@@ -63,7 +63,7 @@ Get info about a Linode Domain.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain) for a list of returned fields
 
 
-- `records` - The domain record in JSON serialized form.
+- `records` - The returned Records.
 
     - Sample Response:
         ```json
@@ -85,28 +85,6 @@ Get info about a Linode Domain.
           }
         ]
         ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
-
-
-- `zone_file` - The zone file for the last rendered zone for the specified domain.
-
-    - Sample Response:
-        ```json
-        [
-          {
-            "zone_file": [
-              "; example.com [123]",
-              "$TTL 864000",
-              "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
-              "@    NS  ns1.linode.com.",
-              "@    NS  ns2.linode.com.",
-              "@    NS  ns3.linode.com.",
-              "@    NS  ns4.linode.com.",
-              "@    NS  ns5.linode.com."
-            ]
-          }
-        ]
-        ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-zone) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-records) for a list of returned fields
 
 

--- a/docs/modules/domain_list.md
+++ b/docs/modules/domain_list.md
@@ -32,21 +32,21 @@ List and filter on Domains.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list domains in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order domains by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting domains.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Domains in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Domains by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Domains.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Domains to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-domains   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-domains).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `domains` - The returned domains.
+- `domains` - The returned Domains.
 
     - Sample Response:
         ```json

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -1,86 +1,69 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module contains all of the functionality for Linode Domains."""
+"""This file contains the implementation of the domain_info module."""
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain as docs_parent
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    create_filter_and,
     paginated_list_to_json,
+    safe_find,
 )
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import Domain
 
-linode_domain_info_spec = {
-    # We need to overwrite attributes to exclude them as requirements
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "id": SpecField(
-        type=FieldType.integer,
-        required=False,
-        conflicts_with=["domain"],
-        description=[
-            "The unique domain name of the Domain.",
-            "Optional if `domain` is defined.",
-        ],
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="domain",
+        field_type=FieldType.dict,
+        display_name="Domain",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
+        samples=docs_parent.result_domain_samples,
     ),
-    "domain": SpecField(
-        type=FieldType.string,
-        required=False,
-        conflicts_with=["id"],
-        description=[
-            "The unique id of the Domain.",
-            "Optional if `id` is defined.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Domain."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=linode_domain_info_spec,
+    secondary_results=[
+        InfoModuleResult(
+            field_name="records",
+            field_type=FieldType.list,
+            display_name="Records",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-records",
+            samples=docs_parent.result_records_samples,
+            get=lambda client, domain, params: paginated_list_to_json(
+                Domain(client, domain["id"]).records
+            ),
+        )
+    ],
+    attributes=[
+        InfoModuleAttr(
+            display_name="ID",
+            name="id",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                Domain,
+                params.get("id"),
+            )._raw_json,
+        ),
+        InfoModuleAttr(
+            display_name="domain",
+            name="domain",
+            type=FieldType.string,
+            get=lambda client, params: safe_find(
+                client.domains,
+                Domain.domain == params.get("domain"),
+                raise_not_found=True,
+            )._raw_json,
+        ),
+    ],
     examples=docs.specdoc_examples,
-    return_values={
-        "domain": SpecReturnValue(
-            description="The domain in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
-            type=FieldType.dict,
-            sample=docs_parent.result_domain_samples,
-        ),
-        "records": SpecReturnValue(
-            description="The domain record in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
-            type=FieldType.list,
-            sample=docs_parent.result_records_samples,
-        ),
-        "zone_file": SpecReturnValue(
-            description="The zone file for the last rendered zone for the specified domain.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-zone",
-            type=FieldType.list,
-            sample=docs_parent.result_zone_file_samples,
-        ),
-    },
 )
 
-linode_domain_valid_filters = ["id", "domain"]
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -89,64 +72,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class LinodeDomainInfo(LinodeModuleBase):
-    """Module for getting info about a Linode Domain"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.required_one_of: List[str] = []
-        self.results = {"domain": None, "records": None, "zone_file": None}
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def _get_matching_domain(self, spec_args: dict) -> Optional[Domain]:
-        filter_items = {
-            k: v
-            for k, v in spec_args.items()
-            if k in linode_domain_valid_filters and v is not None
-        }
-
-        filter_statement = create_filter_and(Domain, filter_items)
-
-        try:
-            # Special case because ID is not filterable
-            if "id" in filter_items.keys():
-                result = Domain(self.client, spec_args.get("id"))
-                result._api_get()  # Force lazy-loading
-
-                return result
-
-            return self.client.domains(filter_statement)[0]
-        except IndexError:
-            return None
-        except Exception as exception:
-            return self.fail(msg="failed to get domain {0}".format(exception))
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for domain info module"""
-
-        domain = self._get_matching_domain(kwargs)
-
-        if domain is None:
-            self.fail("failed to get domain")
-
-        self.results["domain"] = domain._raw_json
-        self.results["records"] = paginated_list_to_json(domain.records)
-        self.results["zone_file"] = self.client.get(
-            "/domains/{}/zone-file".format(domain.id)
-        )
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the Linode Domain info module"""
-    LinodeDomainInfo()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/domain_list.py
+++ b/plugins/modules/domain_list.py
@@ -1,95 +1,25 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Domains."""
+"""This file contains the implementation of the domain_list module."""
+
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-domains",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list domains in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string,
-        description=["The attribute to order domains by."],
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting domains."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Domains."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Domains",
+    result_field_name="domains",
+    endpoint_template="/domains",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-domains",
     examples=docs.specdoc_examples,
-    return_values={
-        "domains": SpecReturnValue(
-            description="The returned domains.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domains",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_domains_samples,
-        )
-    },
+    result_samples=docs.result_domains_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -98,34 +28,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of domains"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"domains": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for domain list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["domains"] = get_all_paginated(
-            self.client,
-            "/domains",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

This pull request migrates the `linode.cloud.domain_info` and `linode.cloud.domain_list` modules to the `InfoModule` and `ListModule` base classes respectively.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`

### Integration Testing

```
make TEST_ARGS="-v domain_basic domain_list" test
```

### Manual Testing
