### PR TITLE
Update ubuntu image to latest in unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,10 +7,7 @@ name: Run Unit test
 
 jobs:
   run-tests:
-
-    # TODO:
-    # Upgrade back to ubuntu-latest when the permission issue fixed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.9','3.10','3.11', '3.12' ]


### PR DESCRIPTION
## 📝 Description

```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```
Updating ubuntu image to latest

## ✔️ How to Test

https://github.com/ykim-akamai/ansible_linode/actions/runs/14200501715

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**