### PR TITLE
CI: Notify slack channel on releases

### DIFF
--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   notify:
+    if: github.repository == 'linode/ansible_linode'
     runs-on: ubuntu-latest
-    if: always() && github.repository == 'linode/ansible_linode'
     steps:
       - name: Notify Slack - Main Message
         id: main_message

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'linode/ansible_linode'
     steps:
       - name: Notify Slack - Main Message
         id: main_message

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,0 +1,41 @@
+name: Notify Dev DX Channel on Release
+on:
+  release:
+    workflow_dispatch: null
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack - Main Message
+        id: main_message
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New Release Published: _ansible_linode_ - ${{ github.event.release.tag_name }} is now live!* :tada:"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack - Threaded Release Notes
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "thread_ts": "${{ steps.main_message.outputs.ts }}",
+              "text": "*<${{ github.event.release.html_url }}| ${{ github.event.release.tag_name }} Release notes>*"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,8 +1,8 @@
 name: Notify Dev DX Channel on Release
 on:
   release:
-    workflow_dispatch: null
     types: [published]
+  workflow_dispatch: null
 
 jobs:
   notify:


### PR DESCRIPTION
## 📝 Description

Notify `dev-dx` slack channel upon release publication.

Main message announces release notice followed by threaded message for release notes link. Refer to images below

## ✔️ How to Test

Tested on my forked and private channel
E.g.
![image](https://github.com/user-attachments/assets/9faa732c-d1ed-4801-bd17-166730bfcbdc)
E.g. 
![image](https://github.com/user-attachments/assets/dd63e04d-af85-45aa-af29-1e888e27adb5)

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**