### PR TITLE
new: Support LKE node pool labels and taints

### DIFF
--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -87,6 +87,8 @@ Manage Linode LKE clusters.
 | `count` | <center>`int`</center> | <center>**Required**</center> | The number of nodes in the Node Pool.  **(Updatable)** |
 | `type` | <center>`str`</center> | <center>**Required**</center> | The Linode Type for all of the nodes in the Node Pool.   |
 | [`autoscaler` (sub-options)](#autoscaler) | <center>`dict`</center> | <center>Optional</center> | When enabled, the number of nodes autoscales within the defined minimum and maximum values.  **(Updatable)** |
+| `labels` | <center>`dict`</center> | <center>Optional</center> | Key-value pairs added as labels to nodes in the node pool. Labels help classify your nodes and to easily select subsets of objects.  **(Updatable)** |
+| [`taints` (sub-options)](#taints) | <center>`list`</center> | <center>Optional</center> | Kubernetes taints to add to node pool nodes. Taints help control how pods are scheduled onto nodes, specifically allowing them to repel certain pods.  **(Updatable)** |
 
 ### autoscaler
 
@@ -95,6 +97,14 @@ Manage Linode LKE clusters.
 | `enabled` | <center>`bool`</center> | <center>Optional</center> | Whether autoscaling is enabled for this Node Pool. NOTE: Subsequent playbook runs will override nodes created by the cluster autoscaler.  **(Updatable)** |
 | `max` | <center>`int`</center> | <center>Optional</center> | The maximum number of nodes to autoscale to. Defaults to the value provided by the count field.  **(Updatable)** |
 | `min` | <center>`int`</center> | <center>Optional</center> | The minimum number of nodes to autoscale to. Defaults to the Node Pool’s count.  **(Updatable)** |
+
+### taints
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `key` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint key.  **(Updatable)** |
+| `value` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint value.  **(Updatable)** |
+| `effect` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint effect.  **(Choices: `NoSchedule`, `PreferNoSchedule`, `NoExecute`; Updatable)** |
 
 ## Return Values
 

--- a/docs/modules/lke_node_pool.md
+++ b/docs/modules/lke_node_pool.md
@@ -61,6 +61,8 @@ Manage Linode LKE cluster node pools.
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type for all of the nodes in the Node Pool. Required if `state` == `present`.   |
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the node pool to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the node pool to be ready in seconds.  **(Default: `600`)** |
+| `labels` | <center>`dict`</center> | <center>Optional</center> | Key-value pairs added as labels to nodes in the node pool. Labels help classify your nodes and to easily select subsets of objects.  **(Updatable)** |
+| [`taints` (sub-options)](#taints) | <center>`list`</center> | <center>Optional</center> | Kubernetes taints to add to node pool nodes. Taints help control how pods are scheduled onto nodes, specifically allowing them to repel certain pods.  **(Updatable)** |
 
 ### autoscaler
 
@@ -76,6 +78,14 @@ Manage Linode LKE cluster node pools.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `type` | <center>`str`</center> | <center>**Required**</center> | This custom disk partition’s filesystem type.  **(Choices: `raw`, `ext4`)** |
 | `size` | <center>`int`</center> | <center>**Required**</center> | The size of this custom disk partition in MB.   |
+
+### taints
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `key` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint key.  **(Updatable)** |
+| `value` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint value.  **(Updatable)** |
+| `effect` | <center>`str`</center> | <center>**Required**</center> | The Kubernetes taint effect.  **(Choices: `NoSchedule`, `PreferNoSchedule`, `NoExecute`; Updatable)** |
 
 ## Return Values
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -9,6 +9,7 @@ from linode_api4 import (
     LinodeClient,
     LKENodePool,
     LKENodePoolNode,
+    LKENodePoolTaint,
     MappedObject,
     and_,
 )
@@ -203,6 +204,7 @@ def jsonify_node_pool(pool: LKENodePool) -> Dict[str, Any]:
     result = pool._raw_json
 
     result["nodes"] = [jsonify_node_pool_node(node) for node in pool.nodes]
+    result["taints"] = [jsonify_node_pool_taint(taint) for taint in pool.taints]
 
     return result
 
@@ -214,6 +216,16 @@ def jsonify_node_pool_node(node: LKENodePoolNode) -> Dict[str, Any]:
         "id": node.id,
         "instance_id": node.instance_id,
         "status": node.status,
+    }
+
+
+def jsonify_node_pool_taint(taint: LKENodePoolTaint) -> Dict[str, Any]:
+    """Converts an LKENodePoolTaint into a JSON-compatible dict"""
+
+    return {
+        "key": taint.key,
+        "value": taint.value,
+        "effect": taint.effect,
     }
 
 

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -112,6 +112,28 @@ linode_lke_cluster_disk = {
     ),
 }
 
+linode_lke_cluster_taint = {
+    "key": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint key."],
+        required=True,
+        editable=True,
+    ),
+    "value": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint value."],
+        required=True,
+        editable=True,
+    ),
+    "effect": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint effect."],
+        required=True,
+        editable=True,
+        choices=["NoSchedule", "PreferNoSchedule", "NoExecute"],
+    ),
+}
+
 linode_lke_cluster_node_pool_spec = {
     "count": SpecField(
         type=FieldType.integer,
@@ -132,6 +154,23 @@ linode_lke_cluster_node_pool_spec = {
             "defined minimum and maximum values."
         ],
         suboptions=linode_lke_cluster_autoscaler,
+    ),
+    "labels": SpecField(
+        type=FieldType.dict,
+        editable=True,
+        description=[
+            "Key-value pairs added as labels to nodes in the node pool. "
+            "Labels help classify your nodes and to easily select subsets of objects."
+        ],
+    ),
+    "taints": SpecField(
+        type=FieldType.list,
+        editable=True,
+        description=[
+            "Kubernetes taints to add to node pool nodes. Taints help control "
+            "how pods are scheduled onto nodes, specifically allowing them to repel certain pods."
+        ],
+        suboptions=linode_lke_cluster_taint,
     ),
 }
 
@@ -419,6 +458,7 @@ class LinodeLKECluster(LinodeModuleBase):
 
         self._attempt_update_acl(cluster)
 
+    # pylint: disable=too-many-statements
     def _update_cluster(self, cluster: LKECluster) -> None:
         """Handles all update functionality for the current LKE cluster"""
 
@@ -466,6 +506,32 @@ class LinodeLKECluster(LinodeModuleBase):
                         current_pool.autoscaler = pool.get("autoscaler")
                         current_pool.save()
 
+                    if (
+                        "taints" in pool
+                        and current_pool.taints != pool["taints"]
+                    ):
+                        self.register_action(
+                            "Updated taints for Node Pool {}".format(
+                                current_pool.id
+                            )
+                        )
+
+                        current_pool.taints = pool.get("taints")
+                        current_pool.save()
+
+                    if (
+                        "labels" in pool
+                        and current_pool.labels != pool["labels"]
+                    ):
+                        self.register_action(
+                            "Updated labels for Node Pool {}".format(
+                                current_pool.id
+                            )
+                        )
+
+                        current_pool.labels = pool.get("labels")
+                        current_pool.save()
+
                     pools_handled[k] = True
                     should_keep[i] = True
                     break
@@ -506,6 +572,32 @@ class LinodeLKECluster(LinodeModuleBase):
                             )
                         )
                         existing_pool.autoscaler = pool["autoscaler"]
+                        should_update = True
+
+                    if (
+                        "taints" in pool
+                        and existing_pool.taints != pool["taints"]
+                    ):
+                        self.register_action(
+                            "Updated taints for Node Pool {}".format(
+                                existing_pool.id
+                            )
+                        )
+
+                        existing_pool.taints = pool["taints"]
+                        should_update = True
+
+                    if (
+                        "labels" in pool
+                        and existing_pool.labels != pool["labels"]
+                    ):
+                        self.register_action(
+                            "Updated labels for Node Pool {}".format(
+                                existing_pool.id
+                            )
+                        )
+
+                        existing_pool.labels = pool["labels"]
                         should_update = True
 
                     if should_update:

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -69,6 +69,28 @@ linode_lke_pool_disks = {
     ),
 }
 
+linode_lke_pool_taint = {
+    "key": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint key."],
+        required=True,
+        editable=True,
+    ),
+    "value": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint value."],
+        required=True,
+        editable=True,
+    ),
+    "effect": SpecField(
+        type=FieldType.string,
+        description=["The Kubernetes taint effect."],
+        required=True,
+        editable=True,
+        choices=["NoSchedule", "PreferNoSchedule", "NoExecute"],
+    ),
+}
+
 MODULE_SPEC = {
     "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "cluster_id": SpecField(
@@ -139,6 +161,23 @@ MODULE_SPEC = {
             "The period to wait for the node pool to be ready in seconds."
         ],
         default=600,
+    ),
+    "labels": SpecField(
+        type=FieldType.dict,
+        editable=True,
+        description=[
+            "Key-value pairs added as labels to nodes in the node pool. "
+            "Labels help classify your nodes and to easily select subsets of objects."
+        ],
+    ),
+    "taints": SpecField(
+        type=FieldType.list,
+        editable=True,
+        description=[
+            "Kubernetes taints to add to node pool nodes. Taints help control "
+            "how pods are scheduled onto nodes, specifically allowing them to repel certain pods."
+        ],
+        suboptions=linode_lke_pool_taint,
     ),
 }
 
@@ -251,6 +290,8 @@ class LinodeLKENodePool(LinodeModuleBase):
             params.pop("autoscaler") if "autoscaler" in params else None
         )
         new_count = params.pop("count")
+        new_taints = params.pop("taints") if "taints" in params else None
+        new_labels = params.pop("labels") if "labels" in params else None
 
         try:
             handle_updates(pool, params, set(), self.register_action)
@@ -274,6 +315,16 @@ class LinodeLKENodePool(LinodeModuleBase):
         if new_autoscaler is not None and pool.autoscaler != new_autoscaler:
             self.register_action("Updated autoscaler for Node Pool")
             pool.autoscaler = new_autoscaler
+            should_update = True
+
+        if new_taints is not None and pool.taints != new_taints:
+            self.register_action("Updated taints for Node Pool")
+            pool.taints = new_taints
+            should_update = True
+
+        if new_labels is not None and pool.labels != new_labels:
+            self.register_action("Updated labels for Node Pool")
+            pool.labels = new_labels
             should_update = True
 
         if should_update:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linode-api4>=5.20.0
+linode-api4>=5.21.0
 polling>=0.3.2
 types-requests==2.32.0.20240712
 ansible-specdoc>=0.0.15

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -24,6 +24,13 @@
         node_pools:
           - type: g6-standard-1
             count: 3
+            labels:
+               foo.example.com/test: bar
+               foo.example.com/test2: foo
+            taints:
+                - key: foo.example.com/test2
+                  value: test
+                  effect: NoExecute
           - type: g6-standard-4
             count: 1
             autoscaler:
@@ -41,6 +48,11 @@
           - create_cluster.cluster.region == 'us-southeast'
           - create_cluster.node_pools[0].type == 'g6-standard-1'
           - create_cluster.node_pools[0].count == 3
+          - create_cluster.node_pools[0].labels['foo.example.com/test'] == 'bar'
+          - create_cluster.node_pools[0].labels['foo.example.com/test2'] == 'foo'
+          - create_cluster.node_pools[0].taints[0].key == 'foo.example.com/test2'
+          - create_cluster.node_pools[0].taints[0].value == 'test'
+          - create_cluster.node_pools[0].taints[0].effect == 'NoExecute'
           - create_cluster.node_pools[1].autoscaler.enabled
           - create_cluster.node_pools[1].autoscaler.min == 1
           - create_cluster.node_pools[1].autoscaler.max == 2
@@ -54,6 +66,13 @@
         node_pools:
           - type: g6-standard-1
             count: 2
+            labels:
+              foo.example.com/update: updated
+              foo.example.com/test2: foo
+            taints:
+              - key: foo.example.com/update
+                value: updated
+                effect: PreferNoSchedule
           - type: g6-standard-2
             count: 1
           - type: g6-standard-1
@@ -72,6 +91,12 @@
           - update_pools.node_pools[0].type == 'g6-standard-1'
           - update_pools.node_pools[0].count == 2
           - update_pools.node_pools[0].id == create_cluster.node_pools[0].id
+
+          - update_pools.node_pools[0].labels['foo.example.com/update'] == 'updated'
+          - update_pools.node_pools[0].labels['foo.example.com/test2'] == 'foo'
+          - update_pools.node_pools[0].taints[0].key == 'foo.example.com/update'
+          - update_pools.node_pools[0].taints[0].value == 'updated'
+          - update_pools.node_pools[0].taints[0].effect == 'PreferNoSchedule'
 
           - update_pools.node_pools[1].type == 'g6-standard-2'
           - update_pools.node_pools[1].count == 1
@@ -114,8 +139,8 @@
     - name: Get lke_cluster_info about the cluster by id
       linode.cloud.lke_cluster_info:
         id: '{{ upgrade.cluster.id }}'
-        
-        
+
+
       register: info_by_id
 
     - name: Assert lke_cluster_info about cluster by id

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -37,6 +37,13 @@
         tags: ['my-pool']
         type: g6-standard-1
         count: 2
+        labels:
+          foo.example.com/test: bar
+          foo.example.com/test2: foo
+        taints:
+          - key: foo.example.com/test2
+            value: test
+            effect: NoExecute
         state: present
       register: new_pool
 
@@ -47,6 +54,11 @@
           - new_pool.node_pool.type == 'g6-standard-1'
           - new_pool.node_pool.nodes[0].status == 'ready'
           - new_pool.node_pool.nodes[1].status == 'ready'
+          - new_pool.node_pool.labels['foo.example.com/test'] == 'bar'
+          - new_pool.node_pool.labels['foo.example.com/test2'] == 'foo'
+          - new_pool.node_pool.taints[0].key == 'foo.example.com/test2'
+          - new_pool.node_pool.taints[0].value == 'test'
+          - new_pool.node_pool.taints[0].effect == 'NoExecute'
 
     - name: Attempt to update an invalid field on the node pool
       linode.cloud.lke_node_pool:
@@ -71,6 +83,13 @@
           enabled: true
           min: 1
           max: 3
+        labels:
+          foo.example.com/update: updated
+          foo.example.com/test2: foo
+        taints:
+          - key: foo.example.com/update
+            value: updated
+            effect: PreferNoSchedule
         state: present
       register: update_pool
 
@@ -82,6 +101,11 @@
           - update_pool.node_pool.autoscaler.enabled
           - update_pool.node_pool.autoscaler.min == 1
           - update_pool.node_pool.autoscaler.max == 3
+          - update_pool.node_pool.labels['foo.example.com/update'] == 'updated'
+          - update_pool.node_pool.labels['foo.example.com/test2'] == 'foo'
+          - update_pool.node_pool.taints[0].key == 'foo.example.com/update'
+          - update_pool.node_pool.taints[0].value == 'updated'
+          - update_pool.node_pool.taints[0].effect == 'PreferNoSchedule'
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

Add support to LKE node pool labels and taints in `lke_cluster` and `lke_node_pool` modules. The new fields are both updatable. 

## ✔️ How to Test

```
make TEST_ARGS="-v lke_cluster_basic" test
```
```
make TEST_ARGS="-v lke_node_pool_basic" test
```

Manual Test:
1. In a sandbox environment, i.e. dx-devenv, create the following playbook to create a lke_cluster with node pool taints and labels:
```yaml
- name: test
  hosts: localhost
  tasks:
    - name: Create a Linode LKE cluster
      linode.cloud.lke_cluster:
        label: test-ansible-node-pool-taints
        region: us-southeast
        k8s_version: 1.29
        node_pools:
          - type: g6-standard-1
            count: 2
            labels:
               foo.example.com/test: bar
               foo.example.com/test2: foo
            taints:
                - key: foo.example.com/test2
                  value: test
                  effect: NoExecute
        skip_polling: true
        state: present
      register: create_cluster
```
2. Observe the cluster is created successfully.
3. Update labels and taints
```yaml
    - name: Update a Linode LKE cluster labels and taints
      linode.cloud.lke_cluster:
        label: test-ansible-node-pool-taints
        region: us-southeast
        k8s_version: 1.29
        node_pools:
          - type: g6-standard-1
            count: 2
            labels:
               foo.example.com/update: bar
               foo.example.com/test2: update
            taints:
                - key: foo.example.com/update
                  value: test_update
                  effect: PreferNoSchedule
        skip_polling: true
        state: present
```
4. Add a node pool to the cluster with labels and taints use the lke_node_pool module
```yaml
    - name: Add a node pool to the cluster
      linode.cloud.lke_node_pool:
        cluster_id: '{{ create_cluster.cluster.id }}'

        tags: ['my-pool']
        type: g6-standard-1
        count: 1
        labels:
          foo.example.com/test2: bar
        taints:
          - key: foo.example.com/test2
            value: test2
            effect: NoExecute
        state: present
```
5. Update the node pool
```yaml
    - name: Update a node pool of the cluster
      linode.cloud.lke_node_pool:
        cluster_id: '{{ create_cluster.cluster.id }}'

        tags: ['my-pool']
        type: g6-standard-1
        count: 1
        labels:
          foo.example.com/label: tests
        taints:
          - key: foo.example.com/taint
            value: test
            effect: PreferNoSchedule
        state: present
```