### PR TITLE
test: Add job in E2E CI to attach firewall to any remaining instances

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -63,25 +63,10 @@ jobs:
       - name: replace existing keys
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - run: make deps && make TEST_ARGS="-v ${{ inputs.tests }}" test
         if: ${{ steps.disallowed-char-check.outputs.match == '' }}
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
-        env:
-          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
       
       - name: Get the hash value of the latest commit from the PR branch
         uses: octokit/graphql-action@v2.x
@@ -135,3 +120,60 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
+
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration-fork]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration-fork]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,27 +43,12 @@ jobs:
       - name: Replace Existing Keys
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - name: Run Integration Tests
         run: |
           make testall
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           ANSIBLE_CALLBACKS_ENABLED: "junit"
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
-        env:
-          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 
       - name: Upload Test Report as Artifact
         if: always()
@@ -78,7 +63,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: always() && github.repository == 'linode/ansible_linode'
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }}
 
     steps:
       - name: Checkout code
@@ -128,10 +113,67 @@ jobs:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
 
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: always() && github.repository == 'linode/ansible_linode' # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack


### PR DESCRIPTION
## 📝 Description

Adding `add-fw-to-remaining-instances` job to E2E CIs to ensure all remaining instances or nodes have CFW attached

## ✔️ How to Test

Forked run - TBD

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**