### PR TITLE
Remove syntax error from doc fragment for injection

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -103,7 +103,7 @@ Manage Linode Instances, Configs, and Disks.
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    placement_group: 
+    placement_group:
       id: 123
       compliant_only: false
     state: present
@@ -350,14 +350,14 @@ Manage Linode Instances, Configs, and Disks.
           "type": "g6-standard-1",
           "updated": "2018-01-01T00:01:01",
           "watchdog_enabled": true,
+          "disk_encryption": "enabled",
+          "lke_cluster_id": null,
           "placement_group": {
             "id": 123,
             "label": "test",
             "placement_group_type": "anti_affinity:local",
             "placement_group_policy": "strict"
           }
-          "disk_encryption": "enabled",
-          "lke_cluster_id": null                      
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) for a list of returned fields

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -83,14 +83,14 @@ Get info about a Linode Instance.
           "type": "g6-standard-1",
           "updated": "2018-01-01T00:01:01",
           "watchdog_enabled": true,
+          "disk_encryption": "enabled",
+          "lke_cluster_id": null,
           "placement_group": {
             "id": 123,
             "label": "test",
             "placement_group_type": "anti_affinity:local",
             "placement_group_policy": "strict"
           }
-          "disk_encryption": "enabled",
-          "lke_cluster_id": null                      
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) for a list of returned fields

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -77,7 +77,7 @@ specdoc_examples = ['''
     label: my-linode
     type: g6-nanode-1
     region: us-east
-    placement_group: 
+    placement_group:
       id: 123
       compliant_only: false
     state: present''', '''
@@ -129,14 +129,14 @@ result_instance_samples = ['''{
   "type": "g6-standard-1",
   "updated": "2018-01-01T00:01:01",
   "watchdog_enabled": true,
+  "disk_encryption": "enabled",
+  "lke_cluster_id": null,
   "placement_group": {
     "id": 123,
     "label": "test",
     "placement_group_type": "anti_affinity:local",
     "placement_group_policy": "strict"
   }
-  "disk_encryption": "enabled",
-  "lke_cluster_id": null                      
 }''']
 
 result_configs_samples = ['''[


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Removes a whitespace from the doc causing injection errors.
