### PR TITLE
Migrated StackScript list module to new framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Name | Description |
 [linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|
 [linode.cloud.region_list](./docs/modules/region_list.md)|List and filter on Linode Regions.|
 [linode.cloud.ssh_key_list](./docs/modules/ssh_key_list.md)|List and filter on SSH keys in the Linode profile.|
-[linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on Linode stackscripts.|
+[linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on StackScripts.|
 [linode.cloud.token_list](./docs/modules/token_list.md)|List and filter on Linode Account tokens.|
 [linode.cloud.type_list](./docs/modules/type_list.md)|List and filter on Types.|
 [linode.cloud.user_list](./docs/modules/user_list.md)|List Users.|

--- a/docs/modules/stackscript_list.md
+++ b/docs/modules/stackscript_list.md
@@ -1,6 +1,6 @@
 # stackscript_list
 
-List and filter on Linode stackscripts.
+List and filter on StackScripts.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -40,21 +40,21 @@ List and filter on Linode stackscripts.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list events in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order events by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting events.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list StackScripts in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order StackScripts by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting StackScripts.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of StackScripts to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-stack-scripts   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `stackscripts` - The returned stackscripts.
+- `stackscripts` - The returned StackScripts.
 
     - Sample Response:
         ```json

--- a/plugins/modules/stackscript_list.py
+++ b/plugins/modules/stackscript_list.py
@@ -1,98 +1,25 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Linode stackscripts."""
+"""This module contains all of the functionality for listing Linode StackScripts."""
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.stackscript_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            # pylint: disable-next=line-too-long
-            "https://techdocs.akamai.com/linode-api/reference/get-stack-scripts",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list events in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string, description=["The attribute to order events by."]
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting events."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=["List and filter on Linode stackscripts."],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="StackScripts",
+    result_field_name="stackscripts",
+    endpoint_template="/linode/stackscripts",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-stack-scripts",
     examples=docs.specdoc_examples,
-    return_values={
-        "stackscripts": SpecReturnValue(
-            description="The returned stackscripts.",
-            # pylint: disable-next=line-too-long
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-stack-scripts",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_stackscripts_samples,
-        )
-    },
+    result_samples=docs.result_stackscripts_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -101,34 +28,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of Linode stackscripts"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"stackscripts": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for stackscript list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["stackscripts"] = get_all_paginated(
-            self.client,
-            "/linode/stackscripts",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrated `stackscript_list` module to new framework.

## ✔️ How to Test

### Integration Testing

`make TEST_ARGS="-v stackscript_list" test

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:
```
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a stackscript
      linode.cloud.stackscript:
        label: 'test-stackscript'
        images: [ 'linode/alpine3.19' ]
        script: |
          #!/bin/bash
          # <UDF name="package" label="System Package to Install" example="nginx" default="">
          apt-get -q update && apt-get -q -y install $PACKAGE
        state: present
      register: stackscript

    - name: List stackscripts with no filter
      linode.cloud.stackscript_list:
      register: no_filter

    - name: List stackscripts with filter on label
      linode.cloud.stackscript_list:
        filters:
          - name: label
            values: test-stackscript
      register: filter_label
```
2. Ensure that the StackScript list is returned and filtered properly.
3. Ensure that the newly created stackscripts have been successfully deleted.