### PR TITLE
Fix obj integration test

### DIFF
--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -57,10 +57,10 @@
       linode.cloud.object_keys:
         label: 'test-ansible-key-access-{{ r }}'
         access:
-          - cluster: us-ord-1
+          - region: us-ord
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_write
-          - cluster: us-ord-1
+          - region: us-ord
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_only
         state: present

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -73,10 +73,9 @@
           - 'not "REDACTED" in create_access.key.secret_key'
           - create_access.key.bucket_access[0].cluster == 'us-ord-1'
           - create_access.key.bucket_access[0].bucket_name == create_bucket.name
-          - create_access.key.bucket_access[0].permissions == 'read_write'
           - create_access.key.bucket_access[1].cluster == 'us-ord-1'
           - create_access.key.bucket_access[1].bucket_name == create_bucket.name
-          - create_access.key.bucket_access[1].permissions == 'read_only'
+          - "['read_only', 'read_write'] | sort == (create_access.key.bucket_access | map(attribute='permissions') | sort)"
 
   always:
     - ignore_errors: true


### PR DESCRIPTION
## 📝 Description

The API sometimes might return out of order accesses. Update test to adapt to it.

## ✔️ How to Test
```bash
make TEST_SUITE=object_basic test-int
```