### PR TITLE
Add DBaaS Suspend and Resume

### DIFF
--- a/docs/modules/database_mysql_v2.md
+++ b/docs/modules/database_mysql_v2.md
@@ -78,7 +78,7 @@ Create, read, and update a Linode MySQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the Managed Database.  **(Choices: `present`, `absent`)** |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the Managed Database.  **(Choices: `resume`, `suspend`, `present`, `absent`)** |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses and CIDR ranges that can access the Managed Database.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode instance nodes deployed to the Managed Database.  **(Updatable)** |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.  **(Updatable)** |

--- a/docs/modules/database_postgresql_v2.md
+++ b/docs/modules/database_postgresql_v2.md
@@ -78,7 +78,7 @@ Create, read, and update a Linode PostgreSQL database.
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the Managed Database.  **(Choices: `present`, `absent`)** |
+| `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the Managed Database.  **(Choices: `resume`, `suspend`, `present`, `absent`)** |
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses and CIDR ranges that can access the Managed Database.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode instance nodes deployed to the Managed Database.  **(Updatable)** |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.  **(Updatable)** |

--- a/plugins/modules/database_mysql_v2.py
+++ b/plugins/modules/database_mysql_v2.py
@@ -311,7 +311,7 @@ class Module(LinodeModuleBase):
 
         self._populate_results(result)
 
-    def _handle_absent(self) -> None:
+    def _handle_else(self, state: str) -> None:
         params = self.module.params
 
         database = safe_find(
@@ -322,52 +322,33 @@ class Module(LinodeModuleBase):
         if database is not None:
             self._populate_results(database)
 
-            database.delete()
+            if state == "suspend":
+                self._handle_suspend(database)
+            elif state == "resume":
+                self._handle_resume(database)
+            else:
+                self._handle_absent(database)
 
-            self.register_action(f"Deleted MySQL database {database.id}")
+    def _handle_absent(self, database: MySQLDatabase) -> None:
+        database.delete()
+        self.register_action(f"Deleted MySQL database {database.id}")
 
-    def _handle_suspend(self) -> None:
-        params = self.module.params
+    def _handle_suspend(self, database: MySQLDatabase) -> None:
+        database.suspend()
+        self.register_action(f"Suspended MySQL database {database.id}")
 
-        database = safe_find(
-            self.client.database.mysql_instances,
-            MySQLDatabase.label == params.get("label"),
-        )
-
-        if database is not None:
-            self._populate_results(database)
-
-            database.suspend()
-
-            self.register_action(f"Suspended MySQL database {database.id}")
-
-    def _handle_resume(self) -> None:
-        params = self.module.params
-
-        database = safe_find(
-            self.client.database.mysql_instances,
-            MySQLDatabase.label == params.get("label"),
-        )
-
-        if database is not None:
-            self._populate_results(database)
-
-            database.resume()
-
-            self.register_action(f"Resumed MySQL database {database.id}")
+    def _handle_resume(self, database: MySQLDatabase) -> None:
+        database.resume()
+        self.register_action(f"Resumed MySQL database {database.id}")
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for token module"""
         state = kwargs.get("state")
 
-        if state == "absent":
-            self._handle_absent()
-        if state == "suspend":
-            self._handle_suspend()
-        if state == "resume":
-            self._handle_resume()
-        else:
+        if state == "present":
             self._handle_present()
+        else:
+            self._handle_else(state)
 
         return self.results
 

--- a/plugins/modules/database_postgresql_v2.py
+++ b/plugins/modules/database_postgresql_v2.py
@@ -42,7 +42,7 @@ from linode_api4 import PostgreSQLDatabase
 SPEC = {
     "state": SpecField(
         type=FieldType.string,
-        choices=["present", "absent"],
+        choices=["resume", "suspend", "present", "absent"],
         required=True,
         description=["The desired state of the Managed Database."],
     ),
@@ -309,7 +309,7 @@ class Module(LinodeModuleBase):
 
         self._populate_results(result)
 
-    def _handle_absent(self) -> None:
+    def _handle_else(self, state: str) -> None:
         params = self.module.params
 
         database = safe_find(
@@ -320,52 +320,33 @@ class Module(LinodeModuleBase):
         if database is not None:
             self._populate_results(database)
 
-            database.delete()
+            if state == "suspend":
+                self._handle_suspend(database)
+            elif state == "resume":
+                self._handle_resume(database)
+            else:
+                self._handle_absent(database)
 
-            self.register_action(f"Deleted PostgreSQL database {database.id}")
+    def _handle_absent(self, database: PostgreSQLDatabase) -> None:
+        database.delete()
+        self.register_action(f"Deleted PostgreSQL database {database.id}")
 
-    def _handle_suspend(self) -> None:
-        params = self.module.params
+    def _handle_suspend(self, database: PostgreSQLDatabase) -> None:
+        database.suspend()
+        self.register_action(f"Suspended PostgreSQL database {database.id}")
 
-        database = safe_find(
-            self.client.database.mysql_instances,
-            PostgreSQLDatabase.label == params.get("label"),
-        )
-
-        if database is not None:
-            self._populate_results(database)
-
-            database.suspend()
-
-            self.register_action(f"Suspended PostgreSQL database {database.id}")
-
-    def _handle_resume(self) -> None:
-        params = self.module.params
-
-        database = safe_find(
-            self.client.database.mysql_instances,
-            PostgreSQLDatabase.label == params.get("label"),
-        )
-
-        if database is not None:
-            self._populate_results(database)
-
-            database.resume()
-
-            self.register_action(f"Resumed PostgreSQL database {database.id}")
+    def _handle_resume(self, database: PostgreSQLDatabase) -> None:
+        database.resume()
+        self.register_action(f"Resumed PostgreSQL database {database.id}")
 
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for token module"""
         state = kwargs.get("state")
 
-        if state == "absent":
-            self._handle_absent()
-        if state == "suspend":
-            self._handle_suspend()
-        if state == "resume":
-            self._handle_resume()
-        else:
+        if state == "present":
             self._handle_present()
+        else:
+            self._handle_else(state)
 
         return self.results
 

--- a/plugins/modules/database_postgresql_v2.py
+++ b/plugins/modules/database_postgresql_v2.py
@@ -324,12 +324,46 @@ class Module(LinodeModuleBase):
 
             self.register_action(f"Deleted PostgreSQL database {database.id}")
 
+    def _handle_suspend(self) -> None:
+        params = self.module.params
+
+        database = safe_find(
+            self.client.database.mysql_instances,
+            PostgreSQLDatabase.label == params.get("label"),
+        )
+
+        if database is not None:
+            self._populate_results(database)
+
+            database.suspend()
+
+            self.register_action(f"Suspended PostgreSQL database {database.id}")
+
+    def _handle_resume(self) -> None:
+        params = self.module.params
+
+        database = safe_find(
+            self.client.database.mysql_instances,
+            PostgreSQLDatabase.label == params.get("label"),
+        )
+
+        if database is not None:
+            self._populate_results(database)
+
+            database.resume()
+
+            self.register_action(f"Resumed PostgreSQL database {database.id}")
+
     def exec_module(self, **kwargs: Any) -> Optional[dict]:
         """Entrypoint for token module"""
         state = kwargs.get("state")
 
         if state == "absent":
             self._handle_absent()
+        if state == "suspend":
+            self._handle_suspend()
+        if state == "resume":
+            self._handle_resume()
         else:
             self._handle_present()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-linode-api4>=5.24.0
+# linode-api4>=5.24.0
+/Users/jriddle/dev/repos/linode_api4-python/
 polling==0.3.2
 ansible-specdoc>=0.0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# linode-api4>=5.24.0
-/Users/jriddle/dev/repos/linode_api4-python/
+linode-api4>=5.24.0
 polling==0.3.2
 ansible-specdoc>=0.0.18

--- a/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
@@ -100,7 +100,7 @@
         state: suspend
       register: db_suspend
 
-    - name: Assert database is unchanged
+    - name: Assert database is suspended
       assert:
         that:
           - db_suspend.changed == True
@@ -111,7 +111,7 @@
         state: resume
       register: db_resume
 
-    - name: Assert database is unchanged
+    - name: Assert database is resumed
       assert:
         that:
           - db_resume.changed == True

--- a/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
@@ -94,6 +94,28 @@
         that:
           - db_refresh.changed == False
 
+    - name: Suspend the database
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        state: suspend
+      register: db_suspend
+
+    - name: Assert database is unchanged
+      assert:
+        that:
+          - db_suspend.changed == True
+
+    - name: Resume the database
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        state: resume
+      register: db_resume
+
+    - name: Assert database is unchanged
+      assert:
+        that:
+          - db_resume.changed == True
+
   always:
     - ignore_errors: true
       block:

--- a/tests/integration/targets/database_postgresql_v2_basic/tasks/main.yaml
+++ b/tests/integration/targets/database_postgresql_v2_basic/tasks/main.yaml
@@ -95,7 +95,7 @@
           - db_refresh.changed == False
 
     - name: Suspend the database
-      linode.cloud.database_mysql_v2:
+      linode.cloud.database_postgresql_v2:
         label: "ansible-test-{{ r }}"
         state: suspend
       register: db_suspend
@@ -106,7 +106,7 @@
           - db_suspend.changed == True
 
     - name: Resume the database
-      linode.cloud.database_mysql_v2:
+      linode.cloud.database_postgresql_v2:
         label: "ansible-test-{{ r }}"
         state: resume
       register: db_resume

--- a/tests/integration/targets/database_postgresql_v2_basic/tasks/main.yaml
+++ b/tests/integration/targets/database_postgresql_v2_basic/tasks/main.yaml
@@ -94,6 +94,28 @@
         that:
           - db_refresh.changed == False
 
+    - name: Suspend the database
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        state: suspend
+      register: db_suspend
+
+    - name: Assert database is suspended
+      assert:
+        that:
+          - db_suspend.changed == True
+
+    - name: Resume the database
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        state: resume
+      register: db_resume
+
+    - name: Assert database is resumed
+      assert:
+        that:
+          - db_resume.changed == True
+
   always:
     - ignore_errors: true
       block:


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Allows suspending and resuming a database via the status field in ansible

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

```bash
make test-int TEST_SUITE="database_postgresql_v2_basic"
```
```bash
make test-int TEST_SUITE="database_mysql_v2_basic"
```
