### PR TITLE
Configurable DB Parameters: Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Name | Description |
 [linode.cloud.account_availability_info](./docs/modules/account_availability_info.md)|Get info about a Linode Account Availability.|
 [linode.cloud.account_info](./docs/modules/account_info.md)|Get info about a Linode Account.|
 [linode.cloud.child_account_info](./docs/modules/child_account_info.md)|Get info about a Linode Child Account.|
+[linode.cloud.database_config_info](./docs/modules/database_config_info.md)|Get info about a Linode Configuration.|
 [linode.cloud.database_mysql_info](./docs/modules/database_mysql_info.md)|Get info about a Linode MySQL Managed Database.|
 [linode.cloud.database_postgresql_info](./docs/modules/database_postgresql_info.md)|Get info about a Linode PostgreSQL Managed Database.|
 [linode.cloud.domain_info](./docs/modules/domain_info.md)|Get info about a Linode Domain.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -76,19 +76,19 @@ Parameters
 
 
       **parent_group (type=str):**
-        \• parent group for keyed group.
+        \• parent group for keyed group
 
 
       **prefix (type=str):**
-        \• A keyed group name will start with this prefix.
+        \• A keyed group name will start with this prefix
 
 
       **separator (type=str, default=_):**
-        \• separator used to build the keyed group name.
+        \• separator used to build the keyed group name
 
 
       **key (type=str):**
-        \• The key from input dictionary used to generate groups.
+        \• The key from input dictionary used to generate groups
 
 
       **default_value (type=str):**
@@ -98,7 +98,7 @@ Parameters
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to :literal:`false` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
+        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
         \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
@@ -109,13 +109,13 @@ Parameters
 
 
   **leading_separator (type=boolean, default=True):**
-    \• Use in conjunction with :literal:`keyed\_groups`.
+    \• Use in conjunction with keyed\_groups.
 
     \• By default, a keyed group that does not have a prefix or a separator provided will have a name that starts with an underscore.
 
-    \• This is because the default prefix is :literal:`""` and the default separator is :literal:`"\_"`.
+    \• This is because the default prefix is "" and the default separator is "\_".
 
-    \• Set this option to :literal:`false` to omit the leading underscore (or other separator) if no prefix is given.
+    \• Set this option to False to omit the leading underscore (or other separator) if no prefix is given.
 
     \• If the group name is derived from a mapping the separator is still used to concatenate the items.
 

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -76,19 +76,19 @@ Parameters
 
 
       **parent_group (type=str):**
-        \• parent group for keyed group
+        \• parent group for keyed group.
 
 
       **prefix (type=str):**
-        \• A keyed group name will start with this prefix
+        \• A keyed group name will start with this prefix.
 
 
       **separator (type=str, default=_):**
-        \• separator used to build the keyed group name
+        \• separator used to build the keyed group name.
 
 
       **key (type=str):**
-        \• The key from input dictionary used to generate groups
+        \• The key from input dictionary used to generate groups.
 
 
       **default_value (type=str):**
@@ -98,7 +98,7 @@ Parameters
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
+        \• Set this option to :literal:`false` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
         \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
@@ -109,13 +109,13 @@ Parameters
 
 
   **leading_separator (type=boolean, default=True):**
-    \• Use in conjunction with keyed\_groups.
+    \• Use in conjunction with :literal:`keyed\_groups`.
 
     \• By default, a keyed group that does not have a prefix or a separator provided will have a name that starts with an underscore.
 
-    \• This is because the default prefix is "" and the default separator is "\_".
+    \• This is because the default prefix is :literal:`""` and the default separator is :literal:`"\_"`.
 
-    \• Set this option to False to omit the leading underscore (or other separator) if no prefix is given.
+    \• Set this option to :literal:`false` to omit the leading underscore (or other separator) if no prefix is given.
 
     \• If the group name is derived from a mapping the separator is still used to concatenate the items.
 

--- a/docs/modules/database_config_info.md
+++ b/docs/modules/database_config_info.md
@@ -1,0 +1,275 @@
+# database_config_info
+
+Get info about a Linode Configuration.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get all available engine configuration fields for MySQL databases
+  linode.cloud.database_config_info:
+    engine: mysql
+```
+
+```yaml
+- name: Get all available engine configuration fields for PostgreSQL databases
+  linode.cloud.database_config_info:
+    engine: postgresql
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `engine` | <center>`str`</center> | <center>**Required**</center> | The Database Engine of the Configuration to resolve.   |
+
+## Return Values
+
+- `config` - The returned Configuration.
+
+    - Sample Response:
+        ```json
+        
+        {
+          "binlog_retention_period": {
+            "description": "The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.",
+            "example": 600,
+            "maximum": 86400,
+            "minimum": 600,
+            "requires_restart": false,
+            "type": "integer"
+          },
+          "mysql": {
+            "connect_timeout": {
+              "description": "The number of seconds that the mysqld server waits for a connect packet before responding with Bad handshake",
+              "example": 10,
+              "maximum": 3600,
+              "minimum": 2,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "default_time_zone": {
+              "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default.",
+              "example": "+03:00",
+              "maxLength": 100,
+              "minLength": 2,
+              "pattern": "^([-+][\\d:]*|[\\w/]*)$",
+              "requires_restart": false,
+              "type": "string"
+            },
+            "group_concat_max_len": {
+              "description": "The maximum permitted result length in bytes for the GROUP_CONCAT() function.",
+              "example": 1024,
+              "maximum": 18446744073709551615,
+              "minimum": 4,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "information_schema_stats_expiry": {
+              "description": "The time, in seconds, before cached statistics expire",
+              "example": 86400,
+              "maximum": 31536000,
+              "minimum": 900,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_change_buffer_max_size": {
+              "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool. Default is 25",
+              "example": 30,
+              "maximum": 50,
+              "minimum": 0,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_flush_neighbors": {
+              "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent (default is 1): 0 - dirty pages in the same extent are not flushed, 1 - flush contiguous dirty pages in the same extent, 2 - flush dirty pages in the same extent",
+              "example": 0,
+              "maximum": 2,
+              "minimum": 0,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_ft_min_token_size": {
+              "description": "Minimum length of words that are stored in an InnoDB FULLTEXT index. Changing this parameter will lead to a restart of the MySQL service.",
+              "example": 3,
+              "maximum": 16,
+              "minimum": 0,
+              "requires_restart": true,
+              "type": "integer"
+            },
+            "innodb_ft_server_stopword_table": {
+              "description": "This option is used to specify your own InnoDB FULLTEXT index stopword list for all InnoDB tables.",
+              "example": "db_name/table_name",
+              "maxLength": 1024,
+              "pattern": "^.+/.+$",
+              "requires_restart": false,
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "innodb_lock_wait_timeout": {
+              "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up. Default is 120.",
+              "example": 50,
+              "maximum": 3600,
+              "minimum": 1,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_log_buffer_size": {
+              "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+              "example": 16777216,
+              "maximum": 4294967295,
+              "minimum": 1048576,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_online_alter_log_max_size": {
+              "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+              "example": 134217728,
+              "maximum": 1099511627776,
+              "minimum": 65536,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_read_io_threads": {
+              "description": "The number of I/O threads for read operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+              "example": 10,
+              "maximum": 64,
+              "minimum": 1,
+              "requires_restart": true,
+              "type": "integer"
+            },
+            "innodb_rollback_on_timeout": {
+              "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+              "example": true,
+              "requires_restart": true,
+              "type": "boolean"
+            },
+            "innodb_thread_concurrency": {
+              "description": "Defines the maximum number of threads permitted inside of InnoDB. Default is 0 (infinite concurrency - no limit)",
+              "example": 10,
+              "maximum": 1000,
+              "minimum": 0,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "innodb_write_io_threads": {
+              "description": "The number of I/O threads for write operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+              "example": 10,
+              "maximum": 64,
+              "minimum": 1,
+              "requires_restart": true,
+              "type": "integer"
+            },
+            "interactive_timeout": {
+              "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+              "example": 3600,
+              "maximum": 604800,
+              "minimum": 30,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "internal_tmp_mem_storage_engine": {
+              "description": "The storage engine for in-memory internal temporary tables.",
+              "enum": [
+                "TempTable",
+                "MEMORY"
+              ],
+              "example": "TempTable",
+              "requires_restart": false,
+              "type": "string"
+            },
+            "max_allowed_packet": {
+              "description": "Size of the largest message in bytes that can be received by the server. Default is 67108864 (64M)",
+              "example": 67108864,
+              "maximum": 1073741824,
+              "minimum": 102400,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "max_heap_table_size": {
+              "description": "Limits the size of internal in-memory tables. Also set tmp_table_size. Default is 16777216 (16M)",
+              "example": 16777216,
+              "maximum": 1073741824,
+              "minimum": 1048576,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "net_buffer_length": {
+              "description": "Start sizes of connection buffer and result buffer. Default is 16384 (16K). Changing this parameter will lead to a restart of the MySQL service.",
+              "example": 16384,
+              "maximum": 1048576,
+              "minimum": 1024,
+              "requires_restart": true,
+              "type": "integer"
+            },
+            "net_read_timeout": {
+              "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+              "example": 30,
+              "maximum": 3600,
+              "minimum": 1,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "net_write_timeout": {
+              "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+              "example": 30,
+              "maximum": 3600,
+              "minimum": 1,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "sort_buffer_size": {
+              "description": "Sort buffer size in bytes for ORDER BY optimization. Default is 262144 (256K)",
+              "example": 262144,
+              "maximum": 1073741824,
+              "minimum": 32768,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "sql_mode": {
+              "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field Akamai default SQL mode (strict, SQL standard compliant) will be assigned.",
+              "example": "ANSI,TRADITIONAL",
+              "maxLength": 1024,
+              "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+              "requires_restart": false,
+              "type": "string"
+            },
+            "sql_require_primary_key": {
+              "description": "Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing. It is recommended to always have primary keys because various functionality may break if any large table is missing them.",
+              "example": true,
+              "requires_restart": false,
+              "type": "boolean"
+            },
+            "tmp_table_size": {
+              "description": "Limits the size of internal in-memory tables. Also set max_heap_table_size. Default is 16777216 (16M)",
+              "example": 16777216,
+              "maximum": 1073741824,
+              "minimum": 1048576,
+              "requires_restart": false,
+              "type": "integer"
+            },
+            "wait_timeout": {
+              "description": "The number of seconds the server waits for activity on a noninteractive connection before closing it.",
+              "example": 28800,
+              "maximum": 2147483,
+              "minimum": 1,
+              "requires_restart": false,
+              "type": "integer"
+            }
+          }
+        }
+        ```
+
+

--- a/docs/modules/database_mysql_v2.md
+++ b/docs/modules/database_mysql_v2.md
@@ -40,12 +40,16 @@ Create, read, and update a Linode MySQL database.
 ```
 
 ```yaml
-- name: Create a MySQL database with an explicit maintenance schedule
+- name: Create a MySQL database with an explicit maintenance schedule and engine configuration
   linode.cloud.database_mysql_v2:
     label: my-db
     region: us-mia
     engine: mysql/8
     type: g6-nanode-1
+    engine_config:
+        binlog_retention_period: 600
+        mysql:
+            connect_timeout: 20
     updates:
         duration: 4
         frequency: weekly
@@ -82,12 +86,52 @@ Create, read, and update a Linode MySQL database.
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses and CIDR ranges that can access the Managed Database.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode instance nodes deployed to the Managed Database.  **(Updatable)** |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.  **(Updatable)** |
+| [`engine_config` (sub-options)](#engine_config) | <center>`dict`</center> | <center>Optional</center> | Various parameters used to configure this database's underlying engine. NOTE: If a configuration parameter is not current accepted by this field, configure using the linode.cloud.api_request module.  **(Updatable)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Managed Database.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region of the Managed Database.   |
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.  **(Updatable)** |
 | [`fork` (sub-options)](#fork) | <center>`dict`</center> | <center>Optional</center> | Information about a database to fork from.   |
 | [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The maximum number of seconds a poll operation can take before raising an error.  **(Default: `2700`)** |
+
+### engine_config
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| [`mysql` (sub-options)](#mysql) | <center>`dict`</center> | <center>Optional</center> | MySQL specific configuration fields.   |
+| `binlog_retention_period` | <center>`int`</center> | <center>Optional</center> | The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for use cases like MySQL Debezium Kafka connector.   |
+
+### mysql
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `connect_timeout` | <center>`int`</center> | <center>Optional</center> | The number of seconds that the mysqld server waits for a connect packet before responding with Bad handshake.   |
+| `default_time_zone` | <center>`str`</center> | <center>Optional</center> | Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default.   |
+| `group_concat_max_len` | <center>`int`</center> | <center>Optional</center> | The maximum permitted result length in bytes for the GROUP_CONCAT() function.   |
+| `information_schema_stats_expiry` | <center>`int`</center> | <center>Optional</center> | The time, in seconds, before cached statistics expire.   |
+| `innodb_change_buffer_max_size` | <center>`int`</center> | <center>Optional</center> | Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool.   |
+| `innodb_flush_neighbors` | <center>`int`</center> | <center>Optional</center> | Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent.   |
+| `innodb_ft_min_token_size` | <center>`int`</center> | <center>Optional</center> | Minimum length of words that are stored in an InnoDB FULLTEXT index.   |
+| `innodb_ft_server_stopword_table` | <center>`str`</center> | <center>Optional</center> | This option is used to specify your own InnoDB FULLTEXT index stopword list for all InnoDB tables.   |
+| `innodb_lock_wait_timeout` | <center>`int`</center> | <center>Optional</center> | The length of time in seconds an InnoDB transaction waits for a row lock before giving up.   |
+| `innodb_log_buffer_size` | <center>`int`</center> | <center>Optional</center> | The size in bytes of the buffer that InnoDB uses to write to the log files on disk.   |
+| `innodb_online_alter_log_max_size` | <center>`int`</center> | <center>Optional</center> | The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.   |
+| `innodb_read_io_threads` | <center>`int`</center> | <center>Optional</center> | The number of I/O threads for read operations in InnoDB.   |
+| `innodb_rollback_on_timeout` | <center>`bool`</center> | <center>Optional</center> | When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction.   |
+| `innodb_thread_concurrency` | <center>`int`</center> | <center>Optional</center> | Defines the maximum number of threads permitted inside of InnoDB.   |
+| `innodb_write_io_threads` | <center>`int`</center> | <center>Optional</center> | The number of I/O threads for write operations in InnoDB.   |
+| `interactive_timeout` | <center>`int`</center> | <center>Optional</center> | The number of seconds the server waits for activity on an interactive connection before closing it.   |
+| `internal_tmp_mem_storage_engine` | <center>`str`</center> | <center>Optional</center> | The storage engine for in-memory internal temporary tables.  **(Choices: `TempTable`, `MEMORY`)** |
+| `max_allowed_packet` | <center>`int`</center> | <center>Optional</center> | Size of the largest message in bytes that can be received by the server. Default is 67108864 (64M).   |
+| `max_heap_table_size` | <center>`int`</center> | <center>Optional</center> | Limits the size of internal in-memory tables. Also set tmp_table_size. Default is 16777216 (16M).   |
+| `net_buffer_length` | <center>`int`</center> | <center>Optional</center> | Start sizes of connection buffer and result buffer. Default is 16384 (16K).   |
+| `net_read_timeout` | <center>`int`</center> | <center>Optional</center> | The number of seconds to wait for more data from a connection before aborting the read.   |
+| `net_write_timeout` | <center>`int`</center> | <center>Optional</center> | The number of seconds to wait for a block to be written to a connection before aborting the write.   |
+| `sort_buffer_size` | <center>`int`</center> | <center>Optional</center> | Sort buffer size in bytes for ORDER BY optimization. Default is 262144 (256K).   |
+| `sql_mode` | <center>`str`</center> | <center>Optional</center> | Global SQL mode. Set to empty to use MySQL server defaults.   |
+| `sql_require_primary_key` | <center>`bool`</center> | <center>Optional</center> | Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing.   |
+| `tmp_table_size` | <center>`int`</center> | <center>Optional</center> | Limits the size of internal in-memory tables. Also sets max_heap_table_size. Default is 16777216 (16M).   |
+| `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The number of seconds the server waits for activity on a noninteractive connection before closing it.   |
 
 ### fork
 
@@ -112,42 +156,48 @@ Create, read, and update a Linode MySQL database.
     - Sample Response:
         ```json
         {
-            "allow_list": [
-                "10.0.0.3/32"
-            ],
-            "cluster_size": 3,
-            "created": "2025-02-10T20:10:20",
-            "encrypted": true,
-            "engine": "mysql",
-            "hosts": {
-                "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
-                "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
-            },
-            "id": 12345,
-            "label": "my-db",
-            "members": {
-                "172.104.207.136": "primary",
-                "194.195.112.177": "failover",
-                "45.79.126.72": "failover"
-            },
-            "oldest_restore_time": "2025-02-10T20:15:07",
-            "platform": "rdbms-default",
-            "port": 11876,
-            "region": "ap-west",
-            "ssl_connection": true,
-            "status": "active",
-            "total_disk_size_gb": 30,
-            "type": "g6-standard-1",
-            "updated": "2025-02-10T20:25:55",
-            "updates": {
-                "day_of_week": 4,
-                "duration": 4,
-                "frequency": "weekly",
-                "hour_of_day": 16,
-                "pending": []
-            },
-            "used_disk_size_gb": 0,
-            "version": "8.0.35"
+          "allow_list": [
+            "10.0.0.3/32"
+          ],
+          "cluster_size": 3,
+          "created": "2025-02-10T20:10:20",
+          "encrypted": true,
+          "engine": "mysql",
+          "engine_config": {
+            "binlog_retention_period": 600,
+            "mysql": {
+              "connect_timeout": 20
+            }
+          },
+          "hosts": {
+            "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
+            "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+          },
+          "id": 12345,
+          "label": "my-db",
+          "members": {
+            "172.104.207.136": "primary",
+            "194.195.112.177": "failover",
+            "45.79.126.72": "failover"
+          },
+          "oldest_restore_time": "2025-02-10T20:15:07",
+          "platform": "rdbms-default",
+          "port": 11876,
+          "region": "ap-west",
+          "ssl_connection": true,
+          "status": "active",
+          "total_disk_size_gb": 30,
+          "type": "g6-standard-1",
+          "updated": "2025-02-10T20:25:55",
+          "updates": {
+            "day_of_week": 4,
+            "duration": 4,
+            "frequency": "weekly",
+            "hour_of_day": 16,
+            "pending": []
+          },
+          "used_disk_size_gb": 0,
+          "version": "8.0.35"
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance) for a list of returned fields

--- a/docs/modules/database_postgresql_v2.md
+++ b/docs/modules/database_postgresql_v2.md
@@ -40,12 +40,16 @@ Create, read, and update a Linode PostgreSQL database.
 ```
 
 ```yaml
-- name: Create a PostgreSQL database with an explicit maintenance schedule
+- name: Create a PostgreSQL database with an explicit maintenance schedule and engine configuration
   linode.cloud.database_postgresql_v2:
     label: my-db
     region: us-mia
     engine: postgresql/16
     type: g6-nanode-1
+    engine_config:
+        work_mem: 1023
+        pg:
+            autovacuum_analyze_scale_factor: 0.2
     updates:
         duration: 4
         frequency: weekly
@@ -82,12 +86,77 @@ Create, read, and update a Linode PostgreSQL database.
 | `allow_list` | <center>`list`</center> | <center>Optional</center> | A list of IP addresses and CIDR ranges that can access the Managed Database.  **(Updatable)** |
 | `cluster_size` | <center>`int`</center> | <center>Optional</center> | The number of Linode instance nodes deployed to the Managed Database.  **(Updatable)** |
 | `engine` | <center>`str`</center> | <center>Optional</center> | The Managed Database engine in engine/version format.  **(Updatable)** |
+| [`engine_config` (sub-options)](#engine_config) | <center>`dict`</center> | <center>Optional</center> | Various parameters used to configure this database's underlying engine. NOTE: If a configuration parameter is not current accepted by this field, configure using the linode.cloud.api_request module.  **(Updatable)** |
 | `label` | <center>`str`</center> | <center>Optional</center> | The label of the Managed Database.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region of the Managed Database.   |
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Instance type used by the Managed Database for its nodes.  **(Updatable)** |
 | [`fork` (sub-options)](#fork) | <center>`dict`</center> | <center>Optional</center> | Information about a database to fork from.   |
 | [`updates` (sub-options)](#updates) | <center>`dict`</center> | <center>Optional</center> | Configuration settings for automated patch update maintenance for the Managed Database.  **(Updatable)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The maximum number of seconds a poll operation can take before raising an error.  **(Default: `2700`)** |
+
+### engine_config
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| [`pg` (sub-options)](#pg) | <center>`dict`</center> | <center>Optional</center> | The configuration for PostgreSQL. Contains settings and controls for database behavior.   |
+| [`pglookout` (sub-options)](#pglookout) | <center>`dict`</center> | <center>Optional</center> | The configuration for pglookout. Contains controls for failover and replication settings.   |
+| `pg_stat_monitor_enable` | <center>`bool`</center> | <center>Optional</center> | Enable the pg_stat_monitor extension. Enabling this extension will cause the cluster to be restarted. When this extension is enabled, pg_stat_statements results for utility commands are unreliable.   |
+| `shared_buffers_percentage` | <center>`float`</center> | <center>Optional</center> | Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value.   |
+| `work_mem` | <center>`int`</center> | <center>Optional</center> | Sets the maximum amount of memory to be used by a query operation (such as a sort or hash table) before writing to temporary disk files, in MB. Default is 1MB + 0.075% of total RAM (up to 32MB).   |
+
+### pg
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `autovacuum_analyze_scale_factor` | <center>`float`</center> | <center>Optional</center> | Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size).   |
+| `autovacuum_analyze_threshold` | <center>`int`</center> | <center>Optional</center> | Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an ANALYZE in any one table. The default is 50 tuples.   |
+| `autovacuum_max_workers` | <center>`int`</center> | <center>Optional</center> | Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start.   |
+| `autovacuum_naptime` | <center>`int`</center> | <center>Optional</center> | Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds, and the default is one minute.   |
+| `autovacuum_vacuum_cost_delay` | <center>`int`</center> | <center>Optional</center> | Specifies the cost delay value that will be used in automatic VACUUM operations. If -1 is specified, the regular vacuum_cost_delay value will be used. The default value is 20 milliseconds.   |
+| `autovacuum_vacuum_cost_limit` | <center>`int`</center> | <center>Optional</center> | Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.   |
+| `autovacuum_vacuum_scale_factor` | <center>`float`</center> | <center>Optional</center> | Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size).   |
+| `autovacuum_vacuum_threshold` | <center>`int`</center> | <center>Optional</center> | Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples.   |
+| `bgwriter_delay` | <center>`int`</center> | <center>Optional</center> | Specifies the delay between activity rounds for the background writer in milliseconds. Default is 200.   |
+| `bgwriter_flush_after` | <center>`int`</center> | <center>Optional</center> | Whenever more than bgwriter_flush_after bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes, default is 512. Setting of 0 disables forced writeback.   |
+| `bgwriter_lru_maxpages` | <center>`int`</center> | <center>Optional</center> | In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. Default is 100.   |
+| `bgwriter_lru_multiplier` | <center>`float`</center> | <center>Optional</center> | The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0.   |
+| `deadlock_timeout` | <center>`int`</center> | <center>Optional</center> | This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.   |
+| `default_toast_compression` | <center>`str`</center> | <center>Optional</center> | Specifies the default TOAST compression method for values of compressible columns (the default is lz4).  **(Choices: `pglz`, `lz4`)** |
+| `idle_in_transaction_session_timeout` | <center>`int`</center> | <center>Optional</center> | Time out sessions with open transactions after this number of milliseconds.   |
+| `jit` | <center>`bool`</center> | <center>Optional</center> | Controls system-wide use of Just-in-Time Compilation (JIT).   |
+| `max_files_per_process` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum number of files that can be open per process.   |
+| `max_locks_per_transaction` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum locks per transaction.   |
+| `max_logical_replication_workers` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers).   |
+| `max_parallel_workers` | <center>`int`</center> | <center>Optional</center> | Sets the maximum number of workers that the system can support for parallel queries.   |
+| `max_parallel_workers_per_gather` | <center>`int`</center> | <center>Optional</center> | Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.   |
+| `max_pred_locks_per_transaction` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum predicate locks per transaction.   |
+| `max_replication_slots` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum replication slots.   |
+| `max_slot_wal_keep_size` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum WAL size (MB) reserved for replication slots. Default is -1 (unlimited). wal_keep_size minimum WAL size setting takes precedence over this.   |
+| `max_stack_depth` | <center>`int`</center> | <center>Optional</center> | Maximum depth of the stack in bytes.   |
+| `max_standby_archive_delay` | <center>`int`</center> | <center>Optional</center> | Max standby archive delay in milliseconds.   |
+| `max_standby_streaming_delay` | <center>`int`</center> | <center>Optional</center> | Max standby streaming delay in milliseconds.   |
+| `max_wal_senders` | <center>`int`</center> | <center>Optional</center> | PostgreSQL maximum WAL senders.   |
+| `max_worker_processes` | <center>`int`</center> | <center>Optional</center> | Sets the maximum number of background processes that the system can support.   |
+| `password_encryption` | <center>`str`</center> | <center>Optional</center> | Chooses the algorithm for encrypting passwords.  **(Choices: `md5`, `scram-sha-256`)** |
+| `pg_partman_bgw.interval` | <center>`int`</center> | <center>Optional</center> | Sets the time interval to run pg_partman's scheduled tasks.   |
+| `pg_partman_bgw.role` | <center>`str`</center> | <center>Optional</center> | Controls which role to use for pg_partman's scheduled background tasks.   |
+| `pg_stat_monitor.pgsm_enable_query_plan` | <center>`bool`</center> | <center>Optional</center> | Enables or disables query plan monitoring.   |
+| `pg_stat_monitor.pgsm_max_buckets` | <center>`int`</center> | <center>Optional</center> | Sets the maximum number of buckets.   |
+| `pg_stat_statements.track` | <center>`str`</center> | <center>Optional</center> | Controls which statements are counted. Specify 'top' to track top-level statements (those issued directly by clients), 'all' to also track nested statements (such as statements invoked within functions), or 'none' to disable statement statistics collection. The default value is 'top'.  **(Choices: `top`, `all`, `none`)** |
+| `temp_file_limit` | <center>`int`</center> | <center>Optional</center> | PostgreSQL temporary file limit in KiB, -1 for unlimited.   |
+| `timezone` | <center>`str`</center> | <center>Optional</center> | PostgreSQL service timezone.   |
+| `track_activity_query_size` | <center>`int`</center> | <center>Optional</center> | Specifies the number of bytes reserved to track the currently executing command for each active session.   |
+| `track_commit_timestamp` | <center>`str`</center> | <center>Optional</center> | Record commit time of transactions.  **(Choices: `on`, `off`)** |
+| `track_functions` | <center>`str`</center> | <center>Optional</center> | Enables tracking of function call counts and time used.  **(Choices: `none`, `pl`, `all`)** |
+| `track_io_timing` | <center>`str`</center> | <center>Optional</center> | Enables timing of database I/O calls. This parameter is off by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms.   |
+| `wal_sender_timeout` | <center>`int`</center> | <center>Optional</center> | Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout.   |
+| `wal_writer_delay` | <center>`int`</center> | <center>Optional</center> | WAL flush interval in milliseconds. Note that setting this value to lower than the default 200ms may negatively impact performance.   |
+
+### pglookout
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `max_failover_replication_time_lag` | <center>`int`</center> | <center>Optional</center> | Number of seconds of master unavailability before triggering database failover to standby.   |
 
 ### fork
 
@@ -112,42 +181,48 @@ Create, read, and update a Linode PostgreSQL database.
     - Sample Response:
         ```json
         {
-            "allow_list": [
-                "10.0.0.3/32"
-            ],
-            "cluster_size": 3,
-            "created": "2025-02-10T20:10:20",
-            "encrypted": true,
-            "engine": "postgresql",
-            "hosts": {
-                "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
-                "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+          "allow_list": [
+            "10.0.0.3/32"
+          ],
+          "cluster_size": 3,
+          "created": "2025-02-10T20:10:20",
+          "encrypted": true,
+          "engine": "postgresql",
+          "hosts": {
+            "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
+            "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+          },
+          "id": 12345,
+          "label": "my-db",
+          "members": {
+            "172.104.207.136": "primary",
+            "194.195.112.177": "failover",
+            "45.79.126.72": "failover"
+          },
+          "oldest_restore_time": "2025-02-10T20:15:07",
+          "platform": "rdbms-default",
+          "port": 11876,
+          "region": "ap-west",
+          "ssl_connection": true,
+          "status": "active",
+          "total_disk_size_gb": 30,
+          "type": "g6-standard-1",
+          "updated": "2025-02-10T20:25:55",
+          "engine_config": {
+            "pg": {
+              "autovacuum_analyze_scale_factor": 0.2
             },
-            "id": 12345,
-            "label": "my-db",
-            "members": {
-                "172.104.207.136": "primary",
-                "194.195.112.177": "failover",
-                "45.79.126.72": "failover"
-            },
-            "oldest_restore_time": "2025-02-10T20:15:07",
-            "platform": "rdbms-default",
-            "port": 11876,
-            "region": "ap-west",
-            "ssl_connection": true,
-            "status": "active",
-            "total_disk_size_gb": 30,
-            "type": "g6-standard-1",
-            "updated": "2025-02-10T20:25:55",
-            "updates": {
-                "day_of_week": 4,
-                "duration": 4,
-                "frequency": "weekly",
-                "hour_of_day": 16,
-                "pending": []
-            },
-            "used_disk_size_gb": 0,
-            "version": "8.0.35"
+            "work_mem": 1023
+          },
+          "updates": {
+            "day_of_week": 4,
+            "duration": 4,
+            "frequency": "weekly",
+            "hour_of_day": 16,
+            "pending": []
+          },
+          "used_disk_size_gb": 0,
+          "version": "8.0.35"
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance) for a list of returned fields

--- a/docs/modules/database_postgresql_v2.md
+++ b/docs/modules/database_postgresql_v2.md
@@ -188,6 +188,12 @@ Create, read, and update a Linode PostgreSQL database.
           "created": "2025-02-10T20:10:20",
           "encrypted": true,
           "engine": "postgresql",
+          "engine_config": {
+            "pg": {
+              "autovacuum_analyze_scale_factor": 0.2
+            },
+            "work_mem": 1023
+          },
           "hosts": {
             "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
             "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
@@ -208,12 +214,6 @@ Create, read, and update a Linode PostgreSQL database.
           "total_disk_size_gb": 30,
           "type": "g6-standard-1",
           "updated": "2025-02-10T20:25:55",
-          "engine_config": {
-            "pg": {
-              "autovacuum_analyze_scale_factor": 0.2
-            },
-            "work_mem": 1023
-          },
           "updates": {
             "day_of_week": 4,
             "duration": 4,

--- a/plugins/module_utils/doc_fragments/database_config_info.py
+++ b/plugins/module_utils/doc_fragments/database_config_info.py
@@ -1,0 +1,241 @@
+"""Documentation fragments for the database_mysql module"""
+
+specdoc_examples = ['''
+- name: Get all available engine configuration fields for MySQL databases
+  linode.cloud.database_config_info:
+    engine: mysql''', '''
+- name: Get all available engine configuration fields for PostgreSQL databases
+  linode.cloud.database_config_info:
+    engine: postgresql''']
+
+result_config_samples = [r'''
+{
+  "binlog_retention_period": {
+    "description": "The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.",
+    "example": 600,
+    "maximum": 86400,
+    "minimum": 600,
+    "requires_restart": false,
+    "type": "integer"
+  },
+  "mysql": {
+    "connect_timeout": {
+      "description": "The number of seconds that the mysqld server waits for a connect packet before responding with Bad handshake",
+      "example": 10,
+      "maximum": 3600,
+      "minimum": 2,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "default_time_zone": {
+      "description": "Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default.",
+      "example": "+03:00",
+      "maxLength": 100,
+      "minLength": 2,
+      "pattern": "^([-+][\\d:]*|[\\w/]*)$",
+      "requires_restart": false,
+      "type": "string"
+    },
+    "group_concat_max_len": {
+      "description": "The maximum permitted result length in bytes for the GROUP_CONCAT() function.",
+      "example": 1024,
+      "maximum": 18446744073709551615,
+      "minimum": 4,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "information_schema_stats_expiry": {
+      "description": "The time, in seconds, before cached statistics expire",
+      "example": 86400,
+      "maximum": 31536000,
+      "minimum": 900,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_change_buffer_max_size": {
+      "description": "Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool. Default is 25",
+      "example": 30,
+      "maximum": 50,
+      "minimum": 0,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_flush_neighbors": {
+      "description": "Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent (default is 1): 0 - dirty pages in the same extent are not flushed, 1 - flush contiguous dirty pages in the same extent, 2 - flush dirty pages in the same extent",
+      "example": 0,
+      "maximum": 2,
+      "minimum": 0,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_ft_min_token_size": {
+      "description": "Minimum length of words that are stored in an InnoDB FULLTEXT index. Changing this parameter will lead to a restart of the MySQL service.",
+      "example": 3,
+      "maximum": 16,
+      "minimum": 0,
+      "requires_restart": true,
+      "type": "integer"
+    },
+    "innodb_ft_server_stopword_table": {
+      "description": "This option is used to specify your own InnoDB FULLTEXT index stopword list for all InnoDB tables.",
+      "example": "db_name/table_name",
+      "maxLength": 1024,
+      "pattern": "^.+/.+$",
+      "requires_restart": false,
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "innodb_lock_wait_timeout": {
+      "description": "The length of time in seconds an InnoDB transaction waits for a row lock before giving up. Default is 120.",
+      "example": 50,
+      "maximum": 3600,
+      "minimum": 1,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_log_buffer_size": {
+      "description": "The size in bytes of the buffer that InnoDB uses to write to the log files on disk.",
+      "example": 16777216,
+      "maximum": 4294967295,
+      "minimum": 1048576,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_online_alter_log_max_size": {
+      "description": "The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables.",
+      "example": 134217728,
+      "maximum": 1099511627776,
+      "minimum": 65536,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_read_io_threads": {
+      "description": "The number of I/O threads for read operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+      "example": 10,
+      "maximum": 64,
+      "minimum": 1,
+      "requires_restart": true,
+      "type": "integer"
+    },
+    "innodb_rollback_on_timeout": {
+      "description": "When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service.",
+      "example": true,
+      "requires_restart": true,
+      "type": "boolean"
+    },
+    "innodb_thread_concurrency": {
+      "description": "Defines the maximum number of threads permitted inside of InnoDB. Default is 0 (infinite concurrency - no limit)",
+      "example": 10,
+      "maximum": 1000,
+      "minimum": 0,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "innodb_write_io_threads": {
+      "description": "The number of I/O threads for write operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service.",
+      "example": 10,
+      "maximum": 64,
+      "minimum": 1,
+      "requires_restart": true,
+      "type": "integer"
+    },
+    "interactive_timeout": {
+      "description": "The number of seconds the server waits for activity on an interactive connection before closing it.",
+      "example": 3600,
+      "maximum": 604800,
+      "minimum": 30,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "internal_tmp_mem_storage_engine": {
+      "description": "The storage engine for in-memory internal temporary tables.",
+      "enum": [
+        "TempTable",
+        "MEMORY"
+      ],
+      "example": "TempTable",
+      "requires_restart": false,
+      "type": "string"
+    },
+    "max_allowed_packet": {
+      "description": "Size of the largest message in bytes that can be received by the server. Default is 67108864 (64M)",
+      "example": 67108864,
+      "maximum": 1073741824,
+      "minimum": 102400,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "max_heap_table_size": {
+      "description": "Limits the size of internal in-memory tables. Also set tmp_table_size. Default is 16777216 (16M)",
+      "example": 16777216,
+      "maximum": 1073741824,
+      "minimum": 1048576,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "net_buffer_length": {
+      "description": "Start sizes of connection buffer and result buffer. Default is 16384 (16K). Changing this parameter will lead to a restart of the MySQL service.",
+      "example": 16384,
+      "maximum": 1048576,
+      "minimum": 1024,
+      "requires_restart": true,
+      "type": "integer"
+    },
+    "net_read_timeout": {
+      "description": "The number of seconds to wait for more data from a connection before aborting the read.",
+      "example": 30,
+      "maximum": 3600,
+      "minimum": 1,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "net_write_timeout": {
+      "description": "The number of seconds to wait for a block to be written to a connection before aborting the write.",
+      "example": 30,
+      "maximum": 3600,
+      "minimum": 1,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "sort_buffer_size": {
+      "description": "Sort buffer size in bytes for ORDER BY optimization. Default is 262144 (256K)",
+      "example": 262144,
+      "maximum": 1073741824,
+      "minimum": 32768,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "sql_mode": {
+      "description": "Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field Akamai default SQL mode (strict, SQL standard compliant) will be assigned.",
+      "example": "ANSI,TRADITIONAL",
+      "maxLength": 1024,
+      "pattern": "^[A-Z_]*(,[A-Z_]+)*$",
+      "requires_restart": false,
+      "type": "string"
+    },
+    "sql_require_primary_key": {
+      "description": "Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing. It is recommended to always have primary keys because various functionality may break if any large table is missing them.",
+      "example": true,
+      "requires_restart": false,
+      "type": "boolean"
+    },
+    "tmp_table_size": {
+      "description": "Limits the size of internal in-memory tables. Also set max_heap_table_size. Default is 16777216 (16M)",
+      "example": 16777216,
+      "maximum": 1073741824,
+      "minimum": 1048576,
+      "requires_restart": false,
+      "type": "integer"
+    },
+    "wait_timeout": {
+      "description": "The number of seconds the server waits for activity on a noninteractive connection before closing it.",
+      "example": 28800,
+      "maximum": 2147483,
+      "minimum": 1,
+      "requires_restart": false,
+      "type": "integer"
+    }
+  }
+}''']

--- a/plugins/module_utils/doc_fragments/database_mysql_v2.py
+++ b/plugins/module_utils/doc_fragments/database_mysql_v2.py
@@ -20,12 +20,16 @@ specdoc_examples = ['''
     allow_list:
       - 0.0.0.0/0
     state: present''', '''
-- name: Create a MySQL database with an explicit maintenance schedule
+- name: Create a MySQL database with an explicit maintenance schedule and engine configuration
   linode.cloud.database_mysql_v2:
     label: my-db
     region: us-mia
     engine: mysql/8
     type: g6-nanode-1
+    engine_config:
+        binlog_retention_period: 600
+        mysql:
+            connect_timeout: 20
     updates:
         duration: 4
         frequency: weekly
@@ -47,42 +51,48 @@ specdoc_examples = ['''
     state: absent''']
 
 result_database_samples = ['''{
-    "allow_list": [
-        "10.0.0.3/32"
-    ],
-    "cluster_size": 3,
-    "created": "2025-02-10T20:10:20",
-    "encrypted": true,
-    "engine": "mysql",
-    "hosts": {
-        "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
-        "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
-    },
-    "id": 12345,
-    "label": "my-db",
-    "members": {
-        "172.104.207.136": "primary",
-        "194.195.112.177": "failover",
-        "45.79.126.72": "failover"
-    },
-    "oldest_restore_time": "2025-02-10T20:15:07",
-    "platform": "rdbms-default",
-    "port": 11876,
-    "region": "ap-west",
-    "ssl_connection": true,
-    "status": "active",
-    "total_disk_size_gb": 30,
-    "type": "g6-standard-1",
-    "updated": "2025-02-10T20:25:55",
-    "updates": {
-        "day_of_week": 4,
-        "duration": 4,
-        "frequency": "weekly",
-        "hour_of_day": 16,
-        "pending": []
-    },
-    "used_disk_size_gb": 0,
-    "version": "8.0.35"
+  "allow_list": [
+    "10.0.0.3/32"
+  ],
+  "cluster_size": 3,
+  "created": "2025-02-10T20:10:20",
+  "encrypted": true,
+  "engine": "mysql",
+  "engine_config": {
+    "binlog_retention_period": 600,
+    "mysql": {
+      "connect_timeout": 20
+    }
+  },
+  "hosts": {
+    "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
+    "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+  },
+  "id": 12345,
+  "label": "my-db",
+  "members": {
+    "172.104.207.136": "primary",
+    "194.195.112.177": "failover",
+    "45.79.126.72": "failover"
+  },
+  "oldest_restore_time": "2025-02-10T20:15:07",
+  "platform": "rdbms-default",
+  "port": 11876,
+  "region": "ap-west",
+  "ssl_connection": true,
+  "status": "active",
+  "total_disk_size_gb": 30,
+  "type": "g6-standard-1",
+  "updated": "2025-02-10T20:25:55",
+  "updates": {
+    "day_of_week": 4,
+    "duration": 4,
+    "frequency": "weekly",
+    "hour_of_day": 16,
+    "pending": []
+  },
+  "used_disk_size_gb": 0,
+  "version": "8.0.35"
 }''']
 
 result_credentials_samples = ['''{

--- a/plugins/module_utils/doc_fragments/database_postgresql_v2.py
+++ b/plugins/module_utils/doc_fragments/database_postgresql_v2.py
@@ -20,12 +20,16 @@ specdoc_examples = ['''
     allow_list:
       - 0.0.0.0/0
     state: present''', '''
-- name: Create a PostgreSQL database with an explicit maintenance schedule
+- name: Create a PostgreSQL database with an explicit maintenance schedule and engine configuration
   linode.cloud.database_postgresql_v2:
     label: my-db
     region: us-mia
     engine: postgresql/16
     type: g6-nanode-1
+    engine_config:
+        work_mem: 1023
+        pg:
+            autovacuum_analyze_scale_factor: 0.2
     updates:
         duration: 4
         frequency: weekly
@@ -47,42 +51,48 @@ specdoc_examples = ['''
     state: absent''']
 
 result_database_samples = ['''{
-    "allow_list": [
-        "10.0.0.3/32"
-    ],
-    "cluster_size": 3,
-    "created": "2025-02-10T20:10:20",
-    "encrypted": true,
-    "engine": "postgresql",
-    "hosts": {
-        "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
-        "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+  "allow_list": [
+    "10.0.0.3/32"
+  ],
+  "cluster_size": 3,
+  "created": "2025-02-10T20:10:20",
+  "encrypted": true,
+  "engine": "postgresql",
+  "hosts": {
+    "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
+    "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
+  },
+  "id": 12345,
+  "label": "my-db",
+  "members": {
+    "172.104.207.136": "primary",
+    "194.195.112.177": "failover",
+    "45.79.126.72": "failover"
+  },
+  "oldest_restore_time": "2025-02-10T20:15:07",
+  "platform": "rdbms-default",
+  "port": 11876,
+  "region": "ap-west",
+  "ssl_connection": true,
+  "status": "active",
+  "total_disk_size_gb": 30,
+  "type": "g6-standard-1",
+  "updated": "2025-02-10T20:25:55",
+  "engine_config": {
+    "pg": {
+      "autovacuum_analyze_scale_factor": 0.2
     },
-    "id": 12345,
-    "label": "my-db",
-    "members": {
-        "172.104.207.136": "primary",
-        "194.195.112.177": "failover",
-        "45.79.126.72": "failover"
-    },
-    "oldest_restore_time": "2025-02-10T20:15:07",
-    "platform": "rdbms-default",
-    "port": 11876,
-    "region": "ap-west",
-    "ssl_connection": true,
-    "status": "active",
-    "total_disk_size_gb": 30,
-    "type": "g6-standard-1",
-    "updated": "2025-02-10T20:25:55",
-    "updates": {
-        "day_of_week": 4,
-        "duration": 4,
-        "frequency": "weekly",
-        "hour_of_day": 16,
-        "pending": []
-    },
-    "used_disk_size_gb": 0,
-    "version": "8.0.35"
+    "work_mem": 1023
+  },
+  "updates": {
+    "day_of_week": 4,
+    "duration": 4,
+    "frequency": "weekly",
+    "hour_of_day": 16,
+    "pending": []
+  },
+  "used_disk_size_gb": 0,
+  "version": "8.0.35"
 }''']
 
 result_credentials_samples = ['''{

--- a/plugins/module_utils/doc_fragments/database_postgresql_v2.py
+++ b/plugins/module_utils/doc_fragments/database_postgresql_v2.py
@@ -58,6 +58,12 @@ result_database_samples = ['''{
   "created": "2025-02-10T20:10:20",
   "encrypted": true,
   "engine": "postgresql",
+  "engine_config": {
+    "pg": {
+      "autovacuum_analyze_scale_factor": 0.2
+    },
+    "work_mem": 1023
+  },
   "hosts": {
     "primary": "a225891-akamai-prod-1798333-default.g2a.akamaidb.net",
     "standby": "replica-a225891-akamai-prod-1798333-default.g2a.akamaidb.net"
@@ -78,12 +84,6 @@ result_database_samples = ['''{
   "total_disk_size_gb": 30,
   "type": "g6-standard-1",
   "updated": "2025-02-10T20:25:55",
-  "engine_config": {
-    "pg": {
-      "autovacuum_analyze_scale_factor": 0.2
-    },
-    "work_mem": 1023
-  },
   "updates": {
     "day_of_week": 4,
     "duration": 4,

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 import linode_api4
 import polling
 from linode_api4 import (
+    JSONObject,
     LinodeClient,
     LKENodePool,
     LKENodePoolNode,
@@ -189,6 +190,9 @@ def parse_linode_types(value: any) -> any:
 
     if isinstance(value, dict):
         return {k: parse_linode_types(elem) for k, elem in value.items()}
+
+    if issubclass(type(value), JSONObject):
+        return parse_linode_types(value.dict)
 
     if type(value) in {
         linode_api4.objects.linode.Type,

--- a/plugins/modules/database_config_info.py
+++ b/plugins/modules/database_config_info.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Implementation of linode.cloud.database_config_info module.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Dict
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    database_config_info as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+)
+from linode_api4 import LinodeClient
+
+
+def __resolve_by_engine(
+    client: LinodeClient, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    engine_resolvers = {
+        "mysql": client.database.mysql_config_options,
+        "postgresql": client.database.postgresql_config_options,
+    }
+
+    engine = params.get("engine").lower()
+    if engine not in engine_resolvers:
+        raise ValueError(
+            f"Invalid engine {engine}; must be one of {', '.join(engine_resolvers.keys())}."
+        )
+
+    return engine_resolvers[engine]()
+
+
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="config",
+        field_type=FieldType.dict,
+        display_name="Configuration",
+        docs_url=None,
+        samples=docs.result_config_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            display_name="Database Engine",
+            name="engine",
+            type=FieldType.string,
+            get=__resolve_by_engine,
+        )
+    ],
+    examples=docs.specdoc_examples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/database_mysql_v2.py
+++ b/plugins/modules/database_mysql_v2.py
@@ -37,6 +37,206 @@ from ansible_specdoc.objects import (
 )
 from linode_api4 import MySQLDatabase
 
+SPEC_ENGINE_CONFIG_MYSQL = {
+    "connect_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of seconds that the mysqld server waits for a connect packet "
+            + "before responding with Bad handshake."
+        ],
+    ),
+    "default_time_zone": SpecField(
+        type=FieldType.string,
+        description=[
+            "Default server time zone as an offset from UTC (from -12:00 to +12:00), "
+            + "a time zone name, or 'SYSTEM' to use the MySQL server default."
+        ],
+    ),
+    "group_concat_max_len": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The maximum permitted result length in bytes for the GROUP_CONCAT() function."
+        ],
+    ),
+    "information_schema_stats_expiry": SpecField(
+        type=FieldType.integer,
+        description=["The time, in seconds, before cached statistics expire."],
+    ),
+    "innodb_change_buffer_max_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Maximum size for the InnoDB change buffer, "
+            + "as a percentage of the total size of the buffer pool."
+        ],
+    ),
+    "innodb_flush_neighbors": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies whether flushing a page from the InnoDB buffer pool also "
+            + "flushes other dirty pages in the same extent."
+        ],
+    ),
+    "innodb_ft_min_token_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Minimum length of words that are stored in an InnoDB FULLTEXT index."
+        ],
+    ),
+    "innodb_ft_server_stopword_table": SpecField(
+        type=FieldType.string,
+        description=[
+            "This option is used to specify your own InnoDB FULLTEXT "
+            + "index stopword list for all InnoDB tables."
+        ],
+    ),
+    "innodb_lock_wait_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The length of time in seconds an InnoDB transaction waits "
+            + "for a row lock before giving up."
+        ],
+    ),
+    "innodb_log_buffer_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The size in bytes of the buffer that InnoDB uses to write to the log files on disk."
+        ],
+    ),
+    "innodb_online_alter_log_max_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The upper limit in bytes on the size of the temporary log files "
+            + "used during online DDL operations for InnoDB tables."
+        ],
+    ),
+    "innodb_read_io_threads": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of I/O threads for read operations in InnoDB."
+        ],
+    ),
+    "innodb_rollback_on_timeout": SpecField(
+        type=FieldType.bool,
+        description=[
+            "When enabled a transaction timeout causes InnoDB to "
+            + "abort and roll back the entire transaction."
+        ],
+    ),
+    "innodb_thread_concurrency": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Defines the maximum number of threads permitted inside of InnoDB."
+        ],
+    ),
+    "innodb_write_io_threads": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of I/O threads for write operations in InnoDB."
+        ],
+    ),
+    "interactive_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of seconds the server waits for activity on an "
+            + "interactive connection before closing it."
+        ],
+    ),
+    "internal_tmp_mem_storage_engine": SpecField(
+        type=FieldType.string,
+        description=[
+            "The storage engine for in-memory internal temporary tables."
+        ],
+        choices=["TempTable", "MEMORY"],
+    ),
+    "max_allowed_packet": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Size of the largest message in bytes that can be received by the server.",
+            "Default is 67108864 (64M).",
+        ],
+    ),
+    "max_heap_table_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Limits the size of internal in-memory tables.",
+            "Also set tmp_table_size.",
+            "Default is 16777216 (16M).",
+        ],
+    ),
+    "net_buffer_length": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Start sizes of connection buffer and result buffer.",
+            "Default is 16384 (16K).",
+        ],
+    ),
+    "net_read_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of seconds to wait for more data from a connection "
+            + "before aborting the read."
+        ],
+    ),
+    "net_write_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of seconds to wait for a block to be written "
+            + "to a connection before aborting the write."
+        ],
+    ),
+    "sort_buffer_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sort buffer size in bytes for ORDER BY optimization.",
+            "Default is 262144 (256K).",
+        ],
+    ),
+    "sql_mode": SpecField(
+        type=FieldType.string,
+        description=[
+            "Global SQL mode.",
+            "Set to empty to use MySQL server defaults.",
+        ],
+    ),
+    "sql_require_primary_key": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Require primary key to be defined for new tables or old tables modified "
+            + "with ALTER TABLE and fail if missing."
+        ],
+    ),
+    "tmp_table_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Limits the size of internal in-memory tables.",
+            "Also sets max_heap_table_size.",
+            "Default is 16777216 (16M).",
+        ],
+    ),
+    "wait_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The number of seconds the server waits for activity on a "
+            + "noninteractive connection before closing it."
+        ],
+    ),
+}
+
+SPEC_ENGINE_CONFIG = {
+    "mysql": SpecField(
+        type=FieldType.dict,
+        suboptions=SPEC_ENGINE_CONFIG_MYSQL,
+        description=["MySQL specific configuration fields."],
+    ),
+    "binlog_retention_period": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The minimum amount of time in seconds to keep binlog entries before deletion.",
+            "This may be extended for use cases like MySQL Debezium Kafka connector.",
+        ],
+    ),
+}
+
 SPEC = {
     "state": SpecField(
         type=FieldType.string,
@@ -62,6 +262,16 @@ SPEC = {
     "engine": SpecField(
         type=FieldType.string,
         description=["The Managed Database engine in engine/version format."],
+        editable=True,
+    ),
+    "engine_config": SpecField(
+        type=FieldType.dict,
+        suboptions=SPEC_ENGINE_CONFIG,
+        description=[
+            "Various parameters used to configure this database's underlying engine.",
+            "NOTE: If a configuration parameter is not current accepted by this field, "
+            + "configure using the linode.cloud.api_request module.",
+        ],
         editable=True,
     ),
     "label": SpecField(
@@ -172,6 +382,7 @@ class Module(LinodeModuleBase):
                     "allow_list",
                     "cluster_size",
                     "engine",
+                    "engine_config",
                     "fork",
                     "label",
                     "region",
@@ -254,6 +465,7 @@ class Module(LinodeModuleBase):
                 "label",
                 "allow_list",
                 "cluster_size",
+                "engine_config",
                 "updates",
                 "type",
                 "version",

--- a/plugins/modules/database_postgresql_v2.py
+++ b/plugins/modules/database_postgresql_v2.py
@@ -39,6 +39,357 @@ from ansible_specdoc.objects import (
 )
 from linode_api4 import PostgreSQLDatabase
 
+SPEC_ENGINE_CONFIG_PG = {
+    "autovacuum_analyze_scale_factor": SpecField(
+        type=FieldType.float,
+        description=[
+            "Specifies a fraction of the table size to add to "
+            + "autovacuum_analyze_threshold when deciding "
+            + "whether to trigger an ANALYZE.",
+            "The default is 0.2 (20% of table size).",
+        ],
+    ),
+    "autovacuum_analyze_threshold": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the minimum number of inserted, updated or deleted "
+            + "tuples needed to trigger "
+            "an ANALYZE in any one table.",
+            "The default is 50 tuples.",
+        ],
+    ),
+    "autovacuum_max_workers": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the maximum number of autovacuum processes "
+            + "(other than the autovacuum launcher) "
+            + "that may be running at any one time.",
+            "The default is three.",
+            "This parameter can only be set at server start.",
+        ],
+    ),
+    "autovacuum_naptime": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the minimum delay between autovacuum runs on any given database.",
+            "The delay is measured in seconds, and the default is one minute.",
+        ],
+    ),
+    "autovacuum_vacuum_cost_delay": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the cost delay value that will be used in automatic VACUUM operations.",
+            "If -1 is specified, the regular vacuum_cost_delay value will be used.",
+            "The default value is 20 milliseconds.",
+        ],
+    ),
+    "autovacuum_vacuum_cost_limit": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the cost limit value that will be used in automatic VACUUM operations.",
+            "If -1 is specified (which is the default), the regular "
+            + "vacuum_cost_limit value will be used.",
+        ],
+    ),
+    "autovacuum_vacuum_scale_factor": SpecField(
+        type=FieldType.float,
+        description=[
+            "Specifies a fraction of the table size to add to "
+            + "autovacuum_vacuum_threshold when deciding "
+            + "whether to trigger a VACUUM.",
+            "The default is 0.2 (20% of table size).",
+        ],
+    ),
+    "autovacuum_vacuum_threshold": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the minimum number of updated or deleted tuples needed to "
+            + "trigger a VACUUM in any one table.",
+            "The default is 50 tuples.",
+        ],
+    ),
+    "bgwriter_delay": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the delay between activity rounds for the "
+            + "background writer in milliseconds.",
+            "Default is 200.",
+        ],
+    ),
+    "bgwriter_flush_after": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Whenever more than bgwriter_flush_after bytes have been "
+            + "written by the background writer, attempt to "
+            + "force the OS to issue these writes to the underlying storage.",
+            "Specified in kilobytes, default is 512.",
+            "Setting of 0 disables forced writeback.",
+        ],
+    ),
+    "bgwriter_lru_maxpages": SpecField(
+        type=FieldType.integer,
+        description=[
+            "In each round, no more than this many buffers will be "
+            + "written by the background writer.",
+            "Setting this to zero disables background writing.",
+            "Default is 100.",
+        ],
+    ),
+    "bgwriter_lru_multiplier": SpecField(
+        type=FieldType.float,
+        description=[
+            "The average recent need for new buffers is multiplied by "
+            + "bgwriter_lru_multiplier to arrive at an estimate of the number "
+            + "that will be needed during the next round, (up to bgwriter_lru_maxpages).",
+            "1.0 represents a “just in time” policy of writing exactly the number of "
+            + "buffers predicted to be needed.",
+            "Larger values provide some cushion against spikes in demand, "
+            + "while smaller values intentionally leave writes "
+            "to be done by server processes.",
+            "The default is 2.0.",
+        ],
+    ),
+    "deadlock_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "This is the amount of time, in milliseconds, to wait on a lock "
+            + "before checking to see if there is a deadlock condition."
+        ],
+    ),
+    "default_toast_compression": SpecField(
+        type=FieldType.string,
+        description=[
+            "Specifies the default TOAST compression method for values of "
+            + "compressible columns (the default is lz4)."
+        ],
+        choices=["pglz", "lz4"],
+    ),
+    "idle_in_transaction_session_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Time out sessions with open transactions after this number of milliseconds."
+        ],
+    ),
+    "jit": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Controls system-wide use of Just-in-Time Compilation (JIT)."
+        ],
+    ),
+    "max_files_per_process": SpecField(
+        type=FieldType.integer,
+        description=[
+            "PostgreSQL maximum number of files that can be open per process."
+        ],
+    ),
+    "max_locks_per_transaction": SpecField(
+        type=FieldType.integer,
+        description=["PostgreSQL maximum locks per transaction."],
+    ),
+    "max_logical_replication_workers": SpecField(
+        type=FieldType.integer,
+        description=[
+            "PostgreSQL maximum logical replication workers "
+            + "(taken from the pool of max_parallel_workers)."
+        ],
+    ),
+    "max_parallel_workers": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sets the maximum number of workers that the system "
+            + "can support for parallel queries."
+        ],
+    ),
+    "max_parallel_workers_per_gather": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sets the maximum number of workers that can be started "
+            + "by a single Gather or Gather Merge node."
+        ],
+    ),
+    "max_pred_locks_per_transaction": SpecField(
+        type=FieldType.integer,
+        description=["PostgreSQL maximum predicate locks per transaction."],
+    ),
+    "max_replication_slots": SpecField(
+        type=FieldType.integer,
+        description=["PostgreSQL maximum replication slots."],
+    ),
+    "max_slot_wal_keep_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "PostgreSQL maximum WAL size (MB) reserved for replication slots.",
+            "Default is -1 (unlimited).",
+            "wal_keep_size minimum WAL size setting takes precedence over this.",
+        ],
+    ),
+    "max_stack_depth": SpecField(
+        type=FieldType.integer,
+        description=["Maximum depth of the stack in bytes."],
+    ),
+    "max_standby_archive_delay": SpecField(
+        type=FieldType.integer,
+        description=["Max standby archive delay in milliseconds."],
+    ),
+    "max_standby_streaming_delay": SpecField(
+        type=FieldType.integer,
+        description=["Max standby streaming delay in milliseconds."],
+    ),
+    "max_wal_senders": SpecField(
+        type=FieldType.integer,
+        description=["PostgreSQL maximum WAL senders."],
+    ),
+    "max_worker_processes": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sets the maximum number of background processes that the system can support."
+        ],
+    ),
+    "password_encryption": SpecField(
+        type=FieldType.string,
+        description=["Chooses the algorithm for encrypting passwords."],
+        choices=["md5", "scram-sha-256"],
+    ),
+    "pg_partman_bgw.interval": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sets the time interval to run pg_partman's scheduled tasks."
+        ],
+    ),
+    "pg_partman_bgw.role": SpecField(
+        type=FieldType.string,
+        description=[
+            "Controls which role to use for pg_partman's scheduled background tasks."
+        ],
+    ),
+    "pg_stat_monitor.pgsm_enable_query_plan": SpecField(
+        type=FieldType.bool,
+        description=["Enables or disables query plan monitoring."],
+    ),
+    "pg_stat_monitor.pgsm_max_buckets": SpecField(
+        type=FieldType.integer,
+        description=["Sets the maximum number of buckets."],
+    ),
+    "pg_stat_statements.track": SpecField(
+        type=FieldType.string,
+        description=[
+            "Controls which statements are counted.",
+            "Specify 'top' to track top-level statements (those issued directly by clients), "
+            + "'all' to also track nested statements (such as statements "
+            + "invoked within functions), or 'none' to disable statement statistics collection.",
+            "The default value is 'top'.",
+        ],
+        choices=["top", "all", "none"],
+    ),
+    "temp_file_limit": SpecField(
+        type=FieldType.integer,
+        description=[
+            "PostgreSQL temporary file limit in KiB, -1 for unlimited."
+        ],
+    ),
+    "timezone": SpecField(
+        type=FieldType.string,
+        description=["PostgreSQL service timezone."],
+    ),
+    "track_activity_query_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Specifies the number of bytes reserved to track the currently "
+            + "executing command for each active session."
+        ],
+    ),
+    "track_commit_timestamp": SpecField(
+        type=FieldType.string,
+        description=["Record commit time of transactions."],
+        choices=["on", "off"],
+    ),
+    "track_functions": SpecField(
+        type=FieldType.string,
+        description=["Enables tracking of function call counts and time used."],
+        choices=["none", "pl", "all"],
+    ),
+    "track_io_timing": SpecField(
+        type=FieldType.string,
+        description=[
+            "Enables timing of database I/O calls.",
+            "This parameter is off by default, because it will repeatedly "
+            + "query the operating system for the current time, which may "
+            "cause significant overhead on some platforms.",
+        ],
+    ),
+    "wal_sender_timeout": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Terminate replication connections that are inactive for "
+            + "longer than this amount of time, in milliseconds.",
+            "Setting this value to zero disables the timeout.",
+        ],
+    ),
+    "wal_writer_delay": SpecField(
+        type=FieldType.integer,
+        description=[
+            "WAL flush interval in milliseconds.",
+            "Note that setting this value to lower than the default 200ms "
+            + "may negatively impact performance.",
+        ],
+    ),
+}
+
+SPEC_ENGINE_CONFIG_PGLOOKOUT = {
+    "max_failover_replication_time_lag": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Number of seconds of master unavailability before "
+            + "triggering database failover to standby."
+        ],
+    )
+}
+
+SPEC_ENGINE_CONFIG = {
+    "pg": SpecField(
+        type=FieldType.dict,
+        suboptions=SPEC_ENGINE_CONFIG_PG,
+        description=[
+            "The configuration for PostgreSQL.",
+            "Contains settings and controls for database behavior.",
+        ],
+    ),
+    "pglookout": SpecField(
+        type=FieldType.dict,
+        suboptions=SPEC_ENGINE_CONFIG_PGLOOKOUT,
+        description=[
+            "The configuration for pglookout.",
+            "Contains controls for failover and replication settings.",
+        ],
+    ),
+    "pg_stat_monitor_enable": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Enable the pg_stat_monitor extension.",
+            "Enabling this extension will cause the cluster to be restarted.",
+            "When this extension is enabled, pg_stat_statements results "
+            + "for utility commands are unreliable.",
+        ],
+    ),
+    "shared_buffers_percentage": SpecField(
+        type=FieldType.float,
+        description=[
+            "Percentage of total RAM that the database server uses for shared memory buffers.",
+            "Valid range is 20-60 (float), which corresponds to 20% - 60%.",
+            "This setting adjusts the shared_buffers configuration value.",
+        ],
+    ),
+    "work_mem": SpecField(
+        type=FieldType.integer,
+        description=[
+            "Sets the maximum amount of memory to be used by a "
+            + "query operation (such as a sort or hash table) "
+            + "before writing to temporary disk files, in MB.",
+            "Default is 1MB + 0.075% of total RAM (up to 32MB).",
+        ],
+    ),
+}
+
 SPEC = {
     "state": SpecField(
         type=FieldType.string,
@@ -64,6 +415,16 @@ SPEC = {
     "engine": SpecField(
         type=FieldType.string,
         description=["The Managed Database engine in engine/version format."],
+        editable=True,
+    ),
+    "engine_config": SpecField(
+        type=FieldType.dict,
+        suboptions=SPEC_ENGINE_CONFIG,
+        description=[
+            "Various parameters used to configure this database's underlying engine.",
+            "NOTE: If a configuration parameter is not current accepted by this field, "
+            + "configure using the linode.cloud.api_request module.",
+        ],
         editable=True,
     ),
     "label": SpecField(
@@ -174,6 +535,7 @@ class Module(LinodeModuleBase):
                     "allow_list",
                     "cluster_size",
                     "engine",
+                    "engine_config",
                     "fork",
                     "label",
                     "region",
@@ -250,6 +612,7 @@ class Module(LinodeModuleBase):
                 "label",
                 "allow_list",
                 "cluster_size",
+                "engine_config",
                 "updates",
                 "type",
                 "version",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
-linode-api4>=5.29.0
+# TODO (Configurable DB Params): Uncomment after feature released in Python SDK
+# linode-api4>=5.29.0
+
+# Temporarily commented out while waiting for merge of https://github.com/linode/linode_api4-python/pull/542
+# git+https://github.com/linode/linode_api4-python.git@proj/configurable-db-params
+
+git+https://github.com/lgarber-akamai/linode_api4-python.git@fix/config-request-url
+
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
 # TODO (Configurable DB Params): Uncomment after feature released in Python SDK
 # linode-api4>=5.29.0
-
-# Temporarily commented out while waiting for merge of https://github.com/linode/linode_api4-python/pull/542
-# git+https://github.com/linode/linode_api4-python.git@proj/configurable-db-params
-
-git+https://github.com/lgarber-akamai/linode_api4-python.git@fix/config-request-url
+git+https://github.com/linode/linode_api4-python.git@proj/configurable-db-params
 
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/tests/integration/targets/database_config_info/tasks/main.yaml
+++ b/tests/integration/targets/database_config_info/tasks/main.yaml
@@ -13,6 +13,34 @@
           - get_database_config_mysql.config.mysql.innodb_flush_neighbors.type == "integer"
           - get_database_config_mysql.config.mysql.innodb_flush_neighbors.description != None
 
+    - name: Assert MySQL config structure and types
+      assert:
+        that:
+          - get_database_config_mysql.config.mysql.connect_timeout.type == "integer"
+          - get_database_config_mysql.config.mysql.default_time_zone.type == "string"
+          - get_database_config_mysql.config.mysql.group_concat_max_len.type == "integer"
+          - get_database_config_mysql.config.mysql.information_schema_stats_expiry.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_change_buffer_max_size.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_flush_neighbors.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_ft_min_token_size.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_lock_wait_timeout.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_log_buffer_size.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_online_alter_log_max_size.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_read_io_threads.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_rollback_on_timeout.type == "boolean"
+          - get_database_config_mysql.config.mysql.innodb_thread_concurrency.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_write_io_threads.type == "integer"
+          - get_database_config_mysql.config.mysql.interactive_timeout.type == "integer"
+          - get_database_config_mysql.config.mysql.max_allowed_packet.type == "integer"
+          - get_database_config_mysql.config.mysql.max_heap_table_size.type == "integer"
+          - get_database_config_mysql.config.mysql.net_buffer_length.type == "integer"
+          - get_database_config_mysql.config.mysql.net_read_timeout.type == "integer"
+          - get_database_config_mysql.config.mysql.net_write_timeout.type == "integer"
+          - get_database_config_mysql.config.mysql.sql_mode.type == "string"
+          - get_database_config_mysql.config.mysql.sql_require_primary_key.type == "boolean"
+          - get_database_config_mysql.config.mysql.tmp_table_size.type == "integer"
+          - get_database_config_mysql.config.mysql.wait_timeout.type == "integer"
+
     - name: Get all available configuration fields for PostgreSQL databases
       linode.cloud.database_config_info:
         engine: postgresql
@@ -25,6 +53,40 @@
           - get_database_config_postgresql.config.pg.bgwriter_lru_multiplier.description != None
           - get_database_config_postgresql.config.pglookout.max_failover_replication_time_lag.type == "integer"
           - get_database_config_postgresql.config.pglookout.max_failover_replication_time_lag.description != None
+
+    - name: Assert types of PostgreSQL config values
+      assert:
+        that:
+          - get_database_config_postgresql.config.pg.autovacuum_analyze_scale_factor.type == "number"
+          - get_database_config_postgresql.config.pg.autovacuum_analyze_threshold.type == "integer"
+          - get_database_config_postgresql.config.pg.autovacuum_max_workers.type == "integer"
+          - get_database_config_postgresql.config.pg.autovacuum_naptime.type == "integer"
+          - get_database_config_postgresql.config.pg.autovacuum_vacuum_cost_delay.type == "integer"
+          - get_database_config_postgresql.config.pg.autovacuum_vacuum_cost_limit.type == "integer"
+          - get_database_config_postgresql.config.pg.autovacuum_vacuum_scale_factor.type == "number"
+          - get_database_config_postgresql.config.pg.autovacuum_vacuum_threshold.type == "integer"
+          - get_database_config_postgresql.config.pg.bgwriter_delay.type == "integer"
+          - get_database_config_postgresql.config.pg.bgwriter_flush_after.type == "integer"
+          - get_database_config_postgresql.config.pg.bgwriter_lru_maxpages.type == "integer"
+          - get_database_config_postgresql.config.pg.bgwriter_lru_multiplier.type == "number"
+          - get_database_config_postgresql.config.pg.deadlock_timeout.type == "integer"
+          - get_database_config_postgresql.config.pg.default_toast_compression.type == "string"
+          - get_database_config_postgresql.config.pg.idle_in_transaction_session_timeout.type == "integer"
+          - get_database_config_postgresql.config.pg.jit.type == "boolean"
+          - get_database_config_postgresql.config.pg.max_files_per_process.type == "integer"
+          - get_database_config_postgresql.config.pg.max_locks_per_transaction.type == "integer"
+          - get_database_config_postgresql.config.pg.max_logical_replication_workers.type == "integer"
+          - get_database_config_postgresql.config.pg.max_parallel_workers.type == "integer"
+          - get_database_config_postgresql.config.pg.max_parallel_workers_per_gather.type == "integer"
+          - get_database_config_postgresql.config.pg.max_pred_locks_per_transaction.type == "integer"
+          - get_database_config_postgresql.config.pg.max_replication_slots.type == "integer"
+          - get_database_config_postgresql.config.pg.max_slot_wal_keep_size.type == "integer"
+          - get_database_config_postgresql.config.pg.max_stack_depth.type == "integer"
+          - get_database_config_postgresql.config.pg.max_standby_archive_delay.type == "integer"
+          - get_database_config_postgresql.config.pg.max_standby_streaming_delay.type == "integer"
+          - get_database_config_postgresql.config.pg.max_wal_senders.type == "integer"
+          - get_database_config_postgresql.config.pg.max_worker_processes.type == "integer"
+          - get_database_config_postgresql.config.pg.password_encryption.default == "md5"
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/database_config_info/tasks/main.yaml
+++ b/tests/integration/targets/database_config_info/tasks/main.yaml
@@ -1,0 +1,34 @@
+- name: database_config_info
+  block:
+    - name: Get all available configuration fields for MySQL databases
+      linode.cloud.database_config_info:
+        engine: mysql
+      register: get_database_config_mysql
+
+    - name: Assert the returned MySQL configuration fields match the expected schema
+      assert:
+        that:
+          - get_database_config_mysql.config.binlog_retention_period.type == "integer"
+          - get_database_config_mysql.config.binlog_retention_period.description != None
+          - get_database_config_mysql.config.mysql.innodb_flush_neighbors.type == "integer"
+          - get_database_config_mysql.config.mysql.innodb_flush_neighbors.description != None
+
+    - name: Get all available configuration fields for PostgreSQL databases
+      linode.cloud.database_config_info:
+        engine: postgresql
+      register: get_database_config_postgresql
+
+    - name: Assert the returned PostgreSQL configuration fields match the expected schema
+      assert:
+        that:
+          - get_database_config_postgresql.config.pg.bgwriter_lru_multiplier.type == "number"
+          - get_database_config_postgresql.config.pg.bgwriter_lru_multiplier.description != None
+          - get_database_config_postgresql.config.pglookout.max_failover_replication_time_lag.type == "integer"
+          - get_database_config_postgresql.config.pglookout.max_failover_replication_time_lag.description != None
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/database_mysql_v2_engine_config/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_engine_config/tasks/main.yaml
@@ -1,0 +1,272 @@
+- name: database_mysql_v2_engine_config
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: List regions
+      linode.cloud.region_list: {}
+      register: all_regions
+
+    - set_fact:
+        target_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Databases") | list)[0]["id"] }}'
+
+    - name: Get an available MySQL engine
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: mysql
+      register: available_engines
+
+    - name: Assert available database_engine_list
+      assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ available_engines.database_engines[0]['id'] }}"
+
+    - name: Create a database with an explicit engine_config
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        cluster_size: 1
+        engine_config:
+          binlog_retention_period: 600
+          mysql:
+            connect_timeout: 20
+            default_time_zone: "+00:00"
+            group_concat_max_len: 1024
+            information_schema_stats_expiry: 900
+            innodb_change_buffer_max_size: 25
+            innodb_flush_neighbors: 1
+            innodb_ft_min_token_size: 3
+            innodb_ft_server_stopword_table: "db_name/table_name"
+            innodb_lock_wait_timeout: 50
+            innodb_log_buffer_size: 16777216
+            innodb_online_alter_log_max_size: 134217728
+            innodb_read_io_threads: 4
+            innodb_rollback_on_timeout: True
+            innodb_thread_concurrency: 8
+            innodb_write_io_threads: 4
+            interactive_timeout: 300
+            internal_tmp_mem_storage_engine: "TempTable"
+            max_allowed_packet: 67108864
+            max_heap_table_size: 16777216
+            net_buffer_length: 16384
+            net_read_timeout: 30
+            net_write_timeout: 60
+            sort_buffer_size: 262144
+            sql_mode: "TRADITIONAL"
+            sql_require_primary_key: False
+            tmp_table_size: 16777216
+            wait_timeout: 28800
+        state: present
+      register: db_create
+
+    - name: Assert database is created
+      assert:
+        that:
+          - db_create.changed
+          - db_create.database.status == 'active'
+          - db_create.database.cluster_size == 1
+          - db_create.database.engine == 'mysql'
+          - db_create.database.region == target_region
+          - db_create.database.engine_config.binlog_retention_period == 600
+          - db_create.database.engine_config.mysql.connect_timeout == 20
+          - db_create.database.engine_config.mysql.default_time_zone == "+00:00"
+          - db_create.database.engine_config.mysql.group_concat_max_len == 1024
+          - db_create.database.engine_config.mysql.information_schema_stats_expiry == 900
+          - db_create.database.engine_config.mysql.innodb_change_buffer_max_size == 25
+          - db_create.database.engine_config.mysql.innodb_flush_neighbors == 1
+          - db_create.database.engine_config.mysql.innodb_ft_min_token_size == 3
+          - db_create.database.engine_config.mysql.innodb_ft_server_stopword_table == "db_name/table_name"
+          - db_create.database.engine_config.mysql.innodb_lock_wait_timeout == 50
+          - db_create.database.engine_config.mysql.innodb_log_buffer_size == 16777216
+          - db_create.database.engine_config.mysql.innodb_online_alter_log_max_size == 134217728
+          - db_create.database.engine_config.mysql.innodb_read_io_threads == 4
+          - db_create.database.engine_config.mysql.innodb_rollback_on_timeout == True
+          - db_create.database.engine_config.mysql.innodb_thread_concurrency == 8
+          - db_create.database.engine_config.mysql.innodb_write_io_threads == 4
+          - db_create.database.engine_config.mysql.interactive_timeout == 300
+          - db_create.database.engine_config.mysql.internal_tmp_mem_storage_engine == "TempTable"
+          - db_create.database.engine_config.mysql.max_allowed_packet == 67108864
+          - db_create.database.engine_config.mysql.max_heap_table_size == 16777216
+          - db_create.database.engine_config.mysql.net_buffer_length == 16384
+          - db_create.database.engine_config.mysql.net_read_timeout == 30
+          - db_create.database.engine_config.mysql.net_write_timeout == 60
+          - db_create.database.engine_config.mysql.sort_buffer_size == 262144
+          - db_create.database.engine_config.mysql.sql_mode == "TRADITIONAL"
+          - db_create.database.engine_config.mysql.sql_require_primary_key == False
+          - db_create.database.engine_config.mysql.tmp_table_size == 16777216
+          - db_create.database.engine_config.mysql.wait_timeout == 28800
+
+    - name: Update the database's engine_config
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        engine_config:
+          binlog_retention_period: 601
+          mysql:
+            connect_timeout: 21
+            default_time_zone: "+01:00"
+            group_concat_max_len: 1023
+            information_schema_stats_expiry: 901
+            innodb_change_buffer_max_size: 26
+            innodb_flush_neighbors: 2
+            innodb_ft_min_token_size: 4
+            innodb_ft_server_stopword_table: "db_name/table_name"
+            innodb_lock_wait_timeout: 51
+            innodb_log_buffer_size: 16777215
+            innodb_online_alter_log_max_size: 134217721
+            innodb_read_io_threads: 3
+            innodb_rollback_on_timeout: False
+            innodb_thread_concurrency: 6
+            innodb_write_io_threads: 5
+            interactive_timeout: 299
+            internal_tmp_mem_storage_engine: "MEMORY"
+            max_allowed_packet: 67108863
+            max_heap_table_size: 16777211
+            net_buffer_length: 8192
+            net_read_timeout: 29
+            net_write_timeout: 59
+            sort_buffer_size: 262141
+            sql_mode: "TRADITIONAL"
+            sql_require_primary_key: True
+            tmp_table_size: 16777215
+            wait_timeout: 28799
+        state: present
+      register: db_update
+
+    - name: Assert database is updated
+      assert:
+        that:
+          - db_update.changed
+          - db_update.database.status == 'active'
+          - db_update.database.cluster_size == 1
+          - db_update.database.engine == 'mysql'
+          - db_update.database.region == target_region
+          - db_update.database.type == 'g6-nanode-1'
+          - db_update.database.engine_config.binlog_retention_period == 601
+          - db_update.database.engine_config.mysql.connect_timeout == 21
+          - db_update.database.engine_config.mysql.default_time_zone == "+01:00"
+          - db_update.database.engine_config.mysql.group_concat_max_len == 1023
+          - db_update.database.engine_config.mysql.information_schema_stats_expiry == 901
+          - db_update.database.engine_config.mysql.innodb_change_buffer_max_size == 26
+          - db_update.database.engine_config.mysql.innodb_flush_neighbors == 2
+          - db_update.database.engine_config.mysql.innodb_ft_min_token_size == 4
+          - db_update.database.engine_config.mysql.innodb_ft_server_stopword_table == "db_name/table_name"
+          - db_update.database.engine_config.mysql.innodb_lock_wait_timeout == 51
+          - db_update.database.engine_config.mysql.innodb_log_buffer_size == 16777215
+          - db_update.database.engine_config.mysql.innodb_online_alter_log_max_size == 134217721
+          - db_update.database.engine_config.mysql.innodb_read_io_threads == 3
+          - db_update.database.engine_config.mysql.innodb_rollback_on_timeout == False
+          - db_update.database.engine_config.mysql.innodb_thread_concurrency == 6
+          - db_update.database.engine_config.mysql.innodb_write_io_threads == 5
+          - db_update.database.engine_config.mysql.interactive_timeout == 299
+          - db_update.database.engine_config.mysql.internal_tmp_mem_storage_engine == "MEMORY"
+          - db_update.database.engine_config.mysql.max_allowed_packet == 67108863
+          - db_update.database.engine_config.mysql.max_heap_table_size == 16777211
+          - db_update.database.engine_config.mysql.net_buffer_length == 8192
+          - db_update.database.engine_config.mysql.net_read_timeout == 29
+          - db_update.database.engine_config.mysql.net_write_timeout == 59
+          - db_update.database.engine_config.mysql.sort_buffer_size == 262141
+          - db_update.database.engine_config.mysql.sql_mode == "TRADITIONAL"
+          - db_update.database.engine_config.mysql.sql_require_primary_key == True
+          - db_update.database.engine_config.mysql.tmp_table_size == 16777215
+          - db_update.database.engine_config.mysql.wait_timeout == 28799
+
+    - name: Refresh the database
+      linode.cloud.database_mysql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        engine_config:
+          binlog_retention_period: 601
+          mysql:
+            connect_timeout: 21
+            default_time_zone: "+01:00"
+            group_concat_max_len: 1023
+            information_schema_stats_expiry: 901
+            innodb_change_buffer_max_size: 26
+            innodb_flush_neighbors: 2
+            innodb_ft_min_token_size: 4
+            innodb_ft_server_stopword_table: "db_name/table_name"
+            innodb_lock_wait_timeout: 51
+            innodb_log_buffer_size: 16777215
+            innodb_online_alter_log_max_size: 134217721
+            innodb_read_io_threads: 3
+            innodb_rollback_on_timeout: False
+            innodb_thread_concurrency: 6
+            innodb_write_io_threads: 5
+            interactive_timeout: 299
+            internal_tmp_mem_storage_engine: "MEMORY"
+            max_allowed_packet: 67108863
+            max_heap_table_size: 16777211
+            net_buffer_length: 8192
+            net_read_timeout: 29
+            net_write_timeout: 59
+            sort_buffer_size: 262141
+            sql_mode: "TRADITIONAL"
+            sql_require_primary_key: True
+            tmp_table_size: 16777215
+            wait_timeout: 28799
+        state: present
+      register: db_refresh
+
+    - name: Assert database is unchanged
+      assert:
+        that:
+          - not db_refresh.changed
+          - db_refresh.database.status == 'active'
+          - db_refresh.database.cluster_size == 1
+          - db_refresh.database.engine == 'mysql'
+          - db_refresh.database.region == target_region
+          - db_refresh.database.type == 'g6-nanode-1'
+          - db_refresh.database.engine_config.binlog_retention_period == 601
+          - db_refresh.database.engine_config.mysql.connect_timeout == 21
+          - db_refresh.database.engine_config.mysql.default_time_zone == "+01:00"
+          - db_refresh.database.engine_config.mysql.group_concat_max_len == 1023
+          - db_refresh.database.engine_config.mysql.information_schema_stats_expiry == 901
+          - db_refresh.database.engine_config.mysql.innodb_change_buffer_max_size == 26
+          - db_refresh.database.engine_config.mysql.innodb_flush_neighbors == 2
+          - db_refresh.database.engine_config.mysql.innodb_ft_min_token_size == 4
+          - db_refresh.database.engine_config.mysql.innodb_ft_server_stopword_table == "db_name/table_name"
+          - db_refresh.database.engine_config.mysql.innodb_lock_wait_timeout == 51
+          - db_refresh.database.engine_config.mysql.innodb_log_buffer_size == 16777215
+          - db_refresh.database.engine_config.mysql.innodb_online_alter_log_max_size == 134217721
+          - db_refresh.database.engine_config.mysql.innodb_read_io_threads == 3
+          - db_refresh.database.engine_config.mysql.innodb_rollback_on_timeout == False
+          - db_refresh.database.engine_config.mysql.innodb_thread_concurrency == 6
+          - db_refresh.database.engine_config.mysql.innodb_write_io_threads == 5
+          - db_refresh.database.engine_config.mysql.interactive_timeout == 299
+          - db_refresh.database.engine_config.mysql.internal_tmp_mem_storage_engine == "MEMORY"
+          - db_refresh.database.engine_config.mysql.max_allowed_packet == 67108863
+          - db_refresh.database.engine_config.mysql.max_heap_table_size == 16777211
+          - db_refresh.database.engine_config.mysql.net_buffer_length == 8192
+          - db_refresh.database.engine_config.mysql.net_read_timeout == 29
+          - db_refresh.database.engine_config.mysql.net_write_timeout == 59
+          - db_refresh.database.engine_config.mysql.sort_buffer_size == 262141
+          - db_refresh.database.engine_config.mysql.sql_mode == "TRADITIONAL"
+          - db_refresh.database.engine_config.mysql.sql_require_primary_key == True
+          - db_refresh.database.engine_config.mysql.tmp_table_size == 16777215
+          - db_refresh.database.engine_config.mysql.wait_timeout == 28799
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Delete the original database
+          linode.cloud.database_mysql_v2:
+            label: '{{ db_create.database.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/database_mysql_v2_engine_config/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_engine_config/tasks/main.yaml
@@ -42,7 +42,7 @@
             innodb_change_buffer_max_size: 25
             innodb_flush_neighbors: 1
             innodb_ft_min_token_size: 3
-            innodb_ft_server_stopword_table: "db_name/table_name"
+            innodb_ft_server_stopword_table: # check if this value can be null
             innodb_lock_wait_timeout: 50
             innodb_log_buffer_size: 16777216
             innodb_online_alter_log_max_size: 134217728
@@ -81,7 +81,7 @@
           - db_create.database.engine_config.mysql.innodb_change_buffer_max_size == 25
           - db_create.database.engine_config.mysql.innodb_flush_neighbors == 1
           - db_create.database.engine_config.mysql.innodb_ft_min_token_size == 3
-          - db_create.database.engine_config.mysql.innodb_ft_server_stopword_table == "db_name/table_name"
+          - db_create.database.engine_config.mysql.get('innodb_ft_server_stopword_table', None) is none
           - db_create.database.engine_config.mysql.innodb_lock_wait_timeout == 50
           - db_create.database.engine_config.mysql.innodb_log_buffer_size == 16777216
           - db_create.database.engine_config.mysql.innodb_online_alter_log_max_size == 134217728
@@ -101,6 +101,11 @@
           - db_create.database.engine_config.mysql.sql_require_primary_key == False
           - db_create.database.engine_config.mysql.tmp_table_size == 16777216
           - db_create.database.engine_config.mysql.wait_timeout == 28800
+
+    - name: Assert nullable field safely returns null
+      assert:
+        that:
+          - db_create.database.engine_config.mysql.get('innodb_ft_server_stopword_table', None) is none
 
     - name: Update the database's engine_config
       linode.cloud.database_mysql_v2:

--- a/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
+++ b/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
@@ -25,30 +25,6 @@
     - set_fact:
         engine_id: "{{ (available_engines.database_engines | sort(attribute='version', reverse=True))[0]['id'] }}"
 
-    - set_fact:
-        pg13_engine_id: "{{ (available_engines.database_engines | sort(attribute='version', reverse=False))[0]['id'] }}"
-
-    - name: Returns error to Create postgres13 database with compression algo lv4
-      linode.cloud.database_postgresql_v2:
-        label: "ansible-test-{{ r }}"
-        region: "{{ target_region }}"
-        engine: "{{ pg13_engine_id }}"
-        type: g6-nanode-1
-        cluster_size: 1
-        engine_config:
-          pg:
-            default_toast_compression: "lz4"
-        state: present
-      register: db_result
-      failed_when: false  # Prevents Ansible from stopping play used for negative test cases
-
-    - name: Assert the error message includes default_toast_compression version check
-      assert:
-        that:
-          - db_result.msg is search("default_toast_compression")
-          - db_result.msg is search("version 14")
-        fail_msg: "Expected failure on default_toast_compression for version < 14 not found"
-
     - name: Create a database with an explicit engine_config
       linode.cloud.database_postgresql_v2:
         label: "ansible-test-{{ r }}"

--- a/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
+++ b/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
@@ -1,0 +1,376 @@
+- name: database_postgresql_v2_engine_config
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: List regions
+      linode.cloud.region_list: {}
+      register: all_regions
+
+    - set_fact:
+        target_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Databases") | list)[0]["id"] }}'
+
+    - name: Get an available PostgreSQL engine
+      linode.cloud.database_engine_list:
+        filters:
+          - name: engine
+            values: postgresql
+      register: available_engines
+
+    - name: Assert available database_engine_list
+      assert:
+        that:
+          - available_engines.database_engines | length >= 1
+
+    - set_fact:
+        engine_id: "{{ (available_engines.database_engines | sort(attribute='version', reverse=True))[0]['id'] }}"
+
+    - name: Create a database with an explicit engine_config
+      linode.cloud.database_postgresql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        cluster_size: 1
+        engine_config:
+          pg:
+            autovacuum_analyze_scale_factor: 0.1
+            autovacuum_analyze_threshold: 50
+            autovacuum_max_workers: 3
+            autovacuum_naptime: 60
+            autovacuum_vacuum_cost_delay: 20
+            autovacuum_vacuum_cost_limit: 200
+            autovacuum_vacuum_scale_factor: 0.2
+            autovacuum_vacuum_threshold: 50
+            bgwriter_delay: 200
+            bgwriter_flush_after: 64
+            bgwriter_lru_maxpages: 100
+            bgwriter_lru_multiplier: 2.0
+            deadlock_timeout: 1000
+            default_toast_compression: "lz4"
+            idle_in_transaction_session_timeout: 600000
+            jit: true
+            max_files_per_process: 1000
+            max_locks_per_transaction: 64
+            max_logical_replication_workers: 4
+            max_parallel_workers: 4
+            max_parallel_workers_per_gather: 2
+            max_pred_locks_per_transaction: 64
+            max_replication_slots: 10
+            max_slot_wal_keep_size: 2048
+            max_stack_depth: 6291456
+            max_standby_archive_delay: 30000
+            max_standby_streaming_delay: 30000
+            max_wal_senders: 20
+            max_worker_processes: 8
+            password_encryption: "scram-sha-256"
+            temp_file_limit: 1
+            timezone: "UTC"
+            track_activity_query_size: 2048
+            track_functions: "all"
+            wal_sender_timeout: 60000
+            wal_writer_delay: 200
+            pg_partman_bgw.interval: 3600
+            pg_partman_bgw.role: "myrolename"
+            pg_stat_monitor.pgsm_enable_query_plan: true
+            pg_stat_monitor.pgsm_max_buckets: 2
+            pg_stat_statements.track: "top"
+          pglookout:
+            max_failover_replication_time_lag: 10
+          pg_stat_monitor_enable: true
+          shared_buffers_percentage: 25.0
+          work_mem: 1024
+        state: present
+      register: db_create
+
+    - name: Assert database is created
+      assert:
+        that:
+          - db_create.changed
+          - db_create.database.status == 'active'
+          - db_create.database.cluster_size == 1
+          - db_create.database.engine == 'postgresql'
+          - db_create.database.region == target_region
+          - db_create.database.engine_config.pg.autovacuum_analyze_scale_factor == 0.1
+          - db_create.database.engine_config.pg.autovacuum_analyze_threshold == 50
+          - db_create.database.engine_config.pg.autovacuum_max_workers == 3
+          - db_create.database.engine_config.pg.autovacuum_naptime == 60
+          - db_create.database.engine_config.pg.autovacuum_vacuum_cost_delay == 20
+          - db_create.database.engine_config.pg.autovacuum_vacuum_cost_limit == 200
+          - db_create.database.engine_config.pg.autovacuum_vacuum_scale_factor == 0.2
+          - db_create.database.engine_config.pg.autovacuum_vacuum_threshold == 50
+          - db_create.database.engine_config.pg.bgwriter_delay == 200
+          - db_create.database.engine_config.pg.bgwriter_flush_after == 64
+          - db_create.database.engine_config.pg.bgwriter_lru_maxpages == 100
+          - db_create.database.engine_config.pg.bgwriter_lru_multiplier == 2.0
+          - db_create.database.engine_config.pg.deadlock_timeout == 1000
+          - db_create.database.engine_config.pg.default_toast_compression == "lz4"
+          - db_create.database.engine_config.pg.idle_in_transaction_session_timeout == 600000
+          - db_create.database.engine_config.pg.jit == true
+          - db_create.database.engine_config.pg.max_files_per_process == 1000
+          - db_create.database.engine_config.pg.max_locks_per_transaction == 64
+          - db_create.database.engine_config.pg.max_logical_replication_workers == 4
+          - db_create.database.engine_config.pg.max_parallel_workers == 4
+          - db_create.database.engine_config.pg.max_parallel_workers_per_gather == 2
+          - db_create.database.engine_config.pg.max_pred_locks_per_transaction == 64
+          - db_create.database.engine_config.pg.max_replication_slots == 10
+          - db_create.database.engine_config.pg.max_slot_wal_keep_size == 2048
+          - db_create.database.engine_config.pg.max_stack_depth == 6291456
+          - db_create.database.engine_config.pg.max_standby_archive_delay == 30000
+          - db_create.database.engine_config.pg.max_standby_streaming_delay == 30000
+          - db_create.database.engine_config.pg.max_wal_senders == 20
+          - db_create.database.engine_config.pg.max_worker_processes == 8
+          - db_create.database.engine_config.pg.password_encryption == "scram-sha-256"
+          - db_create.database.engine_config.pg.temp_file_limit == 1
+          - db_create.database.engine_config.pg.timezone == "UTC"
+          - db_create.database.engine_config.pg.track_activity_query_size == 2048
+          - db_create.database.engine_config.pg.track_functions == "all"
+          - db_create.database.engine_config.pg.wal_sender_timeout == 60000
+          - db_create.database.engine_config.pg.wal_writer_delay == 200
+          - db_create.database.engine_config.pg["pg_partman_bgw.interval"] == 3600
+          - db_create.database.engine_config.pg["pg_partman_bgw.role"] == "myrolename"
+          - db_create.database.engine_config.pg["pg_stat_monitor.pgsm_enable_query_plan"] == true
+          - db_create.database.engine_config.pg["pg_stat_monitor.pgsm_max_buckets"] == 2
+          - db_create.database.engine_config.pg["pg_stat_statements.track"] == "top"
+          - db_create.database.engine_config.pglookout.max_failover_replication_time_lag == 10
+          - db_create.database.engine_config.pg_stat_monitor_enable == true
+          - db_create.database.engine_config.shared_buffers_percentage == 25.0
+          - db_create.database.engine_config.work_mem == 1024
+
+    - name: Update the database's engine_config
+      linode.cloud.database_postgresql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        cluster_size: 1
+        engine_config:
+          pg:
+            autovacuum_analyze_scale_factor: 0.2
+            autovacuum_analyze_threshold: 51
+            autovacuum_max_workers: 2
+            autovacuum_naptime: 61
+            autovacuum_vacuum_cost_delay: 21
+            autovacuum_vacuum_cost_limit: 201
+            autovacuum_vacuum_scale_factor: 0.3
+            autovacuum_vacuum_threshold: 51
+            bgwriter_delay: 201
+            bgwriter_flush_after: 63
+            bgwriter_lru_maxpages: 99
+            bgwriter_lru_multiplier: 1.0
+            deadlock_timeout: 999
+            default_toast_compression: "lz4"
+            idle_in_transaction_session_timeout: 600001
+            jit: false
+            max_files_per_process: 1001
+            max_locks_per_transaction: 65
+            max_logical_replication_workers: 6
+            max_parallel_workers: 3
+            max_parallel_workers_per_gather: 4
+            max_pred_locks_per_transaction: 67
+            max_replication_slots: 9
+            max_slot_wal_keep_size: 1024
+            max_stack_depth: 6291455
+            max_standby_archive_delay: 30001
+            max_standby_streaming_delay: 30001
+            max_wal_senders: 21
+            max_worker_processes: 10
+            password_encryption: "md5"
+            temp_file_limit: 2
+            timezone: "America/New_York"
+            track_activity_query_size: 1024
+            track_functions: "pl"
+            wal_sender_timeout: 60001
+            wal_writer_delay: 199
+            pg_partman_bgw.interval: 3601
+            pg_partman_bgw.role: "myupdatedrolename"
+            pg_stat_monitor.pgsm_enable_query_plan: false
+            pg_stat_monitor.pgsm_max_buckets: 3
+            pg_stat_statements.track: "none"
+          pglookout:
+            max_failover_replication_time_lag: 13
+          pg_stat_monitor_enable: false
+          shared_buffers_percentage: 24.0
+          work_mem: 1023
+        state: present
+      register: db_update
+
+    - name: Assert database is updated
+      assert:
+        that:
+          - db_update.database.cluster_size == 1
+          - db_update.database.engine == 'postgresql'
+          - db_update.database.region == target_region
+          - db_update.database.status == 'active'
+          - db_update.database.engine_config.pg.autovacuum_analyze_scale_factor == 0.2
+          - db_update.database.engine_config.pg.autovacuum_analyze_threshold == 51
+          - db_update.database.engine_config.pg.autovacuum_max_workers == 2
+          - db_update.database.engine_config.pg.autovacuum_naptime == 61
+          - db_update.database.engine_config.pg.autovacuum_vacuum_cost_delay == 21
+          - db_update.database.engine_config.pg.autovacuum_vacuum_cost_limit == 201
+          - db_update.database.engine_config.pg.autovacuum_vacuum_scale_factor == 0.3
+          - db_update.database.engine_config.pg.autovacuum_vacuum_threshold == 51
+          - db_update.database.engine_config.pg.bgwriter_delay == 201
+          - db_update.database.engine_config.pg.bgwriter_flush_after == 63
+          - db_update.database.engine_config.pg.bgwriter_lru_maxpages == 99
+          - db_update.database.engine_config.pg.bgwriter_lru_multiplier == 1.0
+          - db_update.database.engine_config.pg.deadlock_timeout == 999
+          - db_update.database.engine_config.pg.default_toast_compression == "lz4"
+          - db_update.database.engine_config.pg.idle_in_transaction_session_timeout == 600001
+          - db_update.database.engine_config.pg.jit == false
+          - db_update.database.engine_config.pg.max_files_per_process == 1001
+          - db_update.database.engine_config.pg.max_locks_per_transaction == 65
+          - db_update.database.engine_config.pg.max_logical_replication_workers == 6
+          - db_update.database.engine_config.pg.max_parallel_workers == 3
+          - db_update.database.engine_config.pg.max_parallel_workers_per_gather == 4
+          - db_update.database.engine_config.pg.max_pred_locks_per_transaction == 67
+          - db_update.database.engine_config.pg.max_replication_slots == 9
+          - db_update.database.engine_config.pg.max_slot_wal_keep_size == 1024
+          - db_update.database.engine_config.pg.max_stack_depth == 6291455
+          - db_update.database.engine_config.pg.max_standby_archive_delay == 30001
+          - db_update.database.engine_config.pg.max_standby_streaming_delay == 30001
+          - db_update.database.engine_config.pg.max_wal_senders == 21
+          - db_update.database.engine_config.pg.max_worker_processes == 10
+          - db_update.database.engine_config.pg.password_encryption == "md5"
+          - db_update.database.engine_config.pg.temp_file_limit == 2
+          - db_update.database.engine_config.pg.timezone == "America/New_York"
+          - db_update.database.engine_config.pg.track_activity_query_size == 1024
+          - db_update.database.engine_config.pg.track_functions == "pl"
+          - db_update.database.engine_config.pg.wal_sender_timeout == 60001
+          - db_update.database.engine_config.pg.wal_writer_delay == 199
+          - db_update.database.engine_config.pg["pg_partman_bgw.interval"] == 3601
+          - db_update.database.engine_config.pg["pg_partman_bgw.role"] == "myupdatedrolename"
+          - db_update.database.engine_config.pg["pg_stat_monitor.pgsm_enable_query_plan"] == false
+          - db_update.database.engine_config.pg["pg_stat_monitor.pgsm_max_buckets"] == 3
+          - db_update.database.engine_config.pg["pg_stat_statements.track"] == "none"
+          - db_update.database.engine_config.pglookout.max_failover_replication_time_lag == 13
+          - db_update.database.engine_config.pg_stat_monitor_enable == false
+          - db_update.database.engine_config.shared_buffers_percentage == 24.0
+          - db_update.database.engine_config.work_mem == 1023
+
+    - name: Refresh the database
+      linode.cloud.database_postgresql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ engine_id }}"
+        type: g6-nanode-1
+        cluster_size: 1
+        engine_config:
+          pg:
+            autovacuum_analyze_scale_factor: 0.2
+            autovacuum_analyze_threshold: 51
+            autovacuum_max_workers: 2
+            autovacuum_naptime: 61
+            autovacuum_vacuum_cost_delay: 21
+            autovacuum_vacuum_cost_limit: 201
+            autovacuum_vacuum_scale_factor: 0.3
+            autovacuum_vacuum_threshold: 51
+            bgwriter_delay: 201
+            bgwriter_flush_after: 63
+            bgwriter_lru_maxpages: 99
+            bgwriter_lru_multiplier: 1.0
+            deadlock_timeout: 999
+            default_toast_compression: "lz4"
+            idle_in_transaction_session_timeout: 600001
+            jit: false
+            max_files_per_process: 1001
+            max_locks_per_transaction: 65
+            max_logical_replication_workers: 6
+            max_parallel_workers: 3
+            max_parallel_workers_per_gather: 4
+            max_pred_locks_per_transaction: 67
+            max_replication_slots: 9
+            max_slot_wal_keep_size: 1024
+            max_stack_depth: 6291455
+            max_standby_archive_delay: 30001
+            max_standby_streaming_delay: 30001
+            max_wal_senders: 21
+            max_worker_processes: 10
+            password_encryption: "md5"
+            temp_file_limit: 2
+            timezone: "America/New_York"
+            track_activity_query_size: 1024
+            track_functions: "pl"
+            wal_sender_timeout: 60001
+            wal_writer_delay: 199
+            pg_partman_bgw.interval: 3601
+            pg_partman_bgw.role: "myupdatedrolename"
+            pg_stat_monitor.pgsm_enable_query_plan: false
+            pg_stat_monitor.pgsm_max_buckets: 3
+            pg_stat_statements.track: "none"
+          pglookout:
+            max_failover_replication_time_lag: 13
+          pg_stat_monitor_enable: false
+          shared_buffers_percentage: 24.0
+          work_mem: 1023
+        state: present
+      register: db_refresh
+
+    - name: Assert database is refreshed
+      assert:
+        that:
+          - not db_refresh.changed
+          - db_refresh.database.cluster_size == 1
+          - db_refresh.database.engine == 'postgresql'
+          - db_refresh.database.region == target_region
+          - db_refresh.database.status == 'active'
+          - db_refresh.database.engine_config.pg.autovacuum_analyze_scale_factor == 0.2
+          - db_refresh.database.engine_config.pg.autovacuum_analyze_threshold == 51
+          - db_refresh.database.engine_config.pg.autovacuum_max_workers == 2
+          - db_refresh.database.engine_config.pg.autovacuum_naptime == 61
+          - db_refresh.database.engine_config.pg.autovacuum_vacuum_cost_delay == 21
+          - db_refresh.database.engine_config.pg.autovacuum_vacuum_cost_limit == 201
+          - db_refresh.database.engine_config.pg.autovacuum_vacuum_scale_factor == 0.3
+          - db_refresh.database.engine_config.pg.autovacuum_vacuum_threshold == 51
+          - db_refresh.database.engine_config.pg.bgwriter_delay == 201
+          - db_refresh.database.engine_config.pg.bgwriter_flush_after == 63
+          - db_refresh.database.engine_config.pg.bgwriter_lru_maxpages == 99
+          - db_refresh.database.engine_config.pg.bgwriter_lru_multiplier == 1.0
+          - db_refresh.database.engine_config.pg.deadlock_timeout == 999
+          - db_refresh.database.engine_config.pg.default_toast_compression == "lz4"
+          - db_refresh.database.engine_config.pg.idle_in_transaction_session_timeout == 600001
+          - db_refresh.database.engine_config.pg.jit == false
+          - db_refresh.database.engine_config.pg.max_files_per_process == 1001
+          - db_refresh.database.engine_config.pg.max_locks_per_transaction == 65
+          - db_refresh.database.engine_config.pg.max_logical_replication_workers == 6
+          - db_refresh.database.engine_config.pg.max_parallel_workers == 3
+          - db_refresh.database.engine_config.pg.max_parallel_workers_per_gather == 4
+          - db_refresh.database.engine_config.pg.max_pred_locks_per_transaction == 67
+          - db_refresh.database.engine_config.pg.max_replication_slots == 9
+          - db_refresh.database.engine_config.pg.max_slot_wal_keep_size == 1024
+          - db_refresh.database.engine_config.pg.max_stack_depth == 6291455
+          - db_refresh.database.engine_config.pg.max_standby_archive_delay == 30001
+          - db_refresh.database.engine_config.pg.max_standby_streaming_delay == 30001
+          - db_refresh.database.engine_config.pg.max_wal_senders == 21
+          - db_refresh.database.engine_config.pg.max_worker_processes == 10
+          - db_refresh.database.engine_config.pg.password_encryption == "md5"
+          - db_refresh.database.engine_config.pg.temp_file_limit == 2
+          - db_refresh.database.engine_config.pg.timezone == "America/New_York"
+          - db_refresh.database.engine_config.pg.track_activity_query_size == 1024
+          - db_refresh.database.engine_config.pg.track_functions == "pl"
+          - db_refresh.database.engine_config.pg.wal_sender_timeout == 60001
+          - db_refresh.database.engine_config.pg.wal_writer_delay == 199
+          - db_refresh.database.engine_config.pg["pg_partman_bgw.interval"] == 3601
+          - db_refresh.database.engine_config.pg["pg_partman_bgw.role"] == "myupdatedrolename"
+          - db_refresh.database.engine_config.pg["pg_stat_monitor.pgsm_enable_query_plan"] == false
+          - db_refresh.database.engine_config.pg["pg_stat_monitor.pgsm_max_buckets"] == 3
+          - db_refresh.database.engine_config.pg["pg_stat_statements.track"] == "none"
+          - db_refresh.database.engine_config.pglookout.max_failover_replication_time_lag == 13
+          - db_refresh.database.engine_config.pg_stat_monitor_enable == false
+          - db_refresh.database.engine_config.shared_buffers_percentage == 24.0
+          - db_refresh.database.engine_config.work_mem == 1023
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Delete the original database
+          linode.cloud.database_postgresql_v2:
+            label: '{{ db_create.database.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
+++ b/tests/integration/targets/database_postgresql_v2_engine_config/tasks/main.yaml
@@ -25,6 +25,30 @@
     - set_fact:
         engine_id: "{{ (available_engines.database_engines | sort(attribute='version', reverse=True))[0]['id'] }}"
 
+    - set_fact:
+        pg13_engine_id: "{{ (available_engines.database_engines | sort(attribute='version', reverse=False))[0]['id'] }}"
+
+    - name: Returns error to Create postgres13 database with compression algo lv4
+      linode.cloud.database_postgresql_v2:
+        label: "ansible-test-{{ r }}"
+        region: "{{ target_region }}"
+        engine: "{{ pg13_engine_id }}"
+        type: g6-nanode-1
+        cluster_size: 1
+        engine_config:
+          pg:
+            default_toast_compression: "lz4"
+        state: present
+      register: db_result
+      failed_when: false  # Prevents Ansible from stopping play used for negative test cases
+
+    - name: Assert the error message includes default_toast_compression version check
+      assert:
+        that:
+          - db_result.msg is search("default_toast_compression")
+          - db_result.msg is search("version 14")
+        fail_msg: "Expected failure on default_toast_compression for version < 14 not found"
+
     - name: Create a database with an explicit engine_config
       linode.cloud.database_postgresql_v2:
         label: "ansible-test-{{ r }}"
@@ -359,6 +383,9 @@
           - db_refresh.database.engine_config.pg_stat_monitor_enable == false
           - db_refresh.database.engine_config.shared_buffers_percentage == 24.0
           - db_refresh.database.engine_config.work_mem == 1023
+
+
+
 
   always:
     - ignore_errors: true


### PR DESCRIPTION
## 📝 Description

This pull request adds support for setting the `engine_config` field using the `linode.cloud.database_mysql_v2` and `linode.cloud.database_postgresql_v2` modules. Additionally, users can retrieve all valid configuration parameters using the new `linode.cloud.database_config_info` module.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make test-int TEST_ARGS="-v database_postgresql_v2_engine_config database_mysql_v2_engine_config database_config_info"
```

### Manual Testing

The following test steps assume you have pointed your local shell environment at a Linode API instance that supports configurable database parameters:

```shell
export LINODE_TOKEN=MY_TOKEN
export LINODE_API_TOKEN=$LINODE_TOKEN

export LINODE_API_URL=https://my.dev.api.linode.com/
export LINODE_CA=/path/to/my/cert.pem
```

You may also need to forcibly reinstall from this Ansible Collections `requirements.txt` to pick up the corresponding SDK changes.

### linode.cloud.database_config_info

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Retrieve all valid MySQL engine_config fields
      linode.cloud.database_config_info:
        engine: mysql
      register: mysql_config_fields

    - debug:
        var: mysql_config_fields
```

2. Ensure the output contains all `engine_config` valid fields for MySQL databases.

#### linode.cloud.database_mysql_v2

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a database with an explicit engine_config
      linode.cloud.database_mysql_v2:
        label: ansible-test-manual
        region: us-mia
        engine: "mysql/8"
        type: g6-nanode-1
        cluster_size: 1
        engine_config:
          binlog_retention_period: 600
          mysql:
            connect_timeout: 20
        state: present
        register: db_create

    - debug:
        var: db_create
```

2. Ensure the playbook runs successfully and the `engine_config` is included in the output.


#### linode.cloud.database_postgresql_v2

1. In an ansible_linode sandbox environment (e.g. dx-devenv), run the following playbook:

```yaml
---
- name: ansible_linode Sandbox Playbook
  hosts: localhost
  tasks:
    - name: Create a database with an explicit engine_config
      linode.cloud.database_postgresql_v2:
        label: ansible-test-manual
        region: us-mia
        engine: "postgresql/17"
        type: g6-nanode-1
        cluster_size: 1
        engine_config:
          pg:
            autovacuum_analyze_scale_factor: 0.2
          work_mem: 1024
        state: present
        register: db_create

    - debug:
        var: db_create
```

2. Ensure the playbook runs successfully and the `engine_config` is included in the output.