### PR TITLE
Cleanup, upgrade, and re-organize dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,10 @@ line_length = 80
 [tool.black]
 line-length = 80
 target-version = [
-    "py37",
-    "py38",
     "py39",
     "py310",
     "py311",
+    "py312",
 ]
 exclude = "plugins/module_utils/doc_fragments"
 
@@ -57,5 +56,5 @@ disable = [
     "fixme",
 ]
 max-positional-arguments = 12
-py-version = "3.8"
+py-version = "3.9"
 extension-pkg-whitelist = "math"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ autoflake>=2.0.1
 pytest>=7.3.1
 pytest-forked>=1.6.0
 pytest-xdist>=3.3.1
+types-requests==2.32.0.20240914

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 linode-api4>=5.22.0
-polling>=0.3.2
-types-requests==2.32.0.20241016
+polling==0.3.2
 ansible-specdoc>=0.0.15


### PR DESCRIPTION
## 📝 Description
This is to organize all dependencies

integration test: https://github.com/linode/ansible_linode/actions/runs/11690045146

1. Downgrade `types-requests` to `2.32.0.20240914` because newer version requiring urllib3>=2, which is not compatible with Python 3.9.
2. Move `types-requests` to dev requirements becauase it's only needed for linters.
3. Upgrade `py-version` to `3.9` for `pylint`.
4. Remove EOL Python versions and add `3.12` for `black`.
5. Pin version of `polling` to 0.3.2 because it's a third party package. (we should consider its fork, [`polling2`](https://github.com/ddmee/polling2), because `polling` is no longer maintained)