### PR TITLE
Configure max-positional-arguments in `pyproject.toml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deps:
 	pip install -r requirements.txt -r requirements-dev.txt --upgrade
 
 lint:
-	pylint --disable=too-many-positional-arguments plugins
+	pylint plugins
 
 	mypy plugins/modules
 	mypy plugins/inventory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ disable = [
     "missing-timeout",
     "use-sequence-for-iteration",
     "broad-exception-raised",
-    "fixme"
+    "fixme",
 ]
+max-positional-arguments = 12
 py-version = "3.8"
 extension-pkg-whitelist = "math"


### PR DESCRIPTION
## 📝 Description

This is to centralize the configuration of pylint into `pyproject.toml` and cleanup the argument passing from `Makefile` that configures the similar thing.

## ✔️ How to Test

```bash
make lint
```