### PR TITLE
Migrate instance_type_list, type_list, and instance_list to use common list module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Name | Description |
 [linode.cloud.event_list](./docs/modules/event_list.md)|List and filter on Linode events.|
 [linode.cloud.firewall_list](./docs/modules/firewall_list.md)|List and filter on Firewalls.|
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
-[linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Linode Instances.|
-[linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|List and filter on Linode Instance Types.|
+[linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Instances.|
+[linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.|
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List Kubernetes versions available for deployment to a Kubernetes cluster.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Nodebalancers.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
@@ -108,7 +108,7 @@ Name | Description |
 [linode.cloud.ssh_key_list](./docs/modules/ssh_key_list.md)|List and filter on SSH keys in the Linode profile.|
 [linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on Linode stackscripts.|
 [linode.cloud.token_list](./docs/modules/token_list.md)|List and filter on Linode Account tokens.|
-[linode.cloud.type_list](./docs/modules/type_list.md)|List and filter on Linode Instance Types.|
+[linode.cloud.type_list](./docs/modules/type_list.md)|List and filter on Types.|
 [linode.cloud.user_list](./docs/modules/user_list.md)|List Users.|
 [linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on Linode VLANs.|
 [linode.cloud.volume_list](./docs/modules/volume_list.md)|List and filter on Linode Volumes.|

--- a/docs/modules/instance_list.md
+++ b/docs/modules/instance_list.md
@@ -1,6 +1,6 @@
 # instance_list
 
-List and filter on Linode Instances.
+List and filter on Instances.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -32,21 +32,21 @@ List and filter on Linode Instances.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list instances in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order instances by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting instances.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Instances in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Instances by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Instances.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Instances to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-instances   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-linode-instances).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `instances` - The returned instances.
+- `instances` - The returned Instances.
 
     - Sample Response:
         ```json

--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -1,5 +1,7 @@
 # instance_type_list
 
+**NOTE: This module has been deprecated in favor of `type_list`.
+
 List and filter on Linode Instance Types.
 
 - [Minimum Required Fields](#minimum-required-fields)
@@ -32,21 +34,21 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list instance types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order instance types by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting instance types.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Instance Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Instance Types by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Instance Types.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Instance Types to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-types   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-linode-types).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `instance_types` - The returned instance types.
+- `instance_types` - The returned Instance Types.
 
     - Sample Response:
         ```json

--- a/docs/modules/type_list.md
+++ b/docs/modules/type_list.md
@@ -1,6 +1,6 @@
 # type_list
 
-List and filter on Linode Instance Types.
+List and filter on Types.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -33,21 +33,21 @@ List and filter on Linode Instance Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Instance Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Instance Types by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Instance Types.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Types by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Types.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Types to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-linode-types   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-linode-types).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `types` - The returned Instance Types.
+- `types` - The returned Types.
 
     - Sample Response:
         ```json

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -4,93 +4,21 @@
 """This module allows users to list Linode instances."""
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.instance_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list instances in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string,
-        description=["The attribute to order instances by."],
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting instances."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode Instances."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Instances",
+    result_field_name="instances",
+    endpoint_template="/linode/instances",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
     examples=docs.specdoc_examples,
-    return_values={
-        "instances": SpecReturnValue(
-            description="The returned instances.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_images_samples,
-        )
-    },
+    result_samples=docs.result_images_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -99,34 +27,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of Linode instances"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"instances": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for instance list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["instances"] = get_all_paginated(
-            self.client,
-            "/linode/instances",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -1,100 +1,31 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Linode instance types."""
+"""This module allows users to list Linode instance types. Deprecated in favor of type_list."""
 from __future__ import absolute_import, division, print_function
-
-from typing import Any, Dict, Optional
 
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
     instance_type_list as docs,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-linode-types",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list instance types in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string,
-        description=["The attribute to order instance types by."],
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=[
-            "A list of filters to apply to the resulting instance types."
-        ],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode Instance Types."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Instance Types",
+    result_field_name="instance_types",
+    endpoint_template="/linode/types",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
     examples=docs.specdoc_examples,
-    return_values={
-        "instance_types": SpecReturnValue(
-            description="The returned instance types.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_instance_type_samples,
-        )
-    },
+    result_samples=docs.result_instance_type_samples,
 )
+
+module.description = [
+    "**NOTE: This module has been deprecated in favor of `type_list`.",
+    "List and filter on Linode Instance Types.",
+]
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -103,34 +34,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of Linode instance types"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"instance_types": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for instance type list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["instance_types"] = get_all_paginated(
-            self.client,
-            "/linode/types",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/type_list.py
+++ b/plugins/modules/type_list.py
@@ -2,98 +2,23 @@
 # -*- coding: utf-8 -*-
 
 """This module allows users to list Linode Instance Types."""
-
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.type_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-linode-types",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list Instance Types in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string,
-        description=["The attribute to order Instance Types by."],
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=[
-            "A list of filters to apply to the resulting Instance Types."
-        ],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode Instance Types."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Types",
+    result_field_name="types",
+    endpoint_template="/linode/types",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
     examples=docs.specdoc_examples,
-    return_values={
-        "types": SpecReturnValue(
-            description="The returned Instance Types.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_type_samples,
-        )
-    },
+    result_samples=docs.result_type_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -102,34 +27,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode Instance Types"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"types": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for Instance Types list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["types"] = get_all_paginated(
-            self.client,
-            "/linode/types",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrated the `instance_type_list`, `type_list`, and `instance_list` modules to use the common list module.

## ✔️ How to Test

### Integration Test
`make TEST_ARGS="-v type_list instance_list instance_type_list" test`

### Manual Test
> **NOTE**: `instance_type_list` and `type_list` are essentially the same module with the exception of the name. `instance_type_list` has been marked as deprecated in favor of `type_list`.

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:
```
---
- name: test
  hosts: localhost
  tasks:
    - name: List Linode Instance Types without a filter
      linode.cloud.instance_type_list:
      register: instance_type_list_no_filter
    - name: List Types without a filter
      linode.cloud.type_list:
      register: type_list_no_filter

    - name: List Linode Instance Types with a filter on class
      linode.cloud.instance_type_list:
        filters:
          - name: class
            values: nanode
      register: instance_type_list_class_filter
    - name: List Types with a filter on class
      linode.cloud.type_list:
        filters:
          - name: class
            values: nanode
      register: type_list_class_filter

    - name: Create a Linode instance without a root password
      linode.cloud.instance:
        label: 'ansible-test-instance-1'
        region: us-ord
        type: g6-standard-1
        image: linode/ubuntu22.04
        private_ip: true
        wait: false
        state: present
        booted: false
      register: create_1
    - name: Create another Linode instance without a root password
      linode.cloud.instance:
        label: 'ansible-test-instance-2'
        region: us-ord
        type: g6-standard-1
        image: linode/ubuntu22.04
        private_ip: true
        wait: false
        state: present
        booted: false
      register: create_2
    - name: List Linode Instances with no filter
      linode.cloud.instance_list:
      register: no_filter
    - name: List Linode Instances with a filter on label
      linode.cloud.instance_list:
        filters:
          - name: label
            values: "{{ create_2.instance.label }}"
      register: filter
    - name: Delete a Linode instance
      linode.cloud.instance:
        label: '{{ create_1.instance.label }}'
        state: absent
      register: delete_1
    - name: Delete a Linode instance
      linode.cloud.instance:
        label: '{{ create_2.instance.label }}'
        state: absent
      register: delete_2
```
2. Ensure that `instance_type_list` and `type_list` returns the same thing with the exception of the name.
3. Ensure that `instance_list` is working properly and displaying the newly created instances.
4. Ensure that the newly created instances have been successfully deleted.