### PR TITLE
test/workflow: Update make test commands and related workflows

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -2,14 +2,14 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      tests:
-        description: 'The tests to run.'
+      test_suite:
+        description: "Specify  test suite to run from the 'tests/integration/targets' directory. Examples: 'domain_basic', 'image_basic', etc. If not provided, all suites are executed"
         required: false
       sha:
-        description: 'The hash value of the commit.'
+        description: 'Specify commit hash to test. This value is mandatory to ensure the tests run against a specific commit'
         required: true
       pull_request_number:
-        description: 'The number of the PR.'
+        description: 'Specify pull request number associated with the commit. Optional, but recommended when providing a commit hash (sha)'
         required: false
 
 name: Integration tests on PR
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-ecosystem/action-regex-match@v2
         id: disallowed-char-check
         with:
-          text: ${{ inputs.tests }}
+          text: ${{ inputs.test_suite }}
           regex: '[^a-z0-9_]'
           flags: gi
 
@@ -56,7 +56,7 @@ jobs:
       - name: replace existing keys
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
 
-      - run: make deps && make TEST_ARGS="-v ${{ inputs.tests }}" test
+      - run: make deps && make TEST_SUITE="${{ inputs.test_suite }}" test-int
         if: ${{ steps.disallowed-char-check.outputs.match == '' }}
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
-        run: pip3 install requests wheel boto3
+        run: pip3 install requests wheel boto3==1.35.99
 
       # Create directory if it doesn't exist
       - name: Create output directory

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       python-version:
-        description: 'Specify Python version to use'
+        description: 'Specify the Python version to use for running tests. Leave empty to use the default Python version configured in the environment'
         required: false
       run-eol-python-version:
-        description: 'Run EOL python version?'
+        description: 'Indicates whether to run tests using an End-of-Life (EOL) Python version. Defaults to "false". Choose "true" to include tests for deprecated Python versions'
         required: false
         default: 'false'
         type: choice
@@ -21,7 +21,7 @@ on:
 
 env:
   DEFAULT_PYTHON_VERSION: "3.10"
-  EOL_PYTHON_VERSION: "3.8"
+  EOL_PYTHON_VERSION: "3.9"
   EXIT_STATUS: 0
 
 jobs:

--- a/.github/workflows/nightly-smoke-tests.yml
+++ b/.github/workflows/nightly-smoke-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run smoke tests
         id: smoke_tests
         run: |
-          make smoketest
+          make test-smoke
         env:
           LINODE_API_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          make unittest
+          make test-unit

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TEST_API_VERSION ?= v4beta
 TEST_API_CA ?=
 
 TEST_ARGS := -v
+TEST_SUITE :=
 INTEGRATION_CONFIG := ./tests/integration/integration_config.yml
 
 clean:
@@ -63,7 +64,7 @@ gendocs:
 integration-test: create-integration-config create-e2e-firewall
 	@echo "Running Integration Test(s)..."
 	{ \
-		ansible-test integration $(TEST_ARGS); \
+		ansible-test integration $(TEST_ARGS) $(TEST_SUITE); \
 		TEST_EXIT_CODE=$$?; \
 		make delete-e2e-firewall; \
 		exit $$TEST_EXIT_CODE; \
@@ -95,17 +96,17 @@ delete-e2e-firewall: update-test-submodules
 	fi
 
 update-test-submodules:
-	@git submodule update --init
+	@git submodule update --init --recursive
 
-test: integration-test
+test-int: integration-test
 
 testall:
 	./scripts/test_all.sh
 
-smoketest:
+test-smoke:
 	./scripts/test_basic_smoke.sh
 
-unittest:
+test-unit:
 	ansible-test units --target-python default
 
 


### PR DESCRIPTION
## 📝 Description

In efforts to unify test commands across all repository, the commands are refactored in Makefile. Refer to "How to Test" Section

Also related GHA workflow yamls have been updated with the latest commands

## ✔️ How to Test

- Integration test: `make test-int`
- Unit test: `make test-unit`
- Smoke test: `make test-smoke`

Test arguments and its usage for Integration test:

```
 TEST_SUITE: Optional, specify a test suite (e.g. domain_basic), Default to run everything if not set
 TEST_ARGS: Optional, additional arguments for ansible test, Default to add `-v` if nothing is provided
 ```
 
Running test suite:
`make TEST_SUITE="domain_basic" test-int`
`make TEST_SUITE="object_keys_basic" test-int`

Running individual test:
N/A


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**