### PR TITLE
fix: Respect existing `zone_file` result structure

### DIFF
--- a/docs/modules/domain.md
+++ b/docs/modules/domain.md
@@ -106,7 +106,6 @@ Manage Linode Domains.
 
     - Sample Response:
         ```json
-        
         {
           "zone_file": [
             "; example.com [123]",

--- a/docs/modules/domain.md
+++ b/docs/modules/domain.md
@@ -106,20 +106,19 @@ Manage Linode Domains.
 
     - Sample Response:
         ```json
-        [
-          {
-            "zone_file": [
-              "; example.com [123]",
-              "$TTL 864000",
-              "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
-              "@    NS  ns1.linode.com.",
-              "@    NS  ns2.linode.com.",
-              "@    NS  ns3.linode.com.",
-              "@    NS  ns4.linode.com.",
-              "@    NS  ns5.linode.com."
-            ]
-          }
-        ]
+        
+        {
+          "zone_file": [
+            "; example.com [123]",
+            "$TTL 864000",
+            "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
+            "@    NS  ns1.linode.com.",
+            "@    NS  ns2.linode.com.",
+            "@    NS  ns3.linode.com.",
+            "@    NS  ns4.linode.com.",
+            "@    NS  ns5.linode.com."
+          ]
+        }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-zone) for a list of returned fields
 

--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -92,7 +92,6 @@ Get info about a Linode Domain.
 
     - Sample Response:
         ```json
-        
         {
           "zone_file": [
             "; example.com [123]",

--- a/docs/modules/domain_info.md
+++ b/docs/modules/domain_info.md
@@ -92,20 +92,19 @@ Get info about a Linode Domain.
 
     - Sample Response:
         ```json
-        [
-          {
-            "zone_file": [
-              "; example.com [123]",
-              "$TTL 864000",
-              "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
-              "@    NS  ns1.linode.com.",
-              "@    NS  ns2.linode.com.",
-              "@    NS  ns3.linode.com.",
-              "@    NS  ns4.linode.com.",
-              "@    NS  ns5.linode.com."
-            ]
-          }
-        ]
+        
+        {
+          "zone_file": [
+            "; example.com [123]",
+            "$TTL 864000",
+            "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
+            "@    NS  ns1.linode.com.",
+            "@    NS  ns2.linode.com.",
+            "@    NS  ns3.linode.com.",
+            "@    NS  ns4.linode.com.",
+            "@    NS  ns5.linode.com."
+          ]
+        }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-domain-zone) for a list of returned fields
 

--- a/plugins/module_utils/doc_fragments/domain.py
+++ b/plugins/module_utils/doc_fragments/domain.py
@@ -49,8 +49,7 @@ result_records_samples = ['''[
   }
 ]''']
 
-result_zone_file_samples = ['''
-{
+result_zone_file_samples = ['''{
   "zone_file": [
     "; example.com [123]",
     "$TTL 864000",

--- a/plugins/module_utils/doc_fragments/domain.py
+++ b/plugins/module_utils/doc_fragments/domain.py
@@ -49,17 +49,16 @@ result_records_samples = ['''[
   }
 ]''']
 
-result_zone_file_samples = ['''[
-  {
-    "zone_file": [
-      "; example.com [123]",
-      "$TTL 864000",
-      "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
-      "@    NS  ns1.linode.com.",
-      "@    NS  ns2.linode.com.",
-      "@    NS  ns3.linode.com.",
-      "@    NS  ns4.linode.com.",
-      "@    NS  ns5.linode.com."
-    ]
-  }
-]''']
+result_zone_file_samples = ['''
+{
+  "zone_file": [
+    "; example.com [123]",
+    "$TTL 864000",
+    "@  IN  SOA  ns1.linode.com. user.example.com. 2021000066 14400 14400 1209600 86400",
+    "@    NS  ns1.linode.com.",
+    "@    NS  ns2.linode.com.",
+    "@    NS  ns3.linode.com.",
+    "@    NS  ns4.linode.com.",
+    "@    NS  ns5.linode.com."
+  ]
+}''']

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -154,7 +154,7 @@ SPECDOC_META = SpecDocMeta(
         "zone_file": SpecReturnValue(
             description="The zone file for the last rendered zone for the specified domain.",
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-zone",
-            type=FieldType.list,
+            type=FieldType.dict,
             sample=docs.result_zone_file_samples,
         ),
     },

--- a/plugins/modules/domain_info.py
+++ b/plugins/modules/domain_info.py
@@ -40,13 +40,13 @@ module = InfoModule(
         ),
         InfoModuleResult(
             field_name="zone_file",
-            field_type=FieldType.list,
+            field_type=FieldType.dict,
             display_name="zone file",
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-domain-zone",
             samples=docs_parent.result_zone_file_samples,
-            get=lambda client, domain, params: Domain(
-                client, domain["id"]
-            ).zone_file_view(),
+            get=lambda client, domain, params: {
+                "zone_file": Domain(client, domain["id"]).zone_file_view()
+            },
         ),
     ],
     attributes=[


### PR DESCRIPTION
## 📝 Description

This pull request resolves an accidental breaking change for the `zone_file` field that was introduced when migrating the `domain_info` module to the InfoModule base class. Additionally, this change corrects the `zone_file` sample to reflect the correct structure in the documentation.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make test TEST_ARGS="-v domain_basic domain_zone_file"
```
