### PR TITLE
test: Add empty `addresses` when disabling ACL  

### DIFF
--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -106,6 +106,9 @@
             count: 1
         acl:
           enabled: false
+          # TODO:: Remove empty addresses after 500 error is handled properly
+          addresses:
+            {}
         skip_polling: true
         state: present
       register: acl_disabled_cluster


### PR DESCRIPTION
## 📝 Description

Adding empty addresses in `Disable ACLs on the cluster` test case to avoid 500 error

## ✔️ How to Test

`make test-int TEST_SUITE="lke_cluster_acl" `

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**