### PR TITLE
test: Allow integration and unit tests to run against EOL or desired python version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,20 @@
 name: Run Integration Tests
 
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: 'Specify Python version to use'
+        required: false
+        default: '3.10'
+      run-eol-python-version:
+        description: 'Run EOL python version?'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
   push:
     branches:
       - main
@@ -29,7 +42,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ inputs.run-eol-python-version == 'true' && '3.9' || inputs.python-version }}
 
       - name: Install dependencies
         run: make deps

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,6 @@ on:
       python-version:
         description: 'Specify Python version to use'
         required: false
-        default: '3.10'
       run-eol-python-version:
         description: 'Run EOL python version?'
         required: false
@@ -19,6 +18,11 @@ on:
     branches:
       - main
       - dev
+
+env:
+  DEFAULT_PYTHON_VERSION: "3.10"
+  EOL_PYTHON_VERSION: "3.8"
+  EXIT_STATUS: 0
 
 jobs:
   integration-tests:
@@ -42,7 +46,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.run-eol-python-version == 'true' && '3.9' || inputs.python-version }}
+          python-version: ${{ inputs.run-eol-python-version == 'true' && env.EOL_PYTHON_VERSION || inputs.python-version || env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install dependencies
         run: make deps

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,9 @@ jobs:
     # TODO:
     # Upgrade back to ubuntu-latest when the permission issue fixed
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [ '3.9','3.10','3.11', '3.12' ]
     defaults:
       run:
         working-directory: .ansible/collections/ansible_collections/linode/cloud
@@ -23,7 +26,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: install dependencies
         run: make deps

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,4 @@ autoflake>=2.0.1
 pytest>=7.3.1
 pytest-forked>=1.6.0
 pytest-xdist>=3.3.1
-types-requests==2.32.0.20240914
+types-requests==2.31.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 linode-api4>=5.22.0
 polling>=0.3.2
-types-requests==2.32.0.20241016
+types-requests==2.31.0.1
 ansible-specdoc>=0.0.15
-urllib3>=1.25.4,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 linode-api4>=5.22.0
 polling>=0.3.2
-types-requests==2.32.0.20241016
 ansible-specdoc>=0.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 linode-api4>=5.22.0
-polling>=0.3.2
-types-requests==2.32.0.20240914
+polling==0.3.2
 ansible-specdoc>=0.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 linode-api4>=5.22.0
-polling==0.3.2
+polling>=0.3.2
+types-requests==2.31.0.1
 ansible-specdoc>=0.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 linode-api4>=5.22.0
 polling>=0.3.2
-types-requests==2.31.0.1
+types-requests==2.32.0.20240914
 ansible-specdoc>=0.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 linode-api4>=5.22.0
 polling>=0.3.2
+types-requests==2.32.0.20241016
 ansible-specdoc>=0.0.15
+urllib3>=1.25.4,<2


### PR DESCRIPTION
## 📝 Description

This PR adds workflow_dispatch inputs to allow e2e tests run against EOL or desired version as an option. 
e.g. 
![image](https://github.com/user-attachments/assets/f10c8404-2a2e-47c2-a083-731575aee175)

## ✔️ How to Test

Forked e2e run with EOL:
- 3.9: https://github.com/ykim-akamai/linode_api4-python/actions/runs/11635801524/job/32405918836

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**