### PR TITLE
ref: Migrate lke_version_list to use common list info

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Name | Description |
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
 [linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Instances.|
 [linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.|
-[linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List Kubernetes versions available for deployment to a Kubernetes cluster.|
+[linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List and filter on LKE Versions.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Node Balancers.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -1,6 +1,6 @@
 # lke_version_list
 
-List Kubernetes versions available for deployment to a Kubernetes cluster.
+List and filter on LKE Versions.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -24,12 +24,21 @@ List Kubernetes versions available for deployment to a Kubernetes cluster.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list lke versions in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list LKE Versions in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order LKE Versions by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting LKE Versions.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of LKE Versions to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-lke-versions).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `lke_versions` - The returned LKE versions.
+- `lke_versions` - The returned LKE Versions.
 
     - Sample Response:
         ```json

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -1,66 +1,27 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Linode instances."""
+"""This module allows users to list Linode LKE Versions."""
+
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_version_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    lke_version_list as docs,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list lke versions in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=[
-        "List Kubernetes versions available for deployment to a Kubernetes cluster."
-    ],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="LKE Versions",
+    result_field_name="lke_versions",
+    endpoint_template="/lke/versions",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-versions",
+    result_samples=docs.result_lke_versions_samples,
     examples=docs.specdoc_examples,
-    return_values={
-        "lke_versions": SpecReturnValue(
-            description="The returned LKE versions.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-versions",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_lke_versions_samples,
-        )
-    },
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -69,33 +30,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of Kubernetes versions"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"lke_versions": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for lke version list module"""
-
-        self.results["lke_versions"] = get_all_paginated(
-            self.client,
-            "/lke/versions",
-            None,
-            num_results=self.module.params["count"],
-        )
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrate the lke_version_list to use the common list info for better maintainability.

## ✔️ How to Test

```
make TEST_ARGS="-v lke_version_list" test
```

Manual Test:
1. In a sandbox environment, run the following playbook script to list lke versions
```yaml
- name: test
  hosts: localhost
  tasks:
    - name: List lke_version_list
      linode.cloud.lke_version_list:
```
2. Observe the versions are successfully listed. 