### PR TITLE
ref: Migrate object_cluster_list module to ListModule base class; add deprecation support to ListModule and InfoModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Name | Description |
 [linode.cloud.firewall_list](./docs/modules/firewall_list.md)|List and filter on Firewalls.|
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
 [linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Instances.|
-[linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.|
+[linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.**|
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List Kubernetes versions available for deployment to a Kubernetes cluster.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Node Balancers.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -58,7 +58,7 @@ Parameters
 
 
   **strict (type=bool):**
-    \• If \ :literal:`yes`\  make invalid entries a fatal error, otherwise skip and continue.
+    \• If :literal:`yes` make invalid entries a fatal error, otherwise skip and continue.
 
     \• Since it is possible to use facts in the expressions they might not always be available and we ignore those errors by default.
 
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
+        \• This option is mutually exclusive with :literal:`keyed\_groups[].trailing\_separator`.
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
+        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
+        \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
 
 

--- a/docs/modules/instance_type_list.md
+++ b/docs/modules/instance_type_list.md
@@ -1,8 +1,8 @@
 # instance_type_list
 
-**NOTE: This module has been deprecated in favor of `type_list`.
+**NOTE: This module has been deprecated in favor of `type_list`.**
 
-List and filter on Linode Instance Types.
+List and filter on Instance Types.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)

--- a/docs/modules/object_cluster_list.md
+++ b/docs/modules/object_cluster_list.md
@@ -34,21 +34,21 @@ List and filter on Object Storage Clusters.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `order` | <center>`str`</center> | <center>Optional</center> | The order to list object storage clusters in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
-| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order object storage clusters by.   |
-| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting object storage clusters.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Object Storage Clusters in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Object Storage Clusters by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Object Storage Clusters.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Object Storage Clusters to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 
-- `clusters` - The returned object storage clusters.
+- `clusters` - The returned Object Storage Clusters.
 
     - Sample Response:
         ```json

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -124,6 +124,8 @@ class InfoModule(LinodeModuleBase):
         examples: List[str] = None,
         description: List[str] = None,
         requires_beta: bool = False,
+        deprecated: bool = False,
+        deprecation_message: Optional[str] = None,
     ) -> None:
         self.primary_result = primary_result
         self.secondary_results = secondary_results or []
@@ -133,6 +135,15 @@ class InfoModule(LinodeModuleBase):
             f"Get info about a Linode {self.primary_result.display_name}."
         ]
         self.requires_beta = requires_beta
+        self.deprecated = deprecated
+        self.deprecation_message = (
+            deprecation_message or "This module has been deprecated."
+        )
+
+        # If this module is deprecated, we should add the deprecation message
+        # to the module's description.
+        if self.deprecated:
+            self.description.insert(0, f"**NOTE: {self.deprecation_message}**")
 
         # Singular params should be translated into groups
         self.param_groups = [
@@ -274,6 +285,10 @@ class InfoModule(LinodeModuleBase):
         """
         Initializes and runs the info module.
         """
+
+        if self.deprecated:
+            self.warn(self.deprecation_message)
+
         base_module_args = {
             "module_arg_spec": self.module_arg_spec,
             "required_one_of": [],

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -56,6 +56,8 @@ class ListModule(
         description: List[str] = None,
         result_samples: List[str] = None,
         requires_beta: bool = False,
+        deprecated: bool = False,
+        deprecation_message: Optional[str] = None,
     ) -> None:
         self.result_display_name = result_display_name
         self.result_field_name = result_field_name
@@ -69,12 +71,24 @@ class ListModule(
         ]
         self.result_samples = result_samples or []
         self.requires_beta = requires_beta
+        self.deprecated = deprecated
+        self.deprecation_message = (
+            deprecation_message or "This module has been deprecated."
+        )
 
         self.module_arg_spec = self.spec.ansible_spec
         self.results: Dict[str, Any] = {self.result_field_name: []}
 
+        # If this module is deprecated, we should add the deprecation message
+        # to the module's description.
+        if self.deprecated:
+            self.description.insert(0, f"**NOTE: {self.deprecation_message}**")
+
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for list module"""
+
+        if self.deprecated:
+            self.warn(self.deprecation_message)
 
         filter_dict = construct_api_filter(self.module.params)
 

--- a/plugins/modules/instance_type_list.py
+++ b/plugins/modules/instance_type_list.py
@@ -18,10 +18,8 @@ module = ListModule(
     result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-types",
     examples=docs.specdoc_examples,
     result_samples=docs.result_instance_type_samples,
-    description=[
-        "**NOTE: This module has been deprecated in favor of `type_list`.",
-        "List and filter on Linode Instance Types.",
-    ],
+    deprecated=True,
+    deprecation_message="This module has been deprecated in favor of `type_list`.",
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/object_cluster_list.py
+++ b/plugins/modules/object_cluster_list.py
@@ -1,106 +1,32 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""This module allows users to list Object Storage clusters."""
-from __future__ import absolute_import, division, print_function
+"""This module allows users to list Linode Object Storage clusters. ."""
 
-from typing import Any, Dict, Optional
+from __future__ import absolute_import, division, print_function
 
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
     object_cluster_list as docs,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-object-storage-buckets",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list object storage clusters in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string,
-        description=["The attribute to order object storage clusters by."],
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=[
-            "A list of filters to apply to the resulting object storage clusters."
-        ],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=[
-        "**NOTE: This module has been deprecated because it "
-        + "relies on deprecated API endpoints. Going forward, `region` will "
-        + "be the preferred way to designate where Object Storage resources "
-        + "should be created.**",
-        "List and filter on Object Storage Clusters.",
-    ],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="Object Storage Clusters",
+    result_field_name="clusters",
+    endpoint_template="/object-storage/clusters",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters",
+    result_samples=docs.result_object_clusters_samples,
     examples=docs.specdoc_examples,
-    return_values={
-        "clusters": SpecReturnValue(
-            description="The returned object storage clusters.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-clusters",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_object_clusters_samples,
-        )
-    },
+    deprecated=True,
+    deprecation_message="This module has been deprecated because it "
+    + "relies on deprecated API endpoints. Going forward, `region` will "
+    + "be the preferred way to designate where Object Storage resources "
+    + "should be created.",
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -109,41 +35,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting a list of Object Storage Clusters"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"clusters": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for object storage cluster list module"""
-
-        self.warn(
-            "The linode.cloud.object_cluster_list has been deprecated because it relies "
-            "on deprecated API endpoints.\n"
-            "Going forward, region will be the preferred way to designate where Object "
-            "Storage resources should be created."
-        )
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["clusters"] = get_all_paginated(
-            self.client,
-            "/object-storage/clusters",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/tests/integration/targets/object_cluster_list/tasks/main.yaml
+++ b/tests/integration/targets/object_cluster_list/tasks/main.yaml
@@ -10,18 +10,6 @@
 #    - assert:
 #        that:
 #          - no_filter.clusters | length >= 1
-#
-#    - name: List regions with filter on region
-#      linode.cloud.object_cluster_list:
-#        filters:
-#          - name: region
-#            values: us-ord
-#      register: filter
-#
-#    - assert:
-#        that:
-#          - filter.clusters | length >= 1
-#          - filter.clusters[0].region == 'us-ord'
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'


### PR DESCRIPTION
## 📝 Description

This pull request migrates the `object_cluster_list` module over to the ListModule base class. Because this module is deprecated, this PR also adds support for deprecating modules using the ListModule and InfoModule base classes.

**NOTE: object_cluster_info was intentionally not migrated as a part of this PR because its usage deviates too much from InfoModule.**

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

1. Open `tests/integration/targets/object_cluster_list/main.yaml`, remove the debug task and uncomment the rest of the playbook.
2. Run the tests:

```
make TEST_ARGS="-v object_basic object_cluster_list" test
```