### PR TITLE
Migrated VLAN-related list module to new framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Name | Description |
 [linode.cloud.token_list](./docs/modules/token_list.md)|List and filter on Linode Account tokens.|
 [linode.cloud.type_list](./docs/modules/type_list.md)|List and filter on Types.|
 [linode.cloud.user_list](./docs/modules/user_list.md)|List Users.|
-[linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on Linode VLANs.|
+[linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on VLANs.|
 [linode.cloud.volume_list](./docs/modules/volume_list.md)|List and filter on Linode Volumes.|
 [linode.cloud.vpc_ip_list](./docs/modules/vpc_ip_list.md)|List and filter on VPC IP Addresses.|
 [linode.cloud.vpc_list](./docs/modules/vpc_list.md)|List and filter on VPCs.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -58,7 +58,7 @@ Parameters
 
 
   **strict (type=bool):**
-    \• If \ :literal:`yes`\  make invalid entries a fatal error, otherwise skip and continue.
+    \• If :literal:`yes` make invalid entries a fatal error, otherwise skip and continue.
 
     \• Since it is possible to use facts in the expressions they might not always be available and we ignore those errors by default.
 
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
+        \• This option is mutually exclusive with :literal:`keyed\_groups[].trailing\_separator`.
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
+        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
+        \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
 
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -2,8 +2,6 @@
 
 Get info about a Linode VLAN.
 
-WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
-
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -28,11 +26,12 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>**Required**</center> | The VLAN’s label.   |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VLAN to resolve.  **(Conflicts With: `id`)** |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VLAN to resolve.  **(Conflicts With: `label`)** |
 
 ## Return Values
 
-- `vlan` - The VLAN in JSON serialized form.
+- `vlan` - The returned VLAN.
 
     - Sample Response:
         ```json

--- a/docs/modules/vlan_list.md
+++ b/docs/modules/vlan_list.md
@@ -1,8 +1,6 @@
 # vlan_list
 
-List and filter on Linode VLANs.
-
-WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+List and filter on VLANs.
 
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
@@ -40,13 +38,13 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 | `order` | <center>`str`</center> | <center>Optional</center> | The order to list VLANs in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order VLANs by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting VLANs.   |
-| `count` | <center>`int`</center> | <center>Optional</center> | The number of results to return. If undefined, all results will be returned.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of VLANs to return. If undefined, all results will be returned.   |
 
 ### filters
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable attributes can be found here: https://techdocs.akamai.com/linode-api/reference/get-vlans   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-vlans).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values

--- a/plugins/modules/vlan_info.py
+++ b/plugins/modules/vlan_info.py
@@ -5,51 +5,51 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, List, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vlan_info as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
 )
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    BETA_DISCLAIMER,
-    global_authors,
-    global_requirements,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    safe_find,
 )
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
-)
+from ansible_specdoc.objects import FieldType
 from linode_api4 import VLAN
 
-linode_vlan_info_spec = {
-    # We need to overwrite attributes to exclude them as requirements
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(
-        type=FieldType.string, required=True, description=["The VLAN’s label."]
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="vlan",
+        field_type=FieldType.dict,
+        display_name="VLAN",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
+        samples=docs.result_vlan_samples,
     ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=[
-        "Get info about a Linode VLAN.",
-        BETA_DISCLAIMER,
+    attributes=[
+        InfoModuleAttr(
+            display_name="ID",
+            name="id",
+            type=FieldType.integer,
+            get=lambda client, params: client.load(
+                VLAN,
+                params.get("id"),
+            )._raw_json,
+        ),
+        InfoModuleAttr(
+            display_name="label",
+            name="label",
+            type=FieldType.string,
+            get=lambda client, params: safe_find(
+                client.networking.vlans,
+                VLAN.label == params.get("label"),
+                raise_not_found=True,
+            )._raw_json,
+        ),
     ],
-    requirements=global_requirements,
-    author=global_authors,
-    options=linode_vlan_info_spec,
     examples=docs.specdoc_examples,
-    return_values={
-        "vlan": SpecReturnValue(
-            description="The VLAN in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
-            type=FieldType.dict,
-            sample=docs.result_vlan_samples,
-        )
-    },
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -58,46 +58,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class LinodeVLANInfo(LinodeModuleBase):
-    """Module for getting info about a Linode VLAN"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.required_one_of: List[str] = []
-        self.results = {"vlan": None}
-
-        super().__init__(
-            module_arg_spec=self.module_arg_spec,
-            required_one_of=self.required_one_of,
-        )
-
-    def _get_vlan_by_label(self, label: str) -> Optional[VLAN]:
-        try:
-            return self.client.networking.vlans(VLAN.label == label)[0]
-        except IndexError:
-            return None
-        except Exception as exception:
-            return self.fail(msg="failed to get VLAN {0}".format(exception))
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for VLAN info module"""
-
-        label: str = kwargs.get("label")
-        vlan = self._get_vlan_by_label(label)
-
-        if vlan is None:
-            self.fail("failed to get vlan")
-
-        self.results["vlan"] = vlan._raw_json
-
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the Linode VLAN info module"""
-    LinodeVLANInfo()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()

--- a/plugins/modules/vlan_list.py
+++ b/plugins/modules/vlan_list.py
@@ -5,96 +5,21 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Dict, Optional
-
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vlan_list as docs
-from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
-    LinodeModuleBase,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
-    BETA_DISCLAIMER,
-    global_authors,
-    global_requirements,
-)
-from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    construct_api_filter,
-    get_all_paginated,
-)
-from ansible_specdoc.objects import (
-    FieldType,
-    SpecDocMeta,
-    SpecField,
-    SpecReturnValue,
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
 )
 
-spec_filter = {
-    "name": SpecField(
-        type=FieldType.string,
-        required=True,
-        description=[
-            "The name of the field to filter on.",
-            "Valid filterable attributes can be found here: "
-            "https://techdocs.akamai.com/linode-api/reference/get-vlans",
-        ],
-    ),
-    "values": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.string,
-        required=True,
-        description=[
-            "A list of values to allow for this field.",
-            "Fields will pass this filter if at least one of these values matches.",
-        ],
-    ),
-}
-
-spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "order": SpecField(
-        type=FieldType.string,
-        description=["The order to list VLANs in."],
-        default="asc",
-        choices=["desc", "asc"],
-    ),
-    "order_by": SpecField(
-        type=FieldType.string, description=["The attribute to order VLANs by."]
-    ),
-    "filters": SpecField(
-        type=FieldType.list,
-        element_type=FieldType.dict,
-        suboptions=spec_filter,
-        description=["A list of filters to apply to the resulting VLANs."],
-    ),
-    "count": SpecField(
-        type=FieldType.integer,
-        description=[
-            "The number of results to return.",
-            "If undefined, all results will be returned.",
-        ],
-    ),
-}
-
-SPECDOC_META = SpecDocMeta(
-    description=[
-        "List and filter on Linode VLANs.",
-        BETA_DISCLAIMER,
-    ],
-    requirements=global_requirements,
-    author=global_authors,
-    options=spec,
+module = ListModule(
+    result_display_name="VLANs",
+    result_field_name="vlans",
+    endpoint_template="/networking/vlans",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
     examples=docs.specdoc_examples,
-    return_values={
-        "vlans": SpecReturnValue(
-            description="The returned VLANs.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/get-vlans",
-            type=FieldType.list,
-            elements=FieldType.dict,
-            sample=docs.result_vlan_samples,
-        )
-    },
+    result_samples=docs.result_vlan_samples,
 )
+
+SPECDOC_META = module.spec
 
 DOCUMENTATION = r"""
 """
@@ -103,34 +28,5 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-
-class Module(LinodeModuleBase):
-    """Module for getting info about a Linode VLANs"""
-
-    def __init__(self) -> None:
-        self.module_arg_spec = SPECDOC_META.ansible_spec
-        self.results: Dict[str, Any] = {"vlans": []}
-
-        super().__init__(module_arg_spec=self.module_arg_spec)
-
-    def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for VLANs list module"""
-
-        filter_dict = construct_api_filter(self.module.params)
-
-        self.results["vlans"] = get_all_paginated(
-            self.client,
-            "/networking/vlans",
-            filter_dict,
-            num_results=self.module.params["count"],
-        )
-        return self.results
-
-
-def main() -> None:
-    """Constructs and calls the module"""
-    Module()
-
-
 if __name__ == "__main__":
-    main()
+    module.run()


### PR DESCRIPTION
## 📝 Description

Migrated `vlan_list` and `vlan_info` modules to new framework.

## ✔️ How to Test

### Integration Tests
`make TEST_ARGS="-v vlan_basic vlan_list" test `

### Manual Tests
1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following:
```
- name: test
  hosts: localhost
  tasks:
    - name: Create a Linode instance with interface
      linode.cloud.instance:
        label: 'testing'
        region: us-southeast
        type: g6-standard-1
        image: linode/ubuntu22.04
        interfaces:
          - purpose: vlan
            label: really-cool-vlan
        private_ip: true
        wait: false
        state: present
      register: create

    - name: Get information about the VLAN
      linode.cloud.vlan_info:
        label: 'really-cool-vlan'
      register: vlan_info

    - name: List VLANs with no filter
      linode.cloud.vlan_list:
      register: no_filter

    - name: List VLANs with a filter on name
      linode.cloud.vlan_list:
        filters:
          - name: label
            values: really-cool-vlan
      register: filter_label

    - name: Delete the Linode instance
      linode.cloud.instance:
        label: 'testing'
        state: absent
      register: delete
```
2. Ensure that the vlan info is returned properly.
3. Ensure that the vlan list is returned and filtered properly.