### PR TITLE
Correct integration-tests dependency name in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
   process-upload-report:
     runs-on: ubuntu-latest
-    needs: [run-tests]
+    needs: [integration-tests]
     if: always() && github.repository == 'linode/ansible_linode'
 
     steps:


### PR DESCRIPTION
## 📝 Description

This pull request resolves an typo in integration-tests.yml that prevented the workflow from being triggered on recent commits.

## ✔️ How to Test

N/A
