### PR TITLE
Add test summary to slack notifications

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) }} $ # && github.repository == 'linode/ansible_linode' }}
+    if: ${{ (success() || failure()) }} # && github.repository == 'linode/ansible_linode' }}
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -216,7 +216,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* ${{ needs.integration-tests.result == 'success' && ':white_check_mark:' || ':failed:' }}""
+                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* ${{ needs.integration-tests.result == 'success' && ':white_check_mark:' || ':failed:' }}"
               - type: divider
               - type: section
                 fields:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) }} # && github.repository == 'linode/ansible_linode' }}
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }}
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 
@@ -201,7 +201,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration-tests, process-upload-report]
-    if: ${{ (success() || failure()) }} # && github.repository == 'linode/ansible_linode' }} # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,9 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }}
+    if: ${{ (success() || failure()) }} $ # && github.repository == 'linode/ansible_linode' }}
+    outputs:
+      summary: ${{ steps.set-test-summary.outputs.summary }}
 
     steps:
       - name: Checkout code
@@ -126,6 +128,18 @@ jobs:
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+      - name: Generate test summary and save to output
+        id: set-test-summary
+        run: |
+          filename=$(ls | grep -E '^[0-9]{12}_ansible_merged\.xml$')
+          test_output=$(python3 e2e_scripts/tod_scripts/generate_test_summary.py "${filename}")
+          echo "$test_output"
+          {
+            echo 'summary<<EOF'
+            echo "$test_output"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
   apply-calico-rules:
     runs-on: ubuntu-latest
@@ -186,11 +200,12 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }} # Run even if integration tests fail and only on main repository
+    needs: [integration-tests, process-upload-report]
+    if: ${{ (success() || failure()) }} # && github.repository == 'linode/ansible_linode' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack
+        id: main_message
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -201,7 +216,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
+                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* ${{ needs.integration-tests.result == 'success' && ':white_check_mark:' || ':failed:' }}""
               - type: divider
               - type: section
                 fields:
@@ -220,3 +235,14 @@ jobs:
                 elements:
                   - type: mrkdwn
                     text: "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
+
+      - name: Test summary thread
+        if: success()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.main_message.outputs.ts }}"
+            text: "${{ needs.process-upload-report.outputs.summary }}"


### PR DESCRIPTION
## 📝 Description

Improving slack test notifications

Overall Test Summary available
Now it is able to thread failures and errors in slack message
e.g.
![image](https://github.com/user-attachments/assets/45107d08-e1b2-4fa4-a58f-bd655e09c3bc)

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**