### PR TITLE
ref: Migrate domain_record_info to InfoModule base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Name | Description |
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
 [linode.cloud.domain_info](./docs/modules/domain_info.md)|Get info about a Linode Domain.|
-[linode.cloud.domain_record_info](./docs/modules/domain_record_info.md)|Get info about a Linode Domain Record.|
+[linode.cloud.domain_record_info](./docs/modules/domain_record_info.md)|Get info about a Linode Records.|
 [linode.cloud.firewall_info](./docs/modules/firewall_info.md)|Get info about a Linode Firewall.|
 [linode.cloud.image_info](./docs/modules/image_info.md)|Get info about a Linode Image.|
 [linode.cloud.instance_info](./docs/modules/instance_info.md)|Get info about a Linode Instance.|

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Name | Description |
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
 [linode.cloud.domain_info](./docs/modules/domain_info.md)|Get info about a Linode Domain.|
-[linode.cloud.domain_record_info](./docs/modules/domain_record_info.md)|Get info about a Linode Records.|
+[linode.cloud.domain_record_info](./docs/modules/domain_record_info.md)|Get info about a Linode Domain Records.|
 [linode.cloud.firewall_info](./docs/modules/firewall_info.md)|Get info about a Linode Firewall.|
 [linode.cloud.image_info](./docs/modules/image_info.md)|Get info about a Linode Image.|
 [linode.cloud.instance_info](./docs/modules/instance_info.md)|Get info about a Linode Instance.|

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -1,6 +1,6 @@
 # domain_record_info
 
-Get info about a Linode Records.
+Get info about a Linode Domain Records.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -35,13 +35,14 @@ Get info about a Linode Records.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `domain_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Domain ID for this resource.   |
-| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Records to resolve.  **(Conflicts With: `name`)** |
-| `name` | <center>`str`</center> | <center>Optional</center> | The name of the Records to resolve.  **(Conflicts With: `id`)** |
+| `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the Domain ID for this resource.  **(Conflicts With: `domain`)** |
+| `domain` | <center>`str`</center> | <center>Optional</center> | The ID of the Domain for this resource.  **(Conflicts With: `domain_id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Domain Records to resolve.  **(Conflicts With: `name`)** |
+| `name` | <center>`str`</center> | <center>Optional</center> | The name of the Domain Records to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 
-- `record` - The returned Records.
+- `record` - The returned Domain Records.
 
     - Sample Response:
         ```json
@@ -61,6 +62,6 @@ Get info about a Linode Records.
           "weight": 50
         }
         ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
 
 

--- a/docs/modules/domain_record_info.md
+++ b/docs/modules/domain_record_info.md
@@ -1,6 +1,6 @@
 # domain_record_info
 
-Get info about a Linode Domain Record.
+Get info about a Linode Records.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -35,14 +35,13 @@ Get info about a Linode Domain Record.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `domain_id` | <center>`int`</center> | <center>Optional</center> | The ID of the parent Domain. Optional if `domain` is defined.  **(Conflicts With: `domain`)** |
-| `domain` | <center>`str`</center> | <center>Optional</center> | The name of the parent Domain. Optional if `domain_id` is defined.  **(Conflicts With: `domain_id`)** |
-| `id` | <center>`int`</center> | <center>Optional</center> | The unique id of the subdomain. Optional if `name` is defined.  **(Conflicts With: `name`)** |
-| `name` | <center>`str`</center> | <center>Optional</center> | The name of the domain record. Optional if `id` is defined.  **(Conflicts With: `id`)** |
+| `domain_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Domain ID for this resource.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Records to resolve.  **(Conflicts With: `name`)** |
+| `name` | <center>`str`</center> | <center>Optional</center> | The name of the Records to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 
-- `record` - View a single Record on this Domain.
+- `record` - The returned Records.
 
     - Sample Response:
         ```json
@@ -62,6 +61,6 @@ Get info about a Linode Domain Record.
           "weight": 50
         }
         ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-record) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain) for a list of returned fields
 
 

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -274,13 +274,13 @@ class InfoModule(LinodeModuleBase):
         """
         Initializes and runs the info module.
         """
-        attribute_names = [v.name for v in self.attributes]
-
         base_module_args = {
             "module_arg_spec": self.module_arg_spec,
-            "required_one_of": [attribute_names],
-            "mutually_exclusive": [attribute_names],
+            "required_one_of": [],
+            "mutually_exclusive": [],
         }
+
+        attribute_names = [v.name for v in self.attributes]
 
         if len(attribute_names) > 0:
             base_module_args["required_one_of"].append(attribute_names)

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -116,7 +116,7 @@ class InfoModule(LinodeModuleBase):
         self,
         primary_result: InfoModuleResult,
         secondary_results: List[InfoModuleResult] = None,
-        params: List[Union[InfoModuleParam, InfoModuleParamGroup]] = None,
+        params: Optional[List[Union[InfoModuleParam, InfoModuleParamGroup]]] = None,
         attributes: List[InfoModuleAttr] = None,
         examples: List[str] = None,
         description: List[str] = None,
@@ -138,7 +138,7 @@ class InfoModule(LinodeModuleBase):
                 if isinstance(entry, InfoModuleParamGroup)
                 else InfoModuleParamGroup(entry)
             )
-            for entry in params
+            for entry in params or []
         ]
 
         self.module_arg_spec = self.spec.ansible_spec

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -47,7 +47,7 @@ class InfoModuleParamGroupPolicy(Enum):
     Defines the policies that can be set for a param group.
     """
 
-    exactly_one_of = "exactly_one_of"
+    EXACTLY_ONE_OF = "exactly_one_of"
 
 
 class InfoModuleParamGroup:
@@ -227,7 +227,7 @@ class InfoModule(LinodeModuleBase):
                     description=f"The ID of the {param.display_name} for this resource.",
                 )
 
-                if InfoModuleParamGroupPolicy.exactly_one_of in group.policies:
+                if InfoModuleParamGroupPolicy.EXACTLY_ONE_OF in group.policies:
                     param_spec.conflicts_with = param_names ^ {param.name}
                     param_spec.required = False
 
@@ -287,7 +287,7 @@ class InfoModule(LinodeModuleBase):
             base_module_args["mutually_exclusive"].append(attribute_names)
 
         for entry in self.param_groups:
-            if InfoModuleParamGroupPolicy.exactly_one_of in entry.policies:
+            if InfoModuleParamGroupPolicy.EXACTLY_ONE_OF in entry.policies:
                 param_names = [param.name for param in entry.params]
                 base_module_args["required_one_of"].append(param_names)
                 base_module_args["mutually_exclusive"].append(param_names)

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -13,6 +13,8 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
     InfoModule,
     InfoModuleAttr,
     InfoModuleParam,
+    InfoModuleParamGroup,
+    InfoModuleParamGroupPolicy,
     InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType
@@ -45,20 +47,19 @@ module = InfoModule(
         samples=docs_parent.result_record_samples,
     ),
     params=[
-        InfoModuleParam(
-            display_name="Domain ID",
-            name="domain_id",
-            type=FieldType.integer,
-            required=False,
-            conflicts_with=["domain"],
-        ),
-        InfoModuleParam(
-            display_name="Domain",
-            name="domain",
-            type=FieldType.string,
-            required=False,
-            conflicts_with=["domain_id"],
-        ),
+        InfoModuleParamGroup(
+            InfoModuleParam(
+                display_name="Domain ID",
+                name="domain_id",
+                type=FieldType.integer,
+            ),
+            InfoModuleParam(
+                display_name="Domain",
+                name="domain",
+                type=FieldType.string,
+            ),
+            policies=[InfoModuleParamGroupPolicy.exactly_one_of],
+        )
     ],
     attributes=[
         InfoModuleAttr(
@@ -84,10 +85,6 @@ module = InfoModule(
             ],
         ),
     ],
-    extended_base_args={
-        "required_one_of": [("domain_id", "domain")],
-        "mutually_exclusive": [("domain_id", "domain")],
-    },
     examples=docs.specdoc_examples,
 )
 

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -42,8 +42,8 @@ module = InfoModule(
     primary_result=InfoModuleResult(
         field_name="record",
         field_type=FieldType.dict,
-        display_name="Records",
-        docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
+        display_name="Domain Records",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
         samples=docs_parent.result_record_samples,
     ),
     params=[

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -7,8 +7,12 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs_parent
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    domain_record as docs_parent,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    domain_record_info as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleAttr,
@@ -58,7 +62,7 @@ module = InfoModule(
                 name="domain",
                 type=FieldType.string,
             ),
-            policies=[InfoModuleParamGroupPolicy.exactly_one_of],
+            policies=[InfoModuleParamGroupPolicy.EXACTLY_ONE_OF],
         )
     ],
     attributes=[

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -1,89 +1,97 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module contains all of the functionality for Linode Domain records."""
+"""This module allows users to retrieve information about a Linode VPC Subnet."""
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
-from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    domain_record as docs_parent,
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.domain_record_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleParam,
+    InfoModuleResult,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
-    domain_record_info as docs,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    paginated_list_to_json,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
-from linode_api4 import Domain, DomainRecord
+from ansible_specdoc.objects import FieldType
+from linode_api4 import Domain, DomainRecord, LinodeClient
 
-linode_domain_record_info_spec = {
-    # We need to overwrite attributes to exclude them as requirements
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "domain_id": SpecField(
-        type=FieldType.integer,
-        conflicts_with=["domain"],
-        description=[
-            "The ID of the parent Domain.",
-            "Optional if `domain` is defined.",
-        ],
-    ),
-    "domain": SpecField(
-        type=FieldType.string,
-        conflicts_with=["domain_id"],
-        description=[
-            "The name of the parent Domain.",
-            "Optional if `domain_id` is defined.",
-        ],
-    ),
-    "id": SpecField(
-        type=FieldType.integer,
-        conflicts_with=["name"],
-        description=[
-            "The unique id of the subdomain.",
-            "Optional if `name` is defined.",
-        ],
-    ),
-    "name": SpecField(
-        type=FieldType.string,
-        conflicts_with=["id"],
-        description=[
-            "The name of the domain record.",
-            "Optional if `id` is defined.",
-        ],
-    ),
-}
 
-SPECDOC_META = SpecDocMeta(
-    description=["Get info about a Linode Domain Record."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=linode_domain_record_info_spec,
-    examples=docs.specdoc_examples,
-    return_values={
-        "record": SpecReturnValue(
-            description="View a single Record on this Domain.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-record",
-            type=FieldType.dict,
-            sample=docs_parent.result_record_samples,
-        )
+def _domain_from_params(client: LinodeClient, params: Dict[str, Any]) -> Domain:
+    domain_id = params.get("domain_id", None)
+    domain = params.get("domain", None)
+
+    if domain_id is not None:
+        return Domain(client, domain_id)
+
+    if domain is not None:
+        target_domains = client.domains(Domain.domain == domain)
+        if len(target_domains) < 1:
+            raise ValueError(f"No domain with name {domain} found")
+
+        return target_domains[0]
+
+    raise ValueError("One of domain_id or domain must be specified")
+
+
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="record",
+        field_type=FieldType.dict,
+        display_name="Records",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain",
+        samples=docs_parent.result_record_samples,
+    ),
+    params=[
+        InfoModuleParam(
+            display_name="Domain ID",
+            name="domain_id",
+            type=FieldType.integer,
+            required=False,
+            conflicts_with=["domain"],
+        ),
+        InfoModuleParam(
+            display_name="Domain",
+            name="domain",
+            type=FieldType.string,
+            required=False,
+            conflicts_with=["domain_id"],
+        ),
+    ],
+    attributes=[
+        InfoModuleAttr(
+            display_name="ID",
+            name="id",
+            type=FieldType.integer,
+            get=lambda client, params: [
+                client.load(
+                    DomainRecord,
+                    params.get("id"),
+                    target_parent_id=_domain_from_params(client, params).id,
+                )._raw_json
+            ],
+        ),
+        InfoModuleAttr(
+            display_name="name",
+            name="name",
+            type=FieldType.string,
+            get=lambda client, params: [
+                record._raw_json
+                for record in _domain_from_params(client, params).records
+                if record.name == params.get("name")
+            ],
+        ),
+    ],
+    extended_base_args={
+        "required_one_of": [("domain_id", "domain")],
+        "mutually_exclusive": [("domain_id", "domain")],
     },
+    examples=docs.specdoc_examples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -92,102 +100,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class LinodeDomainRecordInfo(LinodeModuleBase):
-    """Module for getting info about a Linode Domain record"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.required_one_of: List[List[str]] = [
-            ["domain_id", "domain"],
-            ["id", "name"],
-        ]
-        self.results: Dict[Any, Any] = {"records": []}
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def _get_domain_by_name(self, name: str) -> Optional[Domain]:
-        try:
-            domain = self.client.domains(Domain.domain == name)[0]
-            return domain
-        except IndexError:
-            return None
-        except Exception as exception:
-            return self.fail(
-                msg="failed to get domain {0}: {1}".format(name, exception)
-            )
-
-    def _get_domain_from_params(self) -> Optional[Domain]:
-        domain_id = self.module.params.get("domain_id")
-        domain = self.module.params.get("domain")
-
-        if domain is not None:
-            return self._get_domain_by_name(domain)
-
-        if domain_id is not None:
-            result = Domain(self.client, domain_id)
-            result._api_get()
-            return result
-
-        return None
-
-    def _get_records_by_name(
-        self, domain: Domain, name: str
-    ) -> Optional[List[DomainRecord]]:
-        try:
-            result = []
-
-            for record in domain.records:
-                if record.name == name:
-                    result.append(record)
-
-            return result
-        except IndexError:
-            return []
-        except Exception as exception:
-            return self.fail(
-                msg="failed to get domain record {0}: {1}".format(
-                    name, exception
-                )
-            )
-
-    def _get_records_from_params(self, domain: Domain) -> List[DomainRecord]:
-        record_id = self.module.params.get("id")
-        record_name = self.module.params.get("name")
-
-        if record_name is not None:
-            return self._get_records_by_name(domain, record_name)
-
-        if record_id is not None:
-            result = DomainRecord(self.client, record_id, domain.id)
-            result._api_get()
-            return [result]
-
-        return []
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for domain record info module"""
-
-        domain = self._get_domain_from_params()
-        if domain is None:
-            return self.fail("failed to get domain")
-
-        records = self._get_records_from_params(domain)
-        if records is None:
-            return self.fail("failed to get records")
-
-        self.results["record"] = paginated_list_to_json(records)
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the Linode Domain Record info module"""
-    LinodeDomainRecordInfo()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/domain_record_info.py
+++ b/plugins/modules/domain_record_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to retrieve information about a Linode VPC Subnet."""
+"""This module contains all of the functionality for Linode Domain records."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -87,6 +87,20 @@
           - record_info_id.record[0].ttl_sec == 14400
           - record_info_id.record[0].weight == 62
 
+    - name: Get domain_record_info with both domain_id and domain
+      linode.cloud.domain_record_info:
+        domain: '{{ domain_create.domain.domain }}'
+        domain_id: '{{ domain_create.domain.id }}'
+        id: '{{ record_create.record.id }}'
+      register: info_mutually_exclusive
+      failed_when: '"mutually exclusive" not in info_mutually_exclusive.msg'
+
+    - name: Get domain_record_info with neither domain_id nor domain
+      linode.cloud.domain_record_info:
+        id: '{{ record_create.record.id }}'
+      register: info_one_of
+      failed_when: '"one of the following" not in info_one_of.msg'
+
     - name: Create domain_record with domain id
       linode.cloud.domain_record:
         domain_id: '{{ domain_create.domain.id }}'


### PR DESCRIPTION
## 📝 Description

This pull request migrates the `linode.cloud.domain_record_info` module to the InfoModule base class. Additionally, this PR adds a new `InfoModuleParamGroup` type that allows mutually exclusive parameters to be defined.

## ✔️ How to Test

The following test steps assume you have pulled down this PR and run `make install`.

### Integration Testing

```
make test TEST_ARGS="-v domain_basic domain_list domain_record domain_zone_file"
```

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:

```yaml
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Get information about the current user
      linode.cloud.profile_info: {}
      register: profile_info

    - name: Create a domain
      linode.cloud.domain:
        domain: "ansible-test-{{ profile_info.profile.username }}.com"
        type: master
        soa_email: "{{ profile_info.profile.email }}"
        state: present
      register: domain_create

    - name: Create a domain record
      linode.cloud.domain_record:
        domain_id: "{{ domain_create.domain.id }}"
        name: "test"
        type: A
        target: "8.8.8.8"
        state: present
      register: record_create

    - name: Get information about the record by domain name and record name
      linode.cloud.domain_record_info:
        domain: "{{ domain_create.domain.domain }}"
        name: "{{ record_create.record.name }}"

    - name: Get information about the record by domain ID and record ID
      linode.cloud.domain_record_info:
        domain_id: "{{ domain_create.domain.id }}"
        id: "{{ record_create.record.id }}"
```
2. Ensure the playbook runs successfully.
3. Ensure the output of the `Get information about the record by domain name and record name` task accurately reflects the new domain record.
4. Ensure the output of the `Get information about the record by domain ID and record ID` task accurately reflects the new domain record.