### PR TITLE
ref: Migrate event_list module to ListModule base

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Name | Description |
 [linode.cloud.database_engine_list](./docs/modules/database_engine_list.md)|List and filter on Managed Database engine types.|
 [linode.cloud.database_list](./docs/modules/database_list.md)|List and filter on Linode Managed Databases.|
 [linode.cloud.domain_list](./docs/modules/domain_list.md)|List and filter on Domains.|
-[linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Linode events.|
+[linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Events.|
 [linode.cloud.firewall_list](./docs/modules/firewall_list.md)|List and filter on Firewalls.|
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
 [linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Linode Instances.|

--- a/docs/modules/event_list.md
+++ b/docs/modules/event_list.md
@@ -1,6 +1,6 @@
 # event_list
 
-List and filter on Linode events.
+List and filter on Events.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -40,21 +40,21 @@ List and filter on Linode events.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Events by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Events.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Events to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-events   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-events).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `events` - The returned events.
+- `events` - The returned Events.
 
     - Sample Response:
         ```json

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -283,13 +283,13 @@ def get_all_paginated(
     result = []
     current_page = 1
     page_size = 100
-    num_pages = 1
+    num_pages: Optional[int] = None
 
     if num_results is not None and num_results < page_size:
         # Clamp the page size
         page_size = max(min(num_results, 100), 25)
 
-    while current_page <= num_pages and (
+    while (num_pages is None or current_page <= num_pages) and (
         num_results is None or len(result) < num_results
     ):
         response = client.get(
@@ -299,6 +299,10 @@ def get_all_paginated(
 
         if "data" not in response or "page" not in response:
             raise Exception("Invalid list response")
+
+        # We only want to set num_pages once to avoid undefined behavior
+        # when the number of pages changes mid-aggregation
+        num_pages = num_pages or response["pages"]
 
         result.extend(response["data"])
 

--- a/plugins/modules/event_list.py
+++ b/plugins/modules/event_list.py
@@ -1,96 +1,25 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Linode events."""
+"""This file contains the implementation of the event_list module."""
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.event_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-events",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list events in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string, description=["The attribute to order events by."]
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting events."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode events."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Events",
+    result_field_name="events",
+    endpoint_template="/account/events",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-events",
     examples=docs.specdoc_examples,
-    return_values={
-        "events": SpecReturnValue(
-            description="The returned events.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-events",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_events_samples,
-        )
-    },
+    result_samples=docs.result_events_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -99,34 +28,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode events"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"events": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for event list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["events"] = get_all_paginated(
-            self.client,
-            "/account/events",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

This pull request migrates the `event_list` module to the ListModule base class. Additionally, this pull request resolves an issue that prevented the `get_all_paginated` from making more than one paginated API GET request.

## ✔️ How to Test

The following test steps assume you have pulled down this PR and run `make install`.

### Integration Testing

```
make TEST_ARGS="-v event_list" test
```

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:

```yaml
- name: test
  hosts: localhost
  tasks:
    - name: Get the last 400 events under the current account
      linode.cloud.event_list:
        count: 400
      register: events_last_400

    - name: Get the last 50 "linode_create" events under the current account
      linode.cloud.event_list:
        count: 50
        filters:
          - name: action
            values: linode_create
      register: events_linode_create_last_50

    - debug:
        var: events_last_400.events | length

    - debug:
        var: events_linode_create_last_50.events | length
```
2. Ensure the playbook runs successfully.
3. Ensure the following is true of the output:
    * Events are properly shown in the first event_list output.
    * Only `linode_create` events are shown in the second event_list output.
    * The first `debug` output shows 400 events. 
        * May be fewer if you have < 400 events on your account.
    * The second `debug` output shows 50 events.
        * May be fewer if you have < 50 `linode_create` events on your account.