### PR TITLE
linode.cloud.domain_record: Account for API removal of '.' suffix from target

### DIFF
--- a/plugins/modules/domain_record.py
+++ b/plugins/modules/domain_record.py
@@ -191,14 +191,15 @@ class LinodeDomainRecord(LinodeModuleBase):
         self, domain: Domain, name: str, rtype: str, target: str
     ) -> Optional[DomainRecord]:
         # We should strip the FQDN from the user-defined record name if defined.
-        suffix = "." + domain.domain
-        search_name = name
-        if search_name.endswith(suffix):
-            search_name = search_name[: -len(suffix)]
+        name = name.removesuffix("." + domain.domain)
+
+        # The Linode API will implicitly strip the `.` suffix from returned targets
+        target = target.removesuffix(".")
+
         try:
             for record in domain.records:
                 if (
-                    record.name == search_name
+                    record.name == name
                     and record.type == rtype
                     and record.target == target
                 ):

--- a/tests/integration/targets/domain_record/tasks/main.yaml
+++ b/tests/integration/targets/domain_record/tasks/main.yaml
@@ -233,6 +233,38 @@
           - record_fqdn_delete.record.name == 'fqdn'
           - record_fqdn_delete.changed
 
+    - name: Create a CNAME record with a '.'-suffixed target
+      linode.cloud.domain_record:
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'cname.{{ domain_create.domain.domain }}'
+        type: CNAME
+        target: 'foo.{{ domain_create.domain.domain }}.'
+        state: present
+      register: record_cname
+
+    - name: Assert the CNAME record was successfully created
+      assert:
+        that:
+          - record_cname.changed
+          - record_cname.record.name == 'cname'
+          - record_cname.record.type == 'CNAME'
+          - record_cname.record.target == 'foo.' + domain_create.domain.domain
+
+    - name: Delete the CNAME record
+      linode.cloud.domain_record:
+        domain: '{{ domain_create.domain.domain }}'
+        name: 'cname.{{ domain_create.domain.domain }}'
+        type: CNAME
+        target: 'foo.{{ domain_create.domain.domain }}.'
+        state: absent
+      register: record_cname_delete
+
+    - name: Assert the CNAME record was deleted
+      assert:
+        that:
+          - record_cname_delete.record.name == 'cname'
+          - record_cname_delete.changed
+
   always:
     - ignore_errors: yes
       block:


### PR DESCRIPTION
## 📝 Description

This pull request updates the `linode.cloud.domain_record` module to account for the API stripping of the `.` suffix from record targets during reads. This resolves and issue where records with `.`-suffixed targets could not be deleted using the `absent` state.

Resolves #636 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make TEST_ARGS="-v domain_record" test-int
```

### Manual Testing

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - set_fact:
        r: "{{ 1000000000 | random }}"

    - name: Create a domain
      linode.cloud.domain:
        domain: "test-domain-{{ r }}.com"
        type: master
        soa_email: foo@example.com
        state: present
      register: domain

    - name: Create a CNAME record with a .-suffixed target
      linode.cloud.domain_record:
        domain: "{{ domain.domain.domain }}"
        name: test
        type: CNAME
        target: mail.example.com.
        ttl_sec: 1800
        state: present

    - name: Remove the CNAME record
      linode.cloud.domain_record:
        domain: "{{ domain.domain.domain }}"
        name: test
        type: CNAME
        target: mail.example.com.
        ttl_sec: 1800
        state: absent
```

2. Ensure the playbook runs successfully and all three tasks are marked as changed.
3. In Cloud Manager, ensure the CNAME record does not exist.