### PR TITLE
Add support for LKE, Volume, NodeBalancer, and network transfer pricing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ Name | Description |
 [linode.cloud.image_list](./docs/modules/image_list.md)|List and filter on Images.|
 [linode.cloud.instance_list](./docs/modules/instance_list.md)|List and filter on Instances.|
 [linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.**|
+[linode.cloud.lke_type_list](./docs/modules/lke_type_list.md)|List and filter on LKE Types.|
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List and filter on LKE Versions.|
+[linode.cloud.network_transfer_prices_list](./docs/modules/network_transfer_prices_list.md)|List and filter on Network Transfer Prices.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Node Balancers.|
+[linode.cloud.nodebalancer_type_list](./docs/modules/nodebalancer_type_list.md)|List and filter on Node Balancer Types.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|
 [linode.cloud.region_list](./docs/modules/region_list.md)|List and filter on Regions.|
@@ -112,6 +115,7 @@ Name | Description |
 [linode.cloud.user_list](./docs/modules/user_list.md)|List and filter on Users.|
 [linode.cloud.vlan_list](./docs/modules/vlan_list.md)|List and filter on VLANs.|
 [linode.cloud.volume_list](./docs/modules/volume_list.md)|List and filter on Linode Volumes.|
+[linode.cloud.volume_type_list](./docs/modules/volume_type_list.md)|List and filter on Volume Types.|
 [linode.cloud.vpc_ip_list](./docs/modules/vpc_ip_list.md)|List and filter on VPC IP Addresses.|
 [linode.cloud.vpc_list](./docs/modules/vpc_list.md)|List and filter on VPCs.|
 [linode.cloud.vpc_subnet_list](./docs/modules/vpc_subnet_list.md)|List and filter on VPC Subnets.|

--- a/docs/modules/lke_type_list.md
+++ b/docs/modules/lke_type_list.md
@@ -1,0 +1,79 @@
+# lke_type_list
+
+List and filter on LKE Types.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode LKE Types
+  linode.cloud.lke_type_list: {}
+```
+
+```yaml
+- name: List a Linode LKE Type named LKE High Availability
+  linode.cloud.lke_type_list:
+    filters:
+      - name: label
+        values: LKE High Availability
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list LKE Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order LKE Types by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting LKE Types.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of LKE Types to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `lke_types` - The returned LKE Types.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "id": "lke-ha",
+                "label": "LKE High Availability",
+                "price": {
+                    "hourly": 0.09,
+                    "monthly": 60.0
+                },
+                "region_prices": [
+                    {
+                        "id": "id-cgk"
+                        "hourly": 0.108,
+                        "monthly": 72.0
+                    },
+                    {
+                        "id": "br-gru"
+                        "hourly": 0.126,
+                        "monthly": 84.0
+                    }
+                ],
+                "transfer": 0,
+            }
+        ]
+        ```
+
+

--- a/docs/modules/lke_type_list.md
+++ b/docs/modules/lke_type_list.md
@@ -42,7 +42,7 @@ List and filter on LKE Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/api).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -75,5 +75,6 @@ List and filter on LKE Types.
             }
         ]
         ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/api) for a list of returned fields
 
 

--- a/docs/modules/network_transfer_prices_list.md
+++ b/docs/modules/network_transfer_prices_list.md
@@ -1,0 +1,69 @@
+# network_transfer_prices_list
+
+List and filter on Network Transfer Prices.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode Network Transfer Prices
+  linode.cloud.network_transfer_prices_list: {}
+```
+
+```yaml
+- name: List a Linode Network Transfer Price named Distributed Network Transfer
+  linode.cloud.network_transfer_prices_list:
+    filters:
+      - name: label
+        values: Distributed Network Transfer
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Network Transfer Prices in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Network Transfer Prices by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Network Transfer Prices.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Network Transfer Prices to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-network-transfer-prices).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `network_transfer_prices` - The returned Network Transfer Prices.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "id": "distributed_network_transfer",
+                "label": "Distributed Network Transfer",
+                "price": {
+                    "hourly": 0.01,
+                    "monthly": null
+                },
+                "region_prices": [],
+                "transfer": 0,
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-network-transfer-prices) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_type_list.md
+++ b/docs/modules/nodebalancer_type_list.md
@@ -42,7 +42,7 @@ List and filter on Node Balancer Types.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/api).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -75,5 +75,6 @@ List and filter on Node Balancer Types.
             }
         ]
         ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/api) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_type_list.md
+++ b/docs/modules/nodebalancer_type_list.md
@@ -1,0 +1,79 @@
+# nodebalancer_type_list
+
+List and filter on Node Balancer Types.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode Node Balancer Types
+  linode.cloud.nodebalancer_type_list: {}
+```
+
+```yaml
+- name: List a Linode Node Balancer Type named NodeBalancer
+  linode.cloud.nodebalancer_type_list:
+    filters:
+      - name: label
+        values: NodeBalancer
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Node Balancer Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Node Balancer Types by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Node Balancer Types.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Node Balancer Types to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here]().   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `nodebalancer_types` - The returned Node Balancer Types.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "id": "nodebalancer",
+                "label": "NodeBalancer",
+                "price": {
+                    "hourly": 0.015,
+                    "monthly": 10.0
+                },
+                "region_prices": [
+                    {
+                        "id": "id-cgk"
+                        "hourly": 0.018,
+                        "monthly": 12.0
+                    },
+                    {
+                        "id": "br-gru"
+                        "hourly": 0.021,
+                        "monthly": 14.0
+                    }
+                ],
+                "transfer": 0,
+            }
+        ]
+        ```
+
+

--- a/docs/modules/volume_type_list.md
+++ b/docs/modules/volume_type_list.md
@@ -1,0 +1,80 @@
+# volume_type_list
+
+List and filter on Volume Types.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode Volume Types
+  linode.cloud.volume_type_list: {}
+```
+
+```yaml
+- name: List a Linode Volume Type named Storage Volume
+  linode.cloud.volume_type_list:
+    filters:
+      - name: label
+        values: Storage Volume
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Volume Types in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Volume Types by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Volume Types.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Volume Types to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-volume-types).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `volume_types` - The returned Volume Types.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "id": "volume",
+                "label": "Storage Volume",
+                "price": {
+                    "hourly": 0.00015,
+                    "monthly": 0.1
+                },
+                "region_prices": [
+                    {
+                        "id": "id-cgk"
+                        "hourly": 0.00018,
+                        "monthly": 0.12
+                    },
+                    {
+                        "id": "br-gru"
+                        "hourly": 0.00021,
+                        "monthly": 0.14
+                    }
+                ],
+                "transfer": 0,
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-volume-types) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/lke_type_list.py
+++ b/plugins/module_utils/doc_fragments/lke_type_list.py
@@ -1,0 +1,35 @@
+"""Documentation fragments for the lke_type_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode LKE Types
+  linode.cloud.lke_type_list: {}''', '''
+- name: List a Linode LKE Type named LKE High Availability
+  linode.cloud.lke_type_list:
+    filters:
+      - name: label
+        values: LKE High Availability
+''']
+
+result_lke_type_samples = ['''[
+    {
+        "id": "lke-ha",
+        "label": "LKE High Availability",
+        "price": {
+            "hourly": 0.09,
+            "monthly": 60.0
+        },
+        "region_prices": [
+            {
+                "id": "id-cgk"
+                "hourly": 0.108,
+                "monthly": 72.0
+            },
+            {
+                "id": "br-gru"
+                "hourly": 0.126,
+                "monthly": 84.0
+            }
+        ],
+        "transfer": 0,
+    }
+]''']

--- a/plugins/module_utils/doc_fragments/network_transfer_prices_list.py
+++ b/plugins/module_utils/doc_fragments/network_transfer_prices_list.py
@@ -1,0 +1,24 @@
+"""Documentation fragments for the network_transfer_prices_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode Network Transfer Prices
+  linode.cloud.network_transfer_prices_list: {}''', '''
+- name: List a Linode Network Transfer Price named Distributed Network Transfer
+  linode.cloud.network_transfer_prices_list:
+    filters:
+      - name: label
+        values: Distributed Network Transfer
+''']
+
+result_network_transfer_prices_samples = ['''[
+    {
+        "id": "distributed_network_transfer",
+        "label": "Distributed Network Transfer",
+        "price": {
+            "hourly": 0.01,
+            "monthly": null
+        },
+        "region_prices": [],
+        "transfer": 0,
+    }
+]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_type_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_type_list.py
@@ -1,0 +1,35 @@
+"""Documentation fragments for the nodebalancer_type_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode Node Balancer Types
+  linode.cloud.nodebalancer_type_list: {}''', '''
+- name: List a Linode Node Balancer Type named NodeBalancer
+  linode.cloud.nodebalancer_type_list:
+    filters:
+      - name: label
+        values: NodeBalancer
+''']
+
+result_nodebalancer_type_samples = ['''[
+    {
+        "id": "nodebalancer",
+        "label": "NodeBalancer",
+        "price": {
+            "hourly": 0.015,
+            "monthly": 10.0
+        },
+        "region_prices": [
+            {
+                "id": "id-cgk"
+                "hourly": 0.018,
+                "monthly": 12.0
+            },
+            {
+                "id": "br-gru"
+                "hourly": 0.021,
+                "monthly": 14.0
+            }
+        ],
+        "transfer": 0,
+    }
+]''']

--- a/plugins/module_utils/doc_fragments/volume_type_list.py
+++ b/plugins/module_utils/doc_fragments/volume_type_list.py
@@ -1,0 +1,35 @@
+"""Documentation fragments for the volume_type_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode Volume Types
+  linode.cloud.volume_type_list: {}''', '''
+- name: List a Linode Volume Type named Storage Volume
+  linode.cloud.volume_type_list:
+    filters:
+      - name: label
+        values: Storage Volume
+''']
+
+result_volume_type_samples = ['''[
+    {
+        "id": "volume",
+        "label": "Storage Volume",
+        "price": {
+            "hourly": 0.00015,
+            "monthly": 0.1
+        },
+        "region_prices": [
+            {
+                "id": "id-cgk"
+                "hourly": 0.00018,
+                "monthly": 0.12
+            },
+            {
+                "id": "br-gru"
+                "hourly": 0.00021,
+                "monthly": 0.14
+            }
+        ],
+        "transfer": 0,
+    }
+]''']

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -63,7 +63,10 @@ class ListModule(
         self.result_field_name = result_field_name
         self.endpoint_template = endpoint_template
 
-        self.result_docs_url = result_docs_url or "https://techdocs.akamai.com/linode-api/reference/api"
+        self.result_docs_url = (
+            result_docs_url
+            or "https://techdocs.akamai.com/linode-api/reference/api"
+        )
         self.params = params or []
         self.examples = examples or []
         self.description = description or [

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -50,7 +50,7 @@ class ListModule(
         result_display_name: str,
         result_field_name: str,
         endpoint_template: str,
-        result_docs_url: str = "",
+        result_docs_url: Optional[str] = None,
         params: List[ListModuleParam] = None,
         examples: List[str] = None,
         description: List[str] = None,
@@ -63,7 +63,7 @@ class ListModule(
         self.result_field_name = result_field_name
         self.endpoint_template = endpoint_template
 
-        self.result_docs_url = result_docs_url
+        self.result_docs_url = result_docs_url or ""
         self.params = params or []
         self.examples = examples or []
         self.description = description or [

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -63,7 +63,7 @@ class ListModule(
         self.result_field_name = result_field_name
         self.endpoint_template = endpoint_template
 
-        self.result_docs_url = result_docs_url or ""
+        self.result_docs_url = result_docs_url or "https://techdocs.akamai.com/linode-api/reference/api"
         self.params = params or []
         self.examples = examples or []
         self.description = description or [

--- a/plugins/modules/lke_type_list.py
+++ b/plugins/modules/lke_type_list.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode LKE Types."""
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_type_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="LKE Types",
+    result_field_name="lke_types",
+    endpoint_template="/lke/types",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_lke_type_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/network_transfer_prices_list.py
+++ b/plugins/modules/network_transfer_prices_list.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Network Transfer Prices."""
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    network_transfer_prices_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Network Transfer Prices",
+    result_field_name="network_transfer_prices",
+    endpoint_template="/network-transfer/prices",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-network-transfer-prices",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_network_transfer_prices_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/nodebalancer_type_list.py
+++ b/plugins/modules/nodebalancer_type_list.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Node Balancer Types."""
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    nodebalancer_type_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Node Balancer Types",
+    result_field_name="nodebalancer_types",
+    endpoint_template="/nodebalancers/types",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_nodebalancer_type_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/volume_type_list.py
+++ b/plugins/modules/volume_type_list.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Volume Types."""
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.volume_type_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Volume Types",
+    result_field_name="volume_types",
+    endpoint_template="/volumes/types",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-volume-types",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_volume_type_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linode-api4>=5.21.0
+linode-api4>=5.22.0
 polling>=0.3.2
 types-requests==2.32.0.20240914
 ansible-specdoc>=0.0.15

--- a/tests/integration/targets/lke_type_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_type_list/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: lke_type_list
+  block:
+    - name: List lke types with no filter
+      linode.cloud.lke_type_list:
+      register: no_filter
+
+    - name: Assert lke types with no filter
+      assert:
+        that:
+          - no_filter.lke_types | length >= 1
+
+    - name: List lke types with filter on label
+      linode.cloud.lke_type_list:
+        filters:
+          - name: label
+            values: LKE Standard Availability
+      register: filter
+
+    - name: Assert lke types with filter on class
+      assert:
+        that:
+          - filter.lke_types | length >= 1
+          - filter.lke_types[0].label == 'LKE Standard Availability'
+          - filter.lke_types[0].region_prices | length == 0
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/network_transfer_prices_list/tasks/main.yaml
+++ b/tests/integration/targets/network_transfer_prices_list/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: network_transfer_prices_list
+  block:
+    - name: List network transfer prices with no filter
+      linode.cloud.network_transfer_prices_list:
+      register: no_filter
+
+    - name: Assert network transfer prices with no filter
+      assert:
+        that:
+          - no_filter.network_transfer_prices | length >= 1
+
+    - name: List network transfer prices with filter on label
+      linode.cloud.network_transfer_prices_list:
+        filters:
+          - name: label
+            values: Network Transfer
+      register: filter
+
+    - name: Assert network transfer prices with filter on label
+      assert:
+        that:
+          - filter.network_transfer_prices | length >= 1
+          - filter.network_transfer_prices[0].label == 'Network Transfer'
+          - filter.network_transfer_prices[0].region_prices | length >= 1
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_type_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_type_list/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: nodebalancer_type_list
+  block:
+    - name: List nodebalancer types with no filter
+      linode.cloud.nodebalancer_type_list:
+      register: no_filter
+
+    - name: Assert nodebalancer types with no filter
+      assert:
+        that:
+          - no_filter.nodebalancer_types | length >= 1
+
+    - name: List nodebalancer types with filter on label
+      linode.cloud.nodebalancer_type_list:
+        filters:
+          - name: label
+            values: NodeBalancer
+      register: filter
+
+    - name: Assert nodebalancer types with filter on class
+      assert:
+        that:
+          - filter.nodebalancer_types | length >= 1
+          - filter.nodebalancer_types[0].label == 'NodeBalancer'
+          - filter.nodebalancer_types[0].region_prices | length >= 1
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/volume_type_list/tasks/main.yaml
+++ b/tests/integration/targets/volume_type_list/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: volume_type_list
+  block:
+    - name: List volume types with no filter
+      linode.cloud.volume_type_list:
+      register: no_filter
+
+    - name: Assert volume types with no filter
+      assert:
+        that:
+          - no_filter.volume_types | length >= 1
+
+    - name: List volume types with filter on label
+      linode.cloud.volume_type_list:
+        filters:
+          - name: label
+            values: Storage Volume
+      register: filter
+
+    - name: Assert volume types with filter on class
+      assert:
+        that:
+          - filter.volume_types | length >= 1
+          - filter.volume_types[0].label == 'Storage Volume'
+          - filter.volume_types[0].region_prices | length >= 1
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+


### PR DESCRIPTION
## 📝 Description

Adds modules to support the following API endpoints:

* https://api.linode.com/v4/lke/types
* https://api.linode.com/v4/nodebalancers/types
* https://api.linode.com/v4/volumes/types
* https://api.linode.com/v4/network-transfer/prices

Also, changed the `result_docs_url` field of the List module to be Nullable to allow it to be excluded when there is no API techdoc for a module.

## ✔️ How to Test

Run the following integration tests:

* `make TEST_ARGS="lke_type_list" test`
* `make TEST_ARGS="network_transfer_prices_list" test`
* `make TEST_ARGS="nodebalancer_type_list" test`
* `make TEST_ARGS="volume_type_list" test`