### PR TITLE
Fix handling of None type and empty inputs for ACL ipv4 and ipv6 variables

### DIFF
--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -417,8 +417,8 @@ class LinodeLKECluster(LinodeModuleBase):
             ipv4 = configured_addresses.get("ipv4")
             ipv6 = configured_addresses.get("ipv6")
 
-            configured_acl["addresses"]["ipv4"] = None if ipv4 == [] else ipv4
-            configured_acl["addresses"]["ipv6"] = None if ipv6 == [] else ipv6
+            configured_acl["addresses"]["ipv4"] = [] if not ipv4 else ipv4
+            configured_acl["addresses"]["ipv6"] = [] if not ipv6 else ipv6
 
         user_defined_keys = set(linode_lke_cluster_acl.keys())
         current_acl = control_plane_acl if control_plane_acl is not None else {}

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -53,10 +53,15 @@
           addresses:
             ipv4:
               - 10.0.0.5/32
-            ipv6: []
+            ipv6:
+              - 2001:db8:1234:abcd::/64
         skip_polling: true
         state: present
       register: update_cluster
+
+    - name: Debug update_cluster values
+      debug:
+        var: update_cluster
 
     - name: Assert LKE cluster is updated
       assert:
@@ -66,7 +71,8 @@
           - update_cluster.cluster.region == "us-mia"
           - update_cluster.cluster.control_plane.acl.enabled
           - update_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
-          - update_cluster.cluster.control_plane.acl.addresses.ipv6 == None
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
 
 
     - name: Don't change the cluster
@@ -82,10 +88,15 @@
           addresses:
             ipv4:
               - 10.0.0.5/32
-            ipv6: []
+            ipv6:
+              - 2001:db8:1234:abcd::/64
         skip_polling: true
         state: present
       register: unchanged_cluster
+
+    - name: Debug unchanged_cluster values
+      debug:
+        var: unchanged_cluster
 
     - name: Assert LKE cluster is unchanged
       assert:
@@ -93,7 +104,8 @@
           - not unchanged_cluster.changed
           - unchanged_cluster.cluster.control_plane.acl.enabled
           - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
-          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 == None
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
 
 
     - name: Disable ACLs on the cluster

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -65,6 +65,7 @@
           - update_cluster.cluster.k8s_version == kube_version
           - update_cluster.cluster.region == "us-mia"
           - update_cluster.cluster.control_plane.acl.enabled
+          - update_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
           - update_cluster.cluster.control_plane.acl.addresses.ipv6 == []
 
     - name: Don't change the cluster
@@ -90,6 +91,7 @@
         that:
           - not unchanged_cluster.changed
           - unchanged_cluster.cluster.control_plane.acl.enabled
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
           - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 == []
 
     - name: Disable ACLs on the cluster

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -95,8 +95,8 @@
           - not unchanged_cluster.changed
           - unchanged_cluster.cluster.control_plane.acl.enabled
           - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
-          - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
-          - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
 
     - name: Disable ACLs on the cluster
       linode.cloud.lke_cluster:

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -53,8 +53,7 @@
           addresses:
             ipv4:
               - 10.0.0.5/32
-            ipv6:
-              - 2001:db8:1234:abcd::/64
+            ipv6: []
         skip_polling: true
         state: present
       register: update_cluster
@@ -66,9 +65,7 @@
           - update_cluster.cluster.k8s_version == kube_version
           - update_cluster.cluster.region == "us-mia"
           - update_cluster.cluster.control_plane.acl.enabled
-          - update_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
-          - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
-          - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
+          - update_cluster.cluster.control_plane.acl.addresses.ipv6 == []
 
     - name: Don't change the cluster
       linode.cloud.lke_cluster:
@@ -83,8 +80,7 @@
           addresses:
             ipv4:
               - 10.0.0.5/32
-            ipv6:
-              - 2001:db8:1234:abcd::/64
+            ipv6: []
         skip_polling: true
         state: present
       register: unchanged_cluster
@@ -94,9 +90,7 @@
         that:
           - not unchanged_cluster.changed
           - unchanged_cluster.cluster.control_plane.acl.enabled
-          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
-          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
-          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
+          - unchanged_cluster.cluster.control_plane.acl.addresses.ipv6 == []
 
     - name: Disable ACLs on the cluster
       linode.cloud.lke_cluster:
@@ -120,6 +114,8 @@
         that:
           - acl_disabled_cluster.changed
           - not acl_disabled_cluster.cluster.control_plane.acl.enabled
+          - acl_disabled_cluster.cluster.control_plane.acl.addresses.ipv4 == []
+          - acl_disabled_cluster.cluster.control_plane.acl.addresses.ipv6 == []
   always:
     - ignore_errors: yes
       block:

--- a/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_acl/tasks/main.yaml
@@ -59,10 +59,6 @@
         state: present
       register: update_cluster
 
-    - name: Debug update_cluster values
-      debug:
-        var: update_cluster
-
     - name: Assert LKE cluster is updated
       assert:
         that:
@@ -73,7 +69,6 @@
           - update_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
           - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
           - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
-
 
     - name: Don't change the cluster
       linode.cloud.lke_cluster:
@@ -94,10 +89,6 @@
         state: present
       register: unchanged_cluster
 
-    - name: Debug unchanged_cluster values
-      debug:
-        var: unchanged_cluster
-
     - name: Assert LKE cluster is unchanged
       assert:
         that:
@@ -106,7 +97,6 @@
           - unchanged_cluster.cluster.control_plane.acl.addresses.ipv4[0] == "10.0.0.5/32"
           - update_cluster.cluster.control_plane.acl.addresses.ipv6[0] == "2001:db8:1234:abcd::/64"
           - update_cluster.cluster.control_plane.acl.addresses.ipv6 | length == 1
-
 
     - name: Disable ACLs on the cluster
       linode.cloud.lke_cluster:


### PR DESCRIPTION
## 📝 Description

Fix None and empty input handling for `ipv4` and `ipv6` variables from `configured_acl`

## ✔️ How to Test

`make TEST_SUITE=lke_cluster_acl test-int`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**