### PR TITLE
Bump minimum required version for ansible-specdoc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 linode-api4>=5.24.0
 polling==0.3.2
-ansible-specdoc>=0.0.15
+ansible-specdoc>=0.0.18


### PR DESCRIPTION
## 📝 Description

This PR bumps the minimum required version for ansible-specdoc in order to fix the Run Documentation Validation check.

>_**NOTE: Changes from this PR will not apply to workflows on this PR until it has been merged.**_