### PR TITLE
test: Update disk sizes in integration tests

### DIFF
--- a/tests/integration/targets/instance_config_vlan/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vlan/tasks/main.yaml
@@ -11,7 +11,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 20
         configs:
           - label: cool-config
             devices:
@@ -43,7 +43,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 20
         configs:
           - label: cool-config
             devices:
@@ -76,7 +76,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 20
         configs:
           - label: cool-config
             devices:

--- a/tests/integration/targets/instance_config_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_vpc/tasks/main.yaml
@@ -31,7 +31,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 20
         configs:
           - label: cool-config
             devices:
@@ -84,7 +84,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 30
         configs:
           - label: cool-config
             devices:
@@ -126,7 +126,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 30
         configs:
           - label: cool-config
             devices:

--- a/tests/integration/targets/vpc_ip_list/tasks/main.yaml
+++ b/tests/integration/targets/vpc_ip_list/tasks/main.yaml
@@ -45,7 +45,7 @@
         disks:
           - label: test-disk
             filesystem: ext4
-            size: 10
+            size: 25
         configs:
           - label: cool-config
             devices:


### PR DESCRIPTION
## 📝 Description

Addressing failures caused by `[400] Disk size must be at least 18 MB` 

## ✔️ How to Test

`make TEST_ARGS="vpc_ip_list" test`
`make TEST_ARGS="instance_config_vlan" test`
`make TEST_ARGS="instance_config_vpc" test`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**