### PR TITLE
Use linode_api4 API error handling logic; remove format_api_error(...) helper

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,7 +66,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: install dependencies
         run: make deps

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install: build
 	ansible-galaxy collection install *.tar.gz --force -p $(COLLECTIONS_PATH)
 
 deps:
-	pip install -r requirements.txt -r requirements-dev.txt --upgrade
+	pip install -r requirements.txt -r requirements-dev.txt --force
 
 lint:
 	pylint plugins

--- a/plugins/module_utils/linode_common.py
+++ b/plugins/module_utils/linode_common.py
@@ -7,7 +7,6 @@ from typing import Any, Type
 
 import polling
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    format_api_error,
     format_generic_error,
 )
 
@@ -159,7 +158,7 @@ class LinodeModuleBase:
                 res = self.exec_module(**self.module.params)
             except ApiError as err:
                 # We don't want to return a stack trace for an API error
-                self.fail(msg=format_api_error(err))
+                self.fail(msg=f"Error from Linode API: {str(err)}")
             except polling.TimeoutException as err:
                 self.fail(
                     msg="failed to wait for condition: timeout period expired"

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 import linode_api4
 import polling
 from linode_api4 import (
-    ApiError,
     LinodeClient,
     LKENodePool,
     LKENodePoolNode,
@@ -327,12 +326,6 @@ def get_all_paginated(
         result = result[:num_results]
 
     return result
-
-
-def format_api_error(err: ApiError) -> str:
-    """Formats an API error into a readable string"""
-
-    return f"Error from Linode API: [{err.status}] {';'.join(err.errors)}"
 
 
 def format_generic_error(err: Exception) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode-api4>=5.22.0
+linode-api4>=5.24.0
 polling==0.3.2
 ansible-specdoc>=0.0.15

--- a/tests/integration/targets/api_error/tasks/main.yaml
+++ b/tests/integration/targets/api_error/tasks/main.yaml
@@ -1,0 +1,24 @@
+- name: api_error
+  block:
+    - name: Attempt to create an instance with validation errors
+      linode.cloud.instance:
+        region: fake-region
+        type: g6-fake-plan
+        state: present
+      register: failing_request
+      failed_when: '"msg" not in failing_request'
+
+    - name: Ensure the error message is formatted as expected
+      assert:
+        that:
+          - failing_request.changed == False
+          - 'failing_request.msg.startswith("Error from Linode API: POST /v4beta/linode/instances: [400]")'
+          - '"type: A valid plan type by that ID was not found" in failing_request.msg'
+          - '"region: region is not valid" in failing_request.msg'
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This pull request updates the top-level API error formatting logic to use the formatting logic provided by the Python SDK, which produces errors with more meaningful information (request method, URL, etc.):

```
POST /v4beta/linode/instances: [400] type: A valid plan type by that ID was not found; region: region is not valid
```

This pull request also bumps the minimum `linode_api4` version from `5.22.0` to `5.24.0`.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make deps`.

### Integration Testing

```
make TEST_ARGS="-v api_error" test
```
