### PR TITLE
Add GHA job to validate injected documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Run Documentation Validation
 on: pull_request
 
 jobs:
-  run-docs-validation:
+  test-templated-docs:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,3 +45,31 @@ jobs:
 
       - name: clean up
         run: rm -rf tmp
+
+  test-injected-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/linode/cloud
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: .ansible/collections/ansible_collections/linode/cloud
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install packages
+        run: sudo apt-get install -y make
+
+      - name: setup python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: install dependencies
+        run: make deps
+
+      - name: inject and validate new docs
+        run: make inject


### PR DESCRIPTION
## 📝 Description

This pull request adds a new GitHub Action job to inject and validate documentation fragments using `ansible-test sanity`. This ensures all documentation can be properly parsed and injected into module files, preventing any unexpected release failures. 

## ✔️ How to Test

N/A