### PR TITLE
Add support for LKE-E features

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Name | Description |
 [linode.cloud.ip_info](./docs/modules/ip_info.md)|Get info about a Linode IP.|
 [linode.cloud.ipv6_range_info](./docs/modules/ipv6_range_info.md)|Get info about a Linode IPv6 range.|
 [linode.cloud.lke_cluster_info](./docs/modules/lke_cluster_info.md)|Get info about a Linode LKE cluster.|
+[linode.cloud.lke_version_info](./docs/modules/lke_version_info.md)|Get info about a Linode LKE Version.|
 [linode.cloud.nodebalancer_info](./docs/modules/nodebalancer_info.md)|Get info about a Linode Node Balancer.|
 [linode.cloud.object_cluster_info](./docs/modules/object_cluster_info.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.placement_group_info](./docs/modules/placement_group_info.md)|Get info about a Linode Placement Group.|

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -67,7 +67,7 @@ Manage Linode LKE clusters.
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |
 | `apl_enabled` | <center>`bool`</center> | <center>Optional</center> | Whether this cluster should use APL. NOTE: This endpoint is in beta.  **(Default: `False`)** |
-| `tier` | <center>`str`</center> | <center>Optional</center> | The desired tier of the LKE Cluster. NOTE: LKE Enterprise may not currently be available to all users  and can only be used with v4beta.  **(Choices: `standard`, `enterprise`; Default: `standard`)** |
+| `tier` | <center>`str`</center> | <center>Optional</center> | The desired tier of the LKE Cluster. NOTE: LKE Enterprise may not currently be available to all users  and can only be used with v4beta.  **(Choices: `standard`, `enterprise`)** |
 
 ### acl
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -67,6 +67,7 @@ Manage Linode LKE clusters.
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |
 | `apl_enabled` | <center>`bool`</center> | <center>Optional</center> | Whether this cluster should use APL. NOTE: This endpoint is in beta.  **(Default: `False`)** |
+| `tier` | <center>`str`</center> | <center>Optional</center> | The desired tier of the LKE Cluster.  **(Choices: `standard`, `enterprise`; Default: `standard`)** |
 
 ### acl
 

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -61,7 +61,7 @@ Manage Linode LKE clusters.
 | `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes cluster in the format of <major>.<minor>, and the latest supported patch version will be deployed. A version upgrade requires that you manually recycle the nodes in your cluster.  **(Updatable)** |
 | `region` | <center>`str`</center> | <center>Optional</center> | This Kubernetes cluster’s location.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | An array of tags applied to the Kubernetes cluster.   |
-| `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Default: `False`; Updatable)** |
+| `high_availability` | <center>`bool`</center> | <center>Optional</center> | Defines whether High Availability is enabled for the Control Plane Components of the cluster.   **(Updatable)** |
 | [`acl` (sub-options)](#acl) | <center>`dict`</center> | <center>Optional</center> | The ACL configuration for this cluster's control plane.  **(Updatable)** |
 | [`node_pools` (sub-options)](#node_pools) | <center>`list`</center> | <center>Optional</center> | A list of node pools to configure the cluster with  **(Updatable)** |
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |

--- a/docs/modules/lke_cluster.md
+++ b/docs/modules/lke_cluster.md
@@ -67,7 +67,7 @@ Manage Linode LKE clusters.
 | `skip_polling` | <center>`bool`</center> | <center>Optional</center> | If true, the module will not wait for all nodes in the cluster to be ready.  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the cluster to be ready in seconds.  **(Default: `600`)** |
 | `apl_enabled` | <center>`bool`</center> | <center>Optional</center> | Whether this cluster should use APL. NOTE: This endpoint is in beta.  **(Default: `False`)** |
-| `tier` | <center>`str`</center> | <center>Optional</center> | The desired tier of the LKE Cluster.  **(Choices: `standard`, `enterprise`; Default: `standard`)** |
+| `tier` | <center>`str`</center> | <center>Optional</center> | The desired tier of the LKE Cluster. NOTE: LKE Enterprise may not currently be available to all users  and can only be used with v4beta.  **(Choices: `standard`, `enterprise`; Default: `standard`)** |
 
 ### acl
 

--- a/docs/modules/lke_node_pool.md
+++ b/docs/modules/lke_node_pool.md
@@ -63,6 +63,8 @@ Manage Linode LKE cluster node pools.
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The period to wait for the node pool to be ready in seconds.  **(Default: `600`)** |
 | `labels` | <center>`dict`</center> | <center>Optional</center> | Key-value pairs added as labels to nodes in the node pool. Labels help classify your nodes and to easily select subsets of objects.  **(Updatable)** |
 | [`taints` (sub-options)](#taints) | <center>`list`</center> | <center>Optional</center> | Kubernetes taints to add to node pool nodes. Taints help control how pods are scheduled onto nodes, specifically allowing them to repel certain pods.  **(Updatable)** |
+| `k8s_version` | <center>`str`</center> | <center>Optional</center> | The desired Kubernetes version for this Kubernetes  Node Pool in the format of <major>.<minor>, and the  latest supported patch version. NOTE: Only available for LKE Enterprise to support node pool upgrades.  This field may not currently be available to all users and is under v4beta.  **(Updatable)** |
+| `update_strategy` | <center>`str`</center> | <center>Optional</center> | Upgrade strategy describes the available upgrade strategies. NOTE: Only available for LKE Enterprise to support node pool upgrades.  This field may not currently be available to all users and is under v4beta.  **(Choices: `rolling_update`, `on_recycle`; Updatable)** |
 
 ### autoscaler
 

--- a/docs/modules/lke_version_info.md
+++ b/docs/modules/lke_version_info.md
@@ -1,0 +1,60 @@
+# lke_version_info
+
+Get info about a Linode LKE Version.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get info about an LKE version by ID
+  linode.cloud.lke_cluster_info:
+    id: '1.31' 
+```
+
+```yaml
+- name: Get info about an LKE version by tier and ID
+  linode.cloud.lke_cluster_info:
+    tier: 'standard'
+    id: '1.31'
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `id` | <center>`str`</center> | <center>**Required**</center> | The ID of the LKE Version to resolve.   |
+| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details.  **(Choices: `standard`, `enterprise`)** |
+
+## Return Values
+
+- `lke_version` - The returned LKE Version.
+
+    - Sample Response:
+        ```json
+        
+        # Result getting a Kubernetes version without specifying tier
+        {
+          "id": "1.31"
+        }
+        
+        # Result getting a Kubernetes version with specifying tier
+        {
+          "id": "1.31",
+          "tier": "standard"
+        }
+        
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-version) for a list of returned fields
+
+

--- a/docs/modules/lke_version_info.md
+++ b/docs/modules/lke_version_info.md
@@ -15,17 +15,18 @@ Get info about a Linode LKE Version.
 ## Examples
 
 ```yaml
-- name: Get info about an LKE version by ID
-  linode.cloud.lke_cluster_info:
-    id: '1.31' 
+    - name: Get info about an LKE version by ID
+      linode.cloud.lke_cluster_info:
+        id: '1.31'
+    
 ```
 
 ```yaml
-- name: Get info about an LKE version by tier and ID
-  linode.cloud.lke_cluster_info:
-    tier: 'standard'
-    id: '1.31'
-
+    - name: Get info about an LKE version by tier and ID
+      linode.cloud.lke_cluster_info:
+        tier: 'standard'
+        id: '1.31'
+    
 ```
 
 
@@ -43,17 +44,18 @@ Get info about a Linode LKE Version.
     - Sample Response:
         ```json
         
-        # Result getting a Kubernetes version without specifying tier
-        {
-          "id": "1.31"
-        }
+            {
+              "id": "1.31"
+            }
+            
+        ```
+        ```json
         
-        # Result getting a Kubernetes version with specifying tier
-        {
-          "id": "1.31",
-          "tier": "standard"
-        }
-        
+            {
+              "id": "1.31",
+              "tier": "standard"
+            }
+            
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-version) for a list of returned fields
 

--- a/docs/modules/lke_version_info.md
+++ b/docs/modules/lke_version_info.md
@@ -35,7 +35,7 @@ Get info about a Linode LKE Version.
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `id` | <center>`str`</center> | <center>**Required**</center> | The ID of the LKE Version to resolve.   |
-| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details.  **(Choices: `standard`, `enterprise`)** |
+| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details. NOTE: LKE Enterprise may not currently be available to all users and  can only be used with v4beta.  **(Choices: `standard`, `enterprise`)** |
 
 ## Return Values
 

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -15,12 +15,16 @@ List and filter on LKE Versions.
 ## Examples
 
 ```yaml
-- name: List all Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_version_list: {}
-  
-- name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_version_list: {tier: "enterprise"}
+    - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
+      linode.cloud.lke_version_list:
+    
+```
 
+```yaml
+    - name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
+      linode.cloud.lke_version_list:
+        tier: "enterprise"
+    
 ```
 
 
@@ -48,26 +52,28 @@ List and filter on LKE Versions.
     - Sample Response:
         ```json
         
-        # Result for listing all Kubernetes versions
-        [
-            {
-                "id": "1.32"
-            },
-            {
-                "id": "1.31"
-            },
-            {
-                "id": "1.30"
-            }
-        ]
-        # Result for listing all enterprise-tier Kubernetes versions
-        [
-            {
-                "id": "v1.31.1+lke1",
-                "tier": "enterprise"
-            }
-        ]
+            [
+                {
+                    "id": "1.32"
+                },
+                {
+                    "id": "1.31"
+                },
+                {
+                    "id": "1.30"
+                }
+            ]
+            
+        ```
+        ```json
         
+            [
+                {
+                    "id": "v1.31.1+lke1",
+                    "tier": "enterprise"
+                }
+            ]
+            
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-versions) for a list of returned fields
 

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -36,7 +36,7 @@ List and filter on LKE Versions.
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order LKE Versions by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting LKE Versions.   |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of LKE Versions to return. If undefined, all results will be returned.   |
-| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details.  **(Choices: `standard`, `enterprise`)** |
+| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details. NOTE: LKE Enterprise may not currently be available to all users  and can only be used with v4beta.  **(Choices: `standard`, `enterprise`)** |
 
 ### filters
 

--- a/docs/modules/lke_version_list.md
+++ b/docs/modules/lke_version_list.md
@@ -17,6 +17,10 @@ List and filter on LKE Versions.
 ```yaml
 - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
   linode.cloud.lke_version_list: {}
+  
+- name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
+  linode.cloud.lke_version_list: {tier: "enterprise"}
+
 ```
 
 
@@ -28,6 +32,7 @@ List and filter on LKE Versions.
 | `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order LKE Versions by.   |
 | [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting LKE Versions.   |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of LKE Versions to return. If undefined, all results will be returned.   |
+| `tier` | <center>`str`</center> | <center>Optional</center> | Specifies the service tier for retrieving LKE version details.  **(Choices: `standard`, `enterprise`)** |
 
 ### filters
 
@@ -42,11 +47,27 @@ List and filter on LKE Versions.
 
     - Sample Response:
         ```json
+        
+        # Result for listing all Kubernetes versions
         [
             {
-              "id": "1.25"
+                "id": "1.32"
+            },
+            {
+                "id": "1.31"
+            },
+            {
+                "id": "1.30"
             }
         ]
+        # Result for listing all enterprise-tier Kubernetes versions
+        [
+            {
+                "id": "v1.31.1+lke1",
+                "tier": "enterprise"
+            }
+        ]
+        
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-lke-versions) for a list of returned fields
 

--- a/plugins/module_utils/doc_fragments/lke_version_info.py
+++ b/plugins/module_utils/doc_fragments/lke_version_info.py
@@ -1,0 +1,24 @@
+"""Documentation fragments for the lke_version_info module"""
+
+specdoc_examples = ['''
+- name: Get info about an LKE version by ID
+  linode.cloud.lke_cluster_info:
+    id: '1.31' ''', '''
+- name: Get info about an LKE version by tier and ID
+  linode.cloud.lke_cluster_info:
+    tier: 'standard'
+    id: '1.31'
+''']
+
+result_lke_version_samples = ['''
+# Result getting a Kubernetes version without specifying tier
+{
+  "id": "1.31"
+}
+
+# Result getting a Kubernetes version with specifying tier
+{
+  "id": "1.31",
+  "tier": "standard"
+}
+''']

--- a/plugins/module_utils/doc_fragments/lke_version_info.py
+++ b/plugins/module_utils/doc_fragments/lke_version_info.py
@@ -1,24 +1,28 @@
 """Documentation fragments for the lke_version_info module"""
 
-specdoc_examples = ['''
-- name: Get info about an LKE version by ID
-  linode.cloud.lke_cluster_info:
-    id: '1.31' ''', '''
-- name: Get info about an LKE version by tier and ID
-  linode.cloud.lke_cluster_info:
-    tier: 'standard'
-    id: '1.31'
-''']
+specdoc_examples = [
+    '''
+    - name: Get info about an LKE version by ID
+      linode.cloud.lke_cluster_info:
+        id: '1.31'
+    ''', '''
+    - name: Get info about an LKE version by tier and ID
+      linode.cloud.lke_cluster_info:
+        tier: 'standard'
+        id: '1.31'
+    '''
+]
 
-result_lke_version_samples = ['''
-# Result getting a Kubernetes version without specifying tier
-{
-  "id": "1.31"
-}
-
-# Result getting a Kubernetes version with specifying tier
-{
-  "id": "1.31",
-  "tier": "standard"
-}
-''']
+result_lke_version_samples = [
+    '''
+    {
+      "id": "1.31"
+    }
+    ''',
+    '''
+    {
+      "id": "1.31",
+      "tier": "standard"
+    }
+    '''
+]

--- a/plugins/module_utils/doc_fragments/lke_version_list.py
+++ b/plugins/module_utils/doc_fragments/lke_version_list.py
@@ -1,31 +1,36 @@
-"""Documentation fragments for the lke_version_list module with tier left unspecified"""
+"""Documentation fragments for the lke_version_list module"""
 
-specdoc_examples = ['''
-- name: List all Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_version_list: {}
-  
-- name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_version_list: {tier: "enterprise"}
-''']
+specdoc_examples = [
+    '''
+    - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
+      linode.cloud.lke_version_list:
+    ''', '''
+    - name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
+      linode.cloud.lke_version_list:
+        tier: "enterprise"
+    '''
+]
 
-result_lke_versions_samples = ['''
-# Result for listing all Kubernetes versions
-[
-    {
-        "id": "1.32"
-    },
-    {
-        "id": "1.31"
-    },
-    {
-        "id": "1.30"
-    }
+result_lke_versions_samples = [
+    '''
+    [
+        {
+            "id": "1.32"
+        },
+        {
+            "id": "1.31"
+        },
+        {
+            "id": "1.30"
+        }
+    ]
+    ''',
+    '''
+    [
+        {
+            "id": "v1.31.1+lke1",
+            "tier": "enterprise"
+        }
+    ]
+    '''
 ]
-# Result for listing all enterprise-tier Kubernetes versions
-[
-    {
-        "id": "v1.31.1+lke1",
-        "tier": "enterprise"
-    }
-]
-''']

--- a/plugins/module_utils/doc_fragments/lke_version_list.py
+++ b/plugins/module_utils/doc_fragments/lke_version_list.py
@@ -1,11 +1,31 @@
-"""Documentation fragments for the lke_version_list module"""
+"""Documentation fragments for the lke_version_list module with tier left unspecified"""
 
 specdoc_examples = ['''
 - name: List all Kubernetes versions available for deployment to a Kubernetes cluster
-  linode.cloud.lke_version_list: {}''']
+  linode.cloud.lke_version_list: {}
+  
+- name: List all enterprise-tier Kubernetes versions available for deployment to a Kubernetes cluster
+  linode.cloud.lke_version_list: {tier: "enterprise"}
+''']
 
-result_lke_versions_samples = ['''[
+result_lke_versions_samples = ['''
+# Result for listing all Kubernetes versions
+[
     {
-      "id": "1.25"
+        "id": "1.32"
+    },
+    {
+        "id": "1.31"
+    },
+    {
+        "id": "1.30"
     }
-]''']
+]
+# Result for listing all enterprise-tier Kubernetes versions
+[
+    {
+        "id": "v1.31.1+lke1",
+        "tier": "enterprise"
+    }
+]
+''']

--- a/plugins/module_utils/linode_common_info.py
+++ b/plugins/module_utils/linode_common_info.py
@@ -126,6 +126,7 @@ class InfoModule(LinodeModuleBase):
         requires_beta: bool = False,
         deprecated: bool = False,
         deprecation_message: Optional[str] = None,
+        custom_options: Optional[Dict[str, SpecField]] = None,
     ) -> None:
         self.primary_result = primary_result
         self.secondary_results = secondary_results or []
@@ -144,6 +145,9 @@ class InfoModule(LinodeModuleBase):
         # to the module's description.
         if self.deprecated:
             self.description.insert(0, f"**NOTE: {self.deprecation_message}**")
+
+        # Store custom options if provided
+        self.custom_options = custom_options or {}
 
         # Singular params should be translated into groups
         self.param_groups = [
@@ -219,6 +223,8 @@ class InfoModule(LinodeModuleBase):
         """
 
         options = {}
+
+        options.update(self.custom_options)
 
         # Add params to spec
         for group in self.param_groups:

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -258,6 +258,7 @@ linode_lke_cluster_spec = {
             "and can only be used with v4beta.",
         ],
         editable=False,
+        required=False,
         choices=["standard", "enterprise"],
         default="standard",
     ),
@@ -311,6 +312,7 @@ CREATE_FIELDS: Set[str] = {
     "control_plane",
     "high_availability",
     "apl_enabled",
+    "tier"
 }
 
 DOCUMENTATION = r"""

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -259,7 +259,6 @@ linode_lke_cluster_spec = {
         editable=False,
         required=False,
         choices=["standard", "enterprise"],
-        default="standard",
     ),
 }
 
@@ -382,7 +381,8 @@ class LinodeLKECluster(LinodeModuleBase):
 
         label = params.pop("label")
 
-        # Determine high_availability based on tier
+        # We must determine the default value of high_availability here because
+        # the default value is False if the tier is standard, and True if the tier is enterprise
         tier = params.get("tier")
         high_availability = tier not in (
             "standard",
@@ -505,17 +505,8 @@ class LinodeLKECluster(LinodeModuleBase):
 
         pools = new_params.pop("node_pools")
 
-        # These are handled separately
+        # This is handled separately
         new_params.pop("k8s_version")
-
-        # Determine high_availability from tier
-        tier = self.module.params.get("tier")
-        high_avail = tier != "standard"
-
-        if high_avail is not None:
-            new_params["high_availability"] = (
-                high_avail  # Only include if explicitly set
-            )
 
         handle_updates(
             cluster, new_params, MUTABLE_FIELDS, self.register_action

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -251,6 +251,13 @@ linode_lke_cluster_spec = {
         ],
         default=False,
     ),
+    "tier": SpecField(
+        type=FieldType.string,
+        description=["The desired tier of the LKE Cluster."],
+        editable=False,
+        choices=["standard", "enterprise"],
+        default="standard",
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -71,7 +71,6 @@ linode_lke_cluster_acl = {
     ),
 }
 
-
 linode_lke_cluster_autoscaler = {
     "enabled": SpecField(
         type=FieldType.bool,
@@ -253,7 +252,11 @@ linode_lke_cluster_spec = {
     ),
     "tier": SpecField(
         type=FieldType.string,
-        description=["The desired tier of the LKE Cluster."],
+        description=[
+            "The desired tier of the LKE Cluster.",
+            "NOTE: LKE Enterprise may not currently be available to all users ",
+            "and can only be used with v4beta.",
+        ],
         editable=False,
         choices=["standard", "enterprise"],
         default="standard",

--- a/plugins/modules/lke_cluster.py
+++ b/plugins/modules/lke_cluster.py
@@ -312,7 +312,7 @@ CREATE_FIELDS: Set[str] = {
     "control_plane",
     "high_availability",
     "apl_enabled",
-    "tier"
+    "tier",
 }
 
 DOCUMENTATION = r"""

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -178,6 +178,27 @@ MODULE_SPEC = {
         ],
         suboptions=linode_lke_pool_taint,
     ),
+    "k8s_version": SpecField(
+        type=FieldType.string,
+        editable=True,
+        description=[
+            "The desired Kubernetes version for this Kubernetes ",
+            "Node Pool in the format of <major>.<minor>, and the ",
+            "latest supported patch version.",
+            "NOTE: Only available for LKE Enterprise to support node pool upgrades. ",
+            "This field may not currently be available to all users and is under v4beta.",
+        ],
+    ),
+    "update_strategy": SpecField(
+        type=FieldType.string,
+        editable=True,
+        description=[
+            "Upgrade strategy describes the available upgrade strategies.",
+            "NOTE: Only available for LKE Enterprise to support node pool upgrades. ",
+            "This field may not currently be available to all users and is under v4beta.",
+        ],
+        choices=["rolling_update", "on_recycle"],
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(
@@ -291,6 +312,14 @@ class LinodeLKENodePool(LinodeModuleBase):
         new_count = params.pop("count")
         new_taints = params.pop("taints") if "taints" in params else None
         new_labels = params.pop("labels") if "labels" in params else None
+        new_k8s_version = (
+            params.pop("k8s_version") if "k8s_version" in params else None
+        )
+        new_update_strategy = (
+            params.pop("update_strategy")
+            if "update_strategy" in params
+            else None
+        )
 
         try:
             handle_updates(pool, params, set(), self.register_action)
@@ -324,6 +353,19 @@ class LinodeLKENodePool(LinodeModuleBase):
         if new_labels is not None and pool.labels != new_labels:
             self.register_action("Updated labels for Node Pool")
             pool.labels = new_labels
+            should_update = True
+
+        if new_k8s_version is not None and pool.k8s_version != new_k8s_version:
+            self.register_action("Updated k8s version for Node Pool")
+            pool.k8s_version = new_k8s_version
+            should_update = True
+
+        if (
+            new_update_strategy is not None
+            and pool.update_strategy != new_update_strategy
+        ):
+            self.register_action("Updated update strategy for Node Pool")
+            pool.update_strategy = new_update_strategy
             should_update = True
 
         if should_update:

--- a/plugins/modules/lke_node_pool.py
+++ b/plugins/modules/lke_node_pool.py
@@ -265,6 +265,13 @@ class LinodeLKENodePool(LinodeModuleBase):
         self, pool: LKENodePool, timeout: int
     ) -> None:
         def _check_pool_nodes_ready() -> bool:
+            # Enterprise node pools take longer than usual to provision nodes, so the API
+            # initially returns an empty list of nodes. This is never possible, so we can
+            # wait for the nodes list to no longer be empty before proceeding to checking on
+            # the nodes' statuses.
+            if len(pool.nodes) == 0:
+                return False
+
             for node in pool.nodes:
                 if node.status != "ready":
                     return False

--- a/plugins/modules/lke_version_info.py
+++ b/plugins/modules/lke_version_info.py
@@ -61,6 +61,8 @@ module = InfoModule(
             choices=["standard", "enterprise"],
             description=[
                 "Specifies the service tier for retrieving LKE version details.",
+                "NOTE: LKE Enterprise may not currently be available to all users and ",
+                "can only be used with v4beta.",
             ],
             required=False,
         ),

--- a/plugins/modules/lke_version_info.py
+++ b/plugins/modules/lke_version_info.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode LKE Version."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Dict
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.lke_version_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType, SpecField
+from linode_api4 import KubeVersion, LinodeClient, TieredKubeVersion
+
+
+def _get_lke_version(
+    client: LinodeClient, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Retrieves the LKE version from the appropriate endpoint based on the tier parameter.
+
+    If 'tier' is specified, it uses the TieredKubeVersion class.
+    Otherwise, it uses the default KubeVersion class.
+    """
+    version_id = params.get("id")
+    tier = params.get("tier")
+
+    if tier:
+        # If `tier` is specified, fetch the LKE version for
+        # that specific tier and id (e.g., standard or enterprise)
+        return client.load(TieredKubeVersion, version_id, tier)._raw_json
+
+    # Otherwise, fetch the LKE version for the specified id
+    return client.load(KubeVersion, version_id)._raw_json
+
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="LKE Version",
+        field_name="lke_version",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-version",
+        samples=docs.result_lke_version_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            name="id",
+            display_name="ID",
+            type=FieldType.string,
+            get=_get_lke_version,
+        ),
+    ],
+    custom_options={
+        "tier": SpecField(
+            type=FieldType.string,
+            choices=["standard", "enterprise"],
+            description=[
+                "Specifies the service tier for retrieving LKE version details.",
+            ],
+            required=False,
+        ),
+    },
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -5,12 +5,33 @@
 
 from __future__ import absolute_import, division, print_function
 
+from typing import Dict
+
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
     lke_version_list as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModule,
 )
+from ansible_specdoc.objects import FieldType, SpecField
+
+
+def custom_field_resolver(params: Dict[str, str]) -> Dict[str, str]:
+    """
+    Resolves the appropriate documentation and examples based on the 'tier' parameter.
+
+    :param params: The parameters passed to the module.
+
+    :returns: The appropriate documentation and examples.
+    """
+    if params.get("tier"):
+        return {
+            "endpoint_template": f"/lke/tiers/{params.get('tier')}/versions",
+        }
+    return {
+        "endpoint_template": "/lke/versions",
+    }
+
 
 module = ListModule(
     result_display_name="LKE Versions",
@@ -19,6 +40,17 @@ module = ListModule(
     result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-lke-versions",
     result_samples=docs.result_lke_versions_samples,
     examples=docs.specdoc_examples,
+    custom_options={
+        "tier": SpecField(
+            type=FieldType.string,
+            choices=["standard", "enterprise"],
+            description=[
+                "Specifies the service tier for retrieving LKE version details.",
+            ],
+            required=False,
+        ),
+    },
+    custom_field_resolver=custom_field_resolver,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/lke_version_list.py
+++ b/plugins/modules/lke_version_list.py
@@ -46,6 +46,8 @@ module = ListModule(
             choices=["standard", "enterprise"],
             description=[
                 "Specifies the service tier for retrieving LKE version details.",
+                "NOTE: LKE Enterprise may not currently be available to all users ",
+                "and can only be used with v4beta.",
             ],
             required=False,
         ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/linode/python-linode-api.git@c26963aa0bd3ef348c33a72db660c9b9ad3fd13a#egg=linode-api4
 polling==0.3.2
-git+https://github.com/linode/ansible-specdoc.git@e40b6748f2f5e81b48552fdb64bc9fe85f02ab62#egg=ansible-specdoc
+ansible-specdoc>=0.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode-api4>=5.24.0
+git+https://github.com/linode/python-linode-api.git@c26963aa0bd3ef348c33a72db660c9b9ad3fd13a#egg=linode-api4
 polling==0.3.2
 ansible-specdoc>=0.0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/linode/python-linode-api.git@c26963aa0bd3ef348c33a72db660c9b9ad3fd13a#egg=linode-api4
+linode-api4>=5.29.0
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/linode/python-linode-api.git@c26963aa0bd3ef348c33a72db660c9b9ad3fd13a#egg=linode-api4
 polling==0.3.2
-ansible-specdoc>=0.0.18
+git+https://github.com/linode/ansible-specdoc.git@e40b6748f2f5e81b48552fdb64bc9fe85f02ab62#egg=ansible-specdoc

--- a/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
@@ -15,12 +15,12 @@
     - set_fact:
         kube_version: '{{ lke_versions[0].id }}'
 
-    - name: List regions that support Disk Encryption
+    - name: List regions that support LKE Enterprise
       linode.cloud.region_list:
       register: all_regions
 
     - set_fact:
-        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[1].id }}'
+        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[1].id }}'
 
     - name: Create a Linode LKE Enterprise cluster
       linode.cloud.lke_cluster:

--- a/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
@@ -20,7 +20,7 @@
       register: all_regions
 
     - set_fact:
-        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[0].id }}'
+        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[1].id }}'
 
     - name: Create a Linode LKE Enterprise cluster
       linode.cloud.lke_cluster:
@@ -29,6 +29,7 @@
         label: 'ansible-test-{{ r }}'
         region: '{{ lke_e_region }}'
         k8s_version: '{{ kube_version }}'
+        high_availability: true
         node_pools:
           - type: g6-standard-1
             count: 3
@@ -52,7 +53,6 @@
           linode.cloud.lke_cluster:
             label: '{{ create_enterprise_cluster.cluster.label }}'
             state: absent
-
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
@@ -1,0 +1,62 @@
+- name: lke_cluster_enterprise
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Resolve an enterprise K8s version
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: "enterprise"
+      register: get_lke_versions_enterprise
+
+    - set_fact:
+        lke_versions: '{{ get_lke_versions_enterprise.lke_versions|sort(attribute="id") }}'
+
+    - set_fact:
+        kube_version: '{{ lke_versions[0].id }}'
+
+    - name: List regions that support Disk Encryption
+      linode.cloud.region_list:
+      register: all_regions
+
+    - set_fact:
+        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[0].id }}'
+
+    - name: Create a Linode LKE Enterprise cluster
+      linode.cloud.lke_cluster:
+        api_version: v4beta
+        tier: 'enterprise'
+        label: 'ansible-test-{{ r }}'
+        region: '{{ lke_e_region }}'
+        k8s_version: '{{ kube_version }}'
+        node_pools:
+          - type: g6-standard-1
+            count: 3
+          - type: g6-standard-4
+            count: 1
+        skip_polling: true
+        state: present
+      register: create_enterprise_cluster
+
+    - name: Assert LKE cluster is created
+      assert:
+        that:
+          - create_enterprise_cluster.cluster.k8s_version == kube_version
+          - create_enterprise_cluster.cluster.region == lke_e_region
+          - create_enterprise_cluster.cluster.tier == 'enterprise'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the LKE cluster
+          linode.cloud.lke_cluster:
+            label: '{{ create_enterprise_cluster.cluster.label }}'
+            state: absent
+
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_enterprise/tasks/main.yaml
@@ -29,7 +29,6 @@
         label: 'ansible-test-{{ r }}'
         region: '{{ lke_e_region }}'
         k8s_version: '{{ kube_version }}'
-        high_availability: true
         node_pools:
           - type: g6-standard-1
             count: 3

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -54,10 +54,6 @@
         state: present
       register: new_pool
 
-    - name: Output the nodes in the new pool
-      debug:
-        var: new_pool.node_pool.nodes
-
     - name: Assert node pool is added to cluster
       assert:
         that:

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -54,6 +54,10 @@
         state: present
       register: new_pool
 
+    - name: Output the nodes in the new pool
+      debug:
+        var: new_pool.node_pool.nodes
+
     - name: Assert node pool is added to cluster
       assert:
         that:

--- a/tests/integration/targets/lke_node_pool_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_enterprise/tasks/main.yaml
@@ -1,0 +1,106 @@
+- name: lke_cluster_enterprise
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Resolve the latest enterprise K8s version
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: 'enterprise'
+      register: lke_versions_enterprise
+
+    - set_fact:
+        kube_version: '{{ lke_versions_enterprise.lke_versions[0].id }}'
+
+    - name: List regions that support LKE Enterprise
+      linode.cloud.region_list:
+      register: all_regions
+
+    - set_fact:
+        lke_e_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Kubernetes Enterprise") | list)[1].id }}'
+
+    - name: Create a Linode LKE Enterprise cluster
+      linode.cloud.lke_cluster:
+        api_version: v4beta
+        tier: 'enterprise'
+        label: 'ansible-test-{{ r }}'
+        region: '{{ lke_e_region }}'
+        k8s_version: '{{ kube_version }}'
+        node_pools:
+          - type: g6-standard-1
+            count: 1
+        skip_polling: true
+        state: present
+      register: create_enterprise_cluster
+
+    - name: Assert LKE  Enterprise cluster is created
+      assert:
+        that:
+          - create_enterprise_cluster.cluster.k8s_version == kube_version
+          - create_enterprise_cluster.cluster.region == lke_e_region
+          - create_enterprise_cluster.node_pools[0].type == 'g6-standard-1'
+          - create_enterprise_cluster.node_pools[0].count == 1
+          - create_enterprise_cluster.cluster.tier == 'enterprise'
+
+    - name: Add an enterprise node pool to the cluster
+      linode.cloud.lke_node_pool:
+        cluster_id: '{{ create_enterprise_cluster.cluster.id }}'
+        tags: [ 'my-pool' ]
+        type: g6-standard-1
+        count: 2
+        k8s_version: '{{ kube_version }}'
+        update_strategy: 'rolling_update'
+        skip_polling: false
+        state: present
+      register: new_pool
+
+    - name: Assert node pool is added to cluster
+      assert:
+        that:
+          - new_pool.node_pool.count == 2
+          - new_pool.node_pool.type == 'g6-standard-1'
+          - new_pool.node_pool.nodes[0].status == 'ready'
+          - new_pool.node_pool.nodes[1].status == 'ready'
+          - new_pool.node_pool.k8s_version == kube_version
+          - new_pool.node_pool.update_strategy == 'rolling_update'
+
+    - name: Update the enterprise node pool
+      linode.cloud.lke_node_pool:
+        cluster_id: '{{ create_enterprise_cluster.cluster.id }}'
+        tags: [ 'my-pool' ]
+        type: g6-standard-1
+        count: 2
+        k8s_version: '{{ kube_version }}'
+        update_strategy: 'on_recycle'
+        state: present
+      register: updated_pool
+
+    - name: Assert node pool is updated
+      assert:
+        that:
+          - new_pool.node_pool.count == 2
+          - new_pool.node_pool.type == 'g6-standard-1'
+          - new_pool.node_pool.nodes[0].status == 'ready'
+          - new_pool.node_pool.nodes[1].status == 'ready'
+          - new_pool.node_pool.k8s_version == kube_version
+          - new_pool.node_pool.update_strategy == 'on_recycle'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the LKE cluster node pool
+          linode.cloud.lke_node_pool:
+            cluster_id: '{{ create_enterprise_cluster.cluster.id }}'
+            tags: [ 'my-pool' ]
+            state: absent
+        - name: Delete the LKE cluster
+          linode.cloud.lke_cluster:
+            label: '{{ create_enterprise_cluster.cluster.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/lke_node_pool_enterprise/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_enterprise/tasks/main.yaml
@@ -78,12 +78,12 @@
     - name: Assert node pool is updated
       assert:
         that:
-          - new_pool.node_pool.count == 2
-          - new_pool.node_pool.type == 'g6-standard-1'
-          - new_pool.node_pool.nodes[0].status == 'ready'
-          - new_pool.node_pool.nodes[1].status == 'ready'
-          - new_pool.node_pool.k8s_version == kube_version
-          - new_pool.node_pool.update_strategy == 'on_recycle'
+          - updated_pool.node_pool.count == 2
+          - updated_pool.node_pool.type == 'g6-standard-1'
+          - updated_pool.node_pool.nodes[0].status == 'ready'
+          - updated_pool.node_pool.nodes[1].status == 'ready'
+          - updated_pool.node_pool.k8s_version == kube_version
+          - updated_pool.node_pool.update_strategy == 'on_recycle'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/lke_version_info/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_info/tasks/main.yaml
@@ -1,39 +1,55 @@
 - name: lke_version_info
   block:
+    - name: List lke_version_list with out specifying tier
+      linode.cloud.lke_version_list:
+      register: lke_version_list_no_tier
+
     - name: Get an LKE Version without specifying tier
       linode.cloud.lke_version_info:
-        id: '1.31'
+        id: '{{ lke_version_list_no_tier.lke_versions[0].id }}'
       register: lke_version_no_tier
 
     - name: Assert lke_version_no_tier
       assert:
         that:
-          - lke_version_no_tier.lke_version.id == '1.31'
+          - lke_version_no_tier.lke_version.id == lke_version_list_no_tier.lke_versions[0].id
+
+    - name: List lke_version_list with standard tier
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: "standard"
+      register: lke_version_list_standard_tier
 
     - name: Get a standard LKE Version
       linode.cloud.lke_version_info:
         api_version: v4beta
-        id: '1.31'
+        id: '{{ lke_version_list_standard_tier.lke_versions[0].id }}'
         tier: 'standard'
       register: lke_version_standard
 
     - name: Assert lke_version_standard
       assert:
         that:
-          - lke_version_standard.lke_version.id == '1.31'
+          - lke_version_standard.lke_version.id == lke_version_list_standard_tier.lke_versions[0].id
           - lke_version_standard.lke_version.tier == 'standard'
+
+    - name: List lke_version_list with enterprise tier
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: "enterprise"
+      register: lke_version_list_enterprise_tier
 
     - name: Get an enterprise LKE Version
       linode.cloud.lke_version_info:
         api_version: v4beta
-        id: 'v1.31.1+lke4'
+        id: '{{ lke_version_list_enterprise_tier.lke_versions[0].id }}'
         tier: 'enterprise'
       register: lke_version_enterprise
 
     - name: Assert lke_version_enterprise
       assert:
         that:
-          - lke_version_enterprise.lke_version.id == 'v1.31.1+lke4'
+          - lke_version_enterprise.lke_version.id == lke_version_list_enterprise_tier.lke_versions[0].id
           - lke_version_enterprise.lke_version.tier == 'enterprise'
 
   environment:

--- a/tests/integration/targets/lke_version_info/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_info/tasks/main.yaml
@@ -1,0 +1,44 @@
+- name: lke_version_info
+  block:
+    - name: Get an LKE Version without specifying tier
+      linode.cloud.lke_version_info:
+        id: '1.31'
+      register: lke_version_no_tier
+
+    - name: Assert lke_version_no_tier
+      assert:
+        that:
+          - lke_version_no_tier.lke_version.id == '1.31'
+
+    - name: Get a standard LKE Version
+      linode.cloud.lke_version_info:
+        api_version: v4beta
+        id: '1.31'
+        tier: 'standard'
+      register: lke_version_standard
+
+    - name: Assert lke_version_standard
+      assert:
+        that:
+          - lke_version_standard.lke_version.id == '1.31'
+          - lke_version_standard.lke_version.tier == 'standard'
+
+    - name: Get an enterprise LKE Version
+      linode.cloud.lke_version_info:
+        api_version: v4beta
+        id: 'v1.31.1+lke1'
+        tier: 'enterprise'
+      register: lke_version_enterprise
+
+    - name: Assert lke_version_enterprise
+      assert:
+        that:
+          - lke_version_enterprise.lke_version.id == 'v1.31.1+lke1'
+          - lke_version_enterprise.lke_version.tier == 'enterprise'
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/lke_version_info/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_info/tasks/main.yaml
@@ -26,14 +26,14 @@
     - name: Get an enterprise LKE Version
       linode.cloud.lke_version_info:
         api_version: v4beta
-        id: 'v1.31.1+lke1'
+        id: 'v1.31.1+lke4'
         tier: 'enterprise'
       register: lke_version_enterprise
 
     - name: Assert lke_version_enterprise
       assert:
         that:
-          - lke_version_enterprise.lke_version.id == 'v1.31.1+lke1'
+          - lke_version_enterprise.lke_version.id == 'v1.31.1+lke4'
           - lke_version_enterprise.lke_version.tier == 'enterprise'
 
   environment:

--- a/tests/integration/targets/lke_version_list/tasks/main.yaml
+++ b/tests/integration/targets/lke_version_list/tasks/main.yaml
@@ -9,10 +9,31 @@
         that:
           - no_filter.lke_versions | length >= 1
 
+    - name: List lke_version_list with standard tier
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: "standard"
+      register: tier_standard
+
+    - name: Assert lke_version_list with standard tier
+      assert:
+        that:
+          - tier_standard.lke_versions | length >= 1
+
+    - name: List lke_version_list with enterprise tier
+      linode.cloud.lke_version_list:
+        api_version: v4beta
+        tier: "enterprise"
+      register: tier_enterprise
+
+    - name: Assert lke_version_list with enterprise tier
+      assert:
+        that:
+          - tier_enterprise.lke_versions | length >= 1
+
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'
     LINODE_API_TOKEN: '{{ api_token }}'
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
-


### PR DESCRIPTION
## 📝 Description

Added support for listing LKE versions with `tier` specified. Added support for getting LKE version info with and without tier specified. Added support for specifying tier upon LKE cluster creation.

Also changed the `high_availability` field to no longer default to false since `enterprise` clusters have `high_availability` set to true by default.

## ✔️ How to Test
The following steps assume you have this PR pulled down locally.

### Integration Testing
`make test-int TEST_SUITE="lke_version_info"`
`make test-int TEST_SUITE="lke_version_list"`
`make test-int TEST_SUITE="lke_cluster_enterprise"` **_NOTE:_** This test will a while to run.
`make test-int TEST_SUITE="lke_node_pool_enterprise"` **_NOTE:_** This test will a while to run.

### Manual Testing
1. In a local testing environment (i.e. dx-devenv sandbox), run the following ansible playbook:
```
    # LKE Version Get tests
    - name: Get an LKE Version without specifying tier
      linode.cloud.lke_version_info:
        id: '1.31'
      register: lke_version_no_tier
      
    - name: Get a standard LKE Version
      linode.cloud.lke_version_info:
        api_version: v4beta
        id: '1.31'
        tier: 'standard'
      register: lke_version_tier_standard
      
    - name: Get an enterprise LKE Version
      linode.cloud.lke_version_info:
        api_version: v4beta
        id: 'v1.31.1+lke4'
        tier: 'enterprise'
      register: lke_version_tier_enterprise


    # LKE Versions List tests
    - name: List all LKE Versions
      linode.cloud.lke_version_list:
      register: all_lke_versions

    - name: List all LKE standard Versions
      linode.cloud.lke_version_list:
        api_version: v4beta
        tier: "standard"
      register: lke_standard_versions

    - name: List all LKE enterprise Versions
      linode.cloud.lke_version_list:
        api_version: v4beta
        tier: "enterprise"
      register: lke_enterprise_versions


    # Create an LKE Enterprise cluster
    - name: Create a Linode LKE Enterprise cluster
      linode.cloud.lke_cluster:
        api_version: v4beta
        tier: 'enterprise'
        label: 'ansible-test-enterprise'
        region: 'us-ord'
        k8s_version: 'v1.31.1+lke4'
        node_pools:
          - type: g6-standard-1
            count: 3
          - type: g6-standard-4
            count: 1
        skip_polling: true
        state: present
      register: create_enterprise_cluster


    # Create an LKE Enterprise node pool
    - name: Add an enterprise node pool to the cluster
    linode.cloud.lke_node_pool:
      cluster_id: '{{ create_enterprise_cluster.cluster.id }}'
      tags: [ 'my-pool' ]
      type: g6-standard-1
      count: 2
      k8s_version: '{{ lke_version_tier_enterprise }}'
      update_strategy: 'rolling_update'
      skip_polling: false
      state: present
    register: new_pool    
```
2. Verify the output for the `info` and `list` modules looks correct.
3. Verify that the LKE Enterprise cluster was successfully created in Cloud Manager.
4. Verify that the LKE Enterprise node pool was successfully created in Cloud Manager.
5. Clean up any resources created for this test.