### PR TITLE
Migrate `account_info` to use common info module

### DIFF
--- a/docs/modules/account_info.md
+++ b/docs/modules/account_info.md
@@ -22,7 +22,7 @@ Get info about a Linode Account.
 
 ## Return Values
 
-- `account` - The account info in JSON serialized form.
+- `account` - The returned Account.
 
     - Sample Response:
         ```json

--- a/plugins/modules/account_info.py
+++ b/plugins/modules/account_info.py
@@ -5,44 +5,26 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleResult,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 
-spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Account."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = InfoModule(
     examples=docs.specdoc_examples,
-    return_values={
-        "account": SpecReturnValue(
-            description="The account info in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-account",
-            type=FieldType.dict,
-            sample=docs.result_account_samples,
-        )
-    },
+    primary_result=InfoModuleResult(
+        display_name="Account",
+        field_name="account",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-account",
+        samples=docs.result_account_samples,
+        get=lambda client, params: client.account()._raw_json,
+    ),
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -51,33 +33,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode Account"""
-
-    def __init__(self) -> None:
-        self.required_one_of: List[str] = []
-        self.results = {"account": None}
-
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for volume info module"""
-
-        self.results["account"] = self.client.account()._raw_json
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the account_info module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrated `account_info` module to use the common info module.

## ✔️ How to Test

### Integration Test
`make TEST_ARGS="-v account_info" test`

### Manual Test

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:
```
- name: test
  hosts: localhost
  tasks:
    - name: Get info about current account
      linode.cloud.account_info:
      register: account_info
```
2. Ensure that the account info is successfully returned.