### PR TITLE
Fix object_key_basic update test assertion

### DIFF
--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -53,8 +53,9 @@
       assert:
         that:
           - update.changed
-          - update.key.regions | length == 1
+          - update.key.regions | length == 2
           - update.key.regions[0].id == "us-ord"
+          - update.key.regions[1].id == "us-ord"
 
     - name: Create an S3 bucket using the key
       amazon.aws.s3_bucket:

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -53,9 +53,8 @@
       assert:
         that:
           - update.changed
-          - update.key.regions | length == 2
+          - update.key.regions | length > 1
           - update.key.regions[0].id == "us-ord"
-          - update.key.regions[1].id == "us-ord"
 
     - name: Create an S3 bucket using the key
       amazon.aws.s3_bucket:

--- a/tests/integration/targets/object_keys_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_keys_basic/tasks/main.yaml
@@ -49,11 +49,15 @@
         state: present
       register: update
 
+    - name: Debug full regions
+      debug:
+        var: update.key.regions
+
     - name: Assert OBJ key was updated
       assert:
         that:
           - update.changed
-          - update.key.regions | length > 1
+          - update.key.regions | length >= 1
           - update.key.regions[0].id == "us-ord"
 
     - name: Create an S3 bucket using the key


### PR DESCRIPTION
## 📝 Description

Addressing failure below
```
TASK [object_keys_basic : Update the regions for the OBJ key] ******************
changed: [testhost] => {"actions": ["Updated regions from ['us-mia', 'us-iad'] to ['us-ord']"], "changed": true, "key": {"access_key": "8LM1WDIX38DTOC5AYJ9L", "bucket_access": null, "id": 1956567, "label": "test-ansible-key-465768069", "limited": false, "regions": [{"endpoint_type": "E1", "id": "us-ord", "s3_endpoint": "us-ord-1.linodeobjects.com"}, {"endpoint_type": "E3", "id": "us-ord", "s3_endpoint": "us-ord-10.linodeobjects.com"}], "secret_key": "[REDACTED]"}}

TASK [object_keys_basic : Assert OBJ key was updated] **************************
fatal: [testhost]: FAILED! => {
    "assertion": "update.key.regions | length == 1",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```

Issue is due to region returning more than 1 when obj customer tag is present on the account

## ✔️ How to Test

`make TEST_SUITE="object_keys_basic" test-int`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**