### PR TITLE
Update test region capability for LDE

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,10 +7,7 @@ name: Run Unit test
 
 jobs:
   run-tests:
-
-    # TODO:
-    # Upgrade back to ubuntu-latest when the permission issue fixed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.9','3.10','3.11', '3.12' ]

--- a/tests/integration/targets/instance_disk_encryption/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_encryption/tasks/main.yaml
@@ -8,7 +8,7 @@
       register: all_regions
 
     - set_fact:
-        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | list)[0].id }}'
+        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "LA Disk Encryption") | list)[0].id }}'
 
     - name: Create a Linode instance with disk encryption set
       linode.cloud.instance:

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -194,7 +194,7 @@
     - name: Assert LKE cluster is created
       assert:
         that:
-          - create_cluster_disk_encryption.node_pools[0].disk_encryption == 'enabled'
+          - create_cluster_disk_encryption.node_pools[0].disk_encryption == 'disabled'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -21,7 +21,7 @@
       register: all_regions
 
     - set_fact:
-        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | list)[0].id }}'
+        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "LA Disk Encryption") | list)[0].id }}'
 
     - name: Create a Linode LKE cluster
       linode.cloud.lke_cluster:

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -148,7 +148,7 @@
         that:
           - new_pool_de.node_pool.count == 2
           - new_pool_de.node_pool.type == 'g6-standard-1'
-          - new_pool_de.node_pool.disk_encryption == 'enabled'
+          - new_pool_de.node_pool.disk_encryption == 'disabled'
           - new_pool_de.node_pool.nodes[0].status == 'ready'
           - new_pool_de.node_pool.nodes[1].status == 'ready'
 

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -15,7 +15,7 @@
       register: all_regions
 
     - set_fact:
-        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Disk Encryption") | list)[0].id }}'
+        lde_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "LA Disk Encryption") | list)[0].id }}'
 
     - name: Create a minimal LKE cluster
       linode.cloud.lke_cluster:


### PR DESCRIPTION
## 📝 Description

Update test region capability to "LA Disk Encryption"
Default disk encryption upon lke or lke node pool creation is now disabled

## ✔️ How to Test

make test-int TEST_SUITE=lke_cluster_basic
make test-int TEST_SUITE=instance_disk_encryption
make test-int TEST_SUITE=lke_node_pool_basic

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**