### PR TITLE
ref: Remove state,tags,label from linode_common

### DIFF
--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -58,7 +58,7 @@ Parameters
 
 
   **strict (type=bool):**
-    \• If :literal:`yes` make invalid entries a fatal error, otherwise skip and continue.
+    \• If \ :literal:`yes`\  make invalid entries a fatal error, otherwise skip and continue.
 
     \• Since it is possible to use facts in the expressions they might not always be available and we ignore those errors by default.
 
@@ -94,13 +94,13 @@ Parameters
       **default_value (type=str):**
         \• The default value when the host variable's value is an empty string.
 
-        \• This option is mutually exclusive with :literal:`keyed\_groups[].trailing\_separator`.
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].trailing\_separator`\ .
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
+        \• Set this option to \ :literal:`False`\  to omit the \ :literal:`keyed\_groups[].separator`\  after the host variable when the value is an empty string.
 
-        \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
+        \• This option is mutually exclusive with \ :literal:`keyed\_groups[].default\_value`\ .
 
 
 

--- a/docs/modules/image_info.md
+++ b/docs/modules/image_info.md
@@ -31,8 +31,8 @@ Get info about a Linode Image.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Image to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`str`</center> | <center>Optional</center> | The ID of the Image to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Image to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -31,8 +31,8 @@ Get info about a Linode Instance.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Instance to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Instance to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -57,6 +57,7 @@ Manage Linode LKE clusters.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `label` | <center>`str`</center> | <center>**Required**</center> | This Kubernetes cluster’s unique label.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 | `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -31,8 +31,8 @@ Get info about a Linode Node Balancer.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Node Balancer to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Node Balancer to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Node Balancer to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/nodebalancer_stats.md
+++ b/docs/modules/nodebalancer_stats.md
@@ -28,8 +28,8 @@ Get info about a Linode Node Balancer Stats.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Node Balancer Stats to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Node Balancer Stats to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Node Balancer Stats to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/placement_group.md
+++ b/docs/modules/placement_group.md
@@ -55,6 +55,7 @@ NOTE: Placement Groups may not currently be available to all users.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique ID of the placement group.   |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region that the placement group is in.   |

--- a/docs/modules/placement_group_assign.md
+++ b/docs/modules/placement_group_assign.md
@@ -40,6 +40,7 @@ NOTE: Placement Groups may not currently be available to all users.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `placement_group_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Placement Group for this assignment.   |
 | `linode_id` | <center>`int`</center> | <center>**Required**</center> | The Linode ID to assign or unassign to the Placement Group.   |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 
 ## Return Values
 

--- a/docs/modules/ssh_key_info.md
+++ b/docs/modules/ssh_key_info.md
@@ -31,8 +31,8 @@ Get info about a Linode SSH Key.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the SSH Key to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the SSH Key to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the SSH Key to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/stackscript_info.md
+++ b/docs/modules/stackscript_info.md
@@ -31,8 +31,8 @@ Get info about a Linode StackScript.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the StackScript to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/token_info.md
+++ b/docs/modules/token_info.md
@@ -31,8 +31,8 @@ Get info about a Linode Personal Access Token.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Personal Access Token to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the Personal Access Token to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the Personal Access Token to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/vlan_info.md
+++ b/docs/modules/vlan_info.md
@@ -26,8 +26,8 @@ Get info about a Linode VLAN.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VLAN to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VLAN to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VLAN to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -31,8 +31,8 @@ Get info about a Linode VPC.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/docs/modules/vpc_subnet_info.md
+++ b/docs/modules/vpc_subnet_info.md
@@ -34,8 +34,8 @@ Get info about a Linode VPC Subnet.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `vpc_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC for this resource.   |
-| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.  **(Conflicts With: `id`)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The ID of the VPC Subnet to resolve.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the VPC Subnet to resolve.  **(Conflicts With: `id`)** |
 
 ## Return Values
 

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -70,11 +70,6 @@ LINODE_COMMON_ARGS = {
         "fallback": (env_fallback, ["LINODE_API_URL"]),
         "default": "https://api.linode.com/",
     },
-    "state": {
-        "type": "str",
-        "required": True,
-        "choices": ["present", "absent"],
-    },
     "ua_prefix": {
         "type": "str",
         "description": "An HTTP User-Agent Prefix to prepend in API requests.",
@@ -85,21 +80,6 @@ LINODE_COMMON_ARGS = {
         "type": "str",
         "description": "A path to a custom certificate authority for using alternate APIs.",
         "fallback": (env_fallback, ["LINODE_CA"]),
-    },
-}
-
-LINODE_TAG_ARGS = {
-    "tags": {
-        "type": "list",
-        "description": "The tags to assign to this resource.",
-    },
-}
-
-LINODE_LABEL_ARGS = {
-    "label": {
-        "type": "str",
-        "required": True,
-        "description": "The label to assign to this resource.",
     },
 }
 
@@ -130,8 +110,6 @@ class LinodeModuleBase:
     def __init__(
         self,
         module_arg_spec: dict,
-        supports_tags: bool = True,
-        has_label: bool = True,
         bypass_checks: bool = False,
         no_log: bool = False,
         mutually_exclusive: Any = None,
@@ -144,12 +122,6 @@ class LinodeModuleBase:
     ) -> None:
         arg_spec = {}
         arg_spec.update(LINODE_COMMON_ARGS)
-
-        if has_label:
-            arg_spec.update(LINODE_LABEL_ARGS)
-
-        if supports_tags:
-            arg_spec.update(LINODE_TAG_ARGS)
 
         arg_spec.update(module_arg_spec)
 

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -207,14 +207,7 @@ class InfoModule(LinodeModuleBase):
         Returns the ansible-specdoc spec for this module.
         """
 
-        options = {
-            "state": SpecField(
-                type=FieldType.string, required=False, doc_hide=True
-            ),
-            "label": SpecField(
-                type=FieldType.string, required=False, doc_hide=True
-            ),
-        }
+        options = {}
 
         # Add params to spec
         for group in self.param_groups:

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -112,13 +112,6 @@ class ListModule(
         }
 
         options = {
-            # Disable the default values
-            "state": SpecField(
-                type=FieldType.string, required=False, doc_hide=True
-            ),
-            "label": SpecField(
-                type=FieldType.string, required=False, doc_hide=True
-            ),
             "order": SpecField(
                 type=FieldType.string,
                 description=[

--- a/plugins/modules/database_engine_list.py
+++ b/plugins/modules/database_engine_list.py
@@ -49,9 +49,6 @@ spec_filter = {
 }
 
 spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "order": SpecField(
         type=FieldType.string,
         description=["The order to list database engine types in."],

--- a/plugins/modules/database_list.py
+++ b/plugins/modules/database_list.py
@@ -50,9 +50,6 @@ spec_filter = {
 }
 
 spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "order": SpecField(
         type=FieldType.string,
         description=["The order to list databases in."],

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -37,8 +37,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import MySQLDatabase
 
 spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(
         type=FieldType.string,
         conflicts_with=["label"],

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -37,8 +37,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import PostgreSQLDatabase
 
 spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(
         type=FieldType.string,
         conflicts_with=["label"],

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -29,8 +29,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain
 
 linode_domain_spec = {
-    # Unused for domain objects
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "axfr_ips": SpecField(
         type=FieldType.list,
         element_type=FieldType.string,

--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -28,8 +28,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import Domain, DomainRecord
 
 linode_domain_record_spec = {
-    # Unused for domain record objects
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "domain_id": SpecField(
         type=FieldType.integer, description=["The ID of the parent Domain."]
     ),

--- a/plugins/modules/ip_assign.py
+++ b/plugins/modules/ip_assign.py
@@ -35,9 +35,6 @@ linode_ip_assignments_spec: dict = {
 }
 
 spec = {
-    # Disable the default values
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "assignments": SpecField(
         type=FieldType.list,
         element_type=FieldType.dict,

--- a/plugins/modules/ip_rdns.py
+++ b/plugins/modules/ip_rdns.py
@@ -26,8 +26,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ExplicitNullValue, IPAddress
 
 ip_rdns_spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "state": SpecField(
         type=FieldType.string,
         choices=["present", "absent"],

--- a/plugins/modules/ip_share.py
+++ b/plugins/modules/ip_share.py
@@ -25,9 +25,6 @@ from ansible_specdoc.objects import (
 from linode_api4.objects import Instance
 
 ip_share_spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "ips": SpecField(
         type=FieldType.list,
         required=True,

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -199,6 +199,12 @@ linode_lke_cluster_spec = {
         ],
         default=600,
     ),
+    "state": SpecField(
+        type=FieldType.string,
+        description=["The desired state of the target."],
+        choices=["present", "absent"],
+        required=True,
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(
@@ -653,7 +659,7 @@ class LinodeLKECluster(LinodeModuleBase):
             self.register_action("Deleted cluster {0}".format(cluster))
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
-        """Entrypoint for Domain module"""
+        """Entrypoint for LKE Cluster module"""
         state = kwargs.get("state")
 
         if state == "absent":

--- a/plugins/modules/lke_cluster_info.py
+++ b/plugins/modules/lke_cluster_info.py
@@ -36,8 +36,6 @@ from ansible_specdoc.objects import (
 from linode_api4 import ApiError, LKECluster
 
 linode_lke_cluster_info_spec = {
-    # We need to overwrite attributes to exclude them as requirements
-    "state": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "id": SpecField(
         type=FieldType.integer,
         required=False,

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -70,7 +70,6 @@ linode_lke_pool_disks = {
 }
 
 MODULE_SPEC = {
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "cluster_id": SpecField(
         type=FieldType.integer,
         required=True,

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -55,6 +55,12 @@ placement_group_spec = {
         ],
         choices=["flexible", "strict"],
     ),
+    "state": SpecField(
+        type=FieldType.string,
+        description=["The desired state of the target."],
+        choices=["present", "absent"],
+        required=True,
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(

--- a/plugins/modules/placement_group_assign.py
+++ b/plugins/modules/placement_group_assign.py
@@ -22,8 +22,6 @@ from ansible_specdoc.objects import FieldType, SpecDocMeta, SpecField
 from linode_api4 import PlacementGroup
 
 placement_group_assignment_spec = {
-    # Disable the default values
-    "label": SpecField(type=FieldType.string, required=False, doc_hide=True),
     "placement_group_id": SpecField(
         type=FieldType.integer,
         required=True,
@@ -40,6 +38,12 @@ placement_group_assignment_spec = {
         type=FieldType.bool,
         description=[],
         doc_hide=True,
+    ),
+    "state": SpecField(
+        type=FieldType.string,
+        description=["The desired state of the target."],
+        choices=["present", "absent"],
+        required=True,
     ),
 }
 

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -165,11 +165,6 @@ SPEC_GRANTS = {
 }
 
 SPEC = {
-    # We don't use label for this module
-    "label": SpecField(
-        type=FieldType.string,
-        doc_hide=True,
-    ),
     "username": SpecField(
         type=FieldType.string,
         required=True,


### PR DESCRIPTION
## 📝 Description

Because of the variety of our modules, we don't require state, tags and label in each of them. Remove these three fields from the linode_common and only implement in those which required. It helps us get rid of some ugly workaround and improves readability. 

## ✔️ How to Test

Tests the modules which are added the state field into the module spec:

```
make TEST_ARGS="-v lke_cluster_basic" test
make TEST_ARGS="-v placement_group_basic" test
make TEST_ARGS="-v placement_group_assign" test
```
