### PR TITLE
Support Object Storage Quota modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Name | Description |
 [linode.cloud.lke_version_info](./docs/modules/lke_version_info.md)|Get info about a Linode LKE Version.|
 [linode.cloud.nodebalancer_info](./docs/modules/nodebalancer_info.md)|Get info about a Linode Node Balancer.|
 [linode.cloud.object_cluster_info](./docs/modules/object_cluster_info.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
+[linode.cloud.object_storage_quota_info](./docs/modules/object_storage_quota_info.md)|Get info about a Linode Object Storage Quota.|
 [linode.cloud.placement_group_info](./docs/modules/placement_group_info.md)|Get info about a Linode Placement Group.|
 [linode.cloud.profile_info](./docs/modules/profile_info.md)|Get info about a Linode Profile.|
 [linode.cloud.region_info](./docs/modules/region_info.md)|Get info about a Linode Region.|
@@ -112,6 +113,7 @@ Name | Description |
 [linode.cloud.nodebalancer_type_list](./docs/modules/nodebalancer_type_list.md)|List and filter on Node Balancer Types.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.object_storage_endpoint_list](./docs/modules/object_storage_endpoint_list.md)|List and filter on Object Storage Endpoints.|
+[linode.cloud.object_storage_quota_list](./docs/modules/object_storage_quota_list.md)|List and filter on Object Storage Quotas.|
 [linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|
 [linode.cloud.region_list](./docs/modules/region_list.md)|List and filter on Regions.|
 [linode.cloud.ssh_key_list](./docs/modules/ssh_key_list.md)|List and filter on SSH Keys.|

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -76,19 +76,19 @@ Parameters
 
 
       **parent_group (type=str):**
-        \• parent group for keyed group.
+        \• parent group for keyed group
 
 
       **prefix (type=str):**
-        \• A keyed group name will start with this prefix.
+        \• A keyed group name will start with this prefix
 
 
       **separator (type=str, default=_):**
-        \• separator used to build the keyed group name.
+        \• separator used to build the keyed group name
 
 
       **key (type=str):**
-        \• The key from input dictionary used to generate groups.
+        \• The key from input dictionary used to generate groups
 
 
       **default_value (type=str):**
@@ -98,7 +98,7 @@ Parameters
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to :literal:`false` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
+        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
         \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
@@ -109,13 +109,13 @@ Parameters
 
 
   **leading_separator (type=boolean, default=True):**
-    \• Use in conjunction with :literal:`keyed\_groups`.
+    \• Use in conjunction with keyed\_groups.
 
     \• By default, a keyed group that does not have a prefix or a separator provided will have a name that starts with an underscore.
 
-    \• This is because the default prefix is :literal:`""` and the default separator is :literal:`"\_"`.
+    \• This is because the default prefix is "" and the default separator is "\_".
 
-    \• Set this option to :literal:`false` to omit the leading underscore (or other separator) if no prefix is given.
+    \• Set this option to False to omit the leading underscore (or other separator) if no prefix is given.
 
     \• If the group name is derived from a mapping the separator is still used to concatenate the items.
 

--- a/docs/inventory/instance.rst
+++ b/docs/inventory/instance.rst
@@ -76,19 +76,19 @@ Parameters
 
 
       **parent_group (type=str):**
-        \• parent group for keyed group
+        \• parent group for keyed group.
 
 
       **prefix (type=str):**
-        \• A keyed group name will start with this prefix
+        \• A keyed group name will start with this prefix.
 
 
       **separator (type=str, default=_):**
-        \• separator used to build the keyed group name
+        \• separator used to build the keyed group name.
 
 
       **key (type=str):**
-        \• The key from input dictionary used to generate groups
+        \• The key from input dictionary used to generate groups.
 
 
       **default_value (type=str):**
@@ -98,7 +98,7 @@ Parameters
 
 
       **trailing_separator (type=bool, default=True):**
-        \• Set this option to :literal:`False` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
+        \• Set this option to :literal:`false` to omit the :literal:`keyed\_groups[].separator` after the host variable when the value is an empty string.
 
         \• This option is mutually exclusive with :literal:`keyed\_groups[].default\_value`.
 
@@ -109,13 +109,13 @@ Parameters
 
 
   **leading_separator (type=boolean, default=True):**
-    \• Use in conjunction with keyed\_groups.
+    \• Use in conjunction with :literal:`keyed\_groups`.
 
     \• By default, a keyed group that does not have a prefix or a separator provided will have a name that starts with an underscore.
 
-    \• This is because the default prefix is "" and the default separator is "\_".
+    \• This is because the default prefix is :literal:`""` and the default separator is :literal:`"\_"`.
 
-    \• Set this option to False to omit the leading underscore (or other separator) if no prefix is given.
+    \• Set this option to :literal:`false` to omit the leading underscore (or other separator) if no prefix is given.
 
     \• If the group name is derived from a mapping the separator is still used to concatenate the items.
 

--- a/docs/modules/object_storage_quota_info.md
+++ b/docs/modules/object_storage_quota_info.md
@@ -1,0 +1,63 @@
+# object_storage_quota_info
+
+Get info about a Linode Object Storage Quota.
+
+WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get info about an Object Storage quota
+  linode.cloud.object_storage_quota_info: 
+    quota_id: obj-buckets-us-sea-1.linodeobjects.com
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `quota_id` | <center>`str`</center> | <center>**Required**</center> | The Quota ID of the Object Storage Quota to resolve.   |
+
+## Return Values
+
+- `object_storage_quota` - The returned Object Storage Quota.
+
+    - Sample Response:
+        ```json
+        {
+            "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+            "endpoint_type": "E1",
+            "quota_id": "obj-buckets-us-sea-1.linodeobjects.com",
+            "quota_limit": 1000,
+            "quota_name": "Number of Buckets",
+            "resource_metric": "bucket",
+            "s3_endpoint": "us-sea-1.linodeobjects.com"
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-quota) for a list of returned fields
+
+
+- `quota_usage` - The returned Quota Usage.
+
+    - Sample Response:
+        ```json
+        {
+            "quota_limit": 1000,
+            "usage": 0
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-quota-usage) for a list of returned fields
+
+

--- a/docs/modules/object_storage_quota_info.md
+++ b/docs/modules/object_storage_quota_info.md
@@ -2,8 +2,6 @@
 
 Get info about a Linode Object Storage Quota.
 
-WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
-
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -20,7 +18,6 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 - name: Get info about an Object Storage quota
   linode.cloud.object_storage_quota_info: 
     quota_id: obj-buckets-us-sea-1.linodeobjects.com
-
 ```
 
 

--- a/docs/modules/object_storage_quota_list.md
+++ b/docs/modules/object_storage_quota_list.md
@@ -2,8 +2,6 @@
 
 List and filter on Object Storage Quotas.
 
-WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
-
 - [Minimum Required Fields](#minimum-required-fields)
 - [Examples](#examples)
 - [Parameters](#parameters)
@@ -19,12 +17,10 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 ```yaml
 - name: List all of Object Storage Quotas for the current account
   linode.cloud.object_storage_quotas:
-    api_version: v4beta
     filters:
       - name: s3_endpoint
         values:
-          - es-mad-1.linodeobjects.com 
-
+          - es-mad-1.linodeobjects.com
 ```
 
 

--- a/docs/modules/object_storage_quota_list.md
+++ b/docs/modules/object_storage_quota_list.md
@@ -1,0 +1,76 @@
+# object_storage_quota_list
+
+List and filter on Object Storage Quotas.
+
+WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of Object Storage Quotas for the current account
+  linode.cloud.object_storage_quotas:
+    api_version: v4beta
+    filters:
+      - name: s3_endpoint
+        values:
+          - es-mad-1.linodeobjects.com 
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Object Storage Quotas in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Object Storage Quotas by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Object Storage Quotas.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Object Storage Quotas to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `object_storage_quotas` - The returned Object Storage Quotas.
+
+    - Sample Response:
+        ```json
+        [
+                {
+                    "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+                    "endpoint_type": "E1",
+                    "quota_id": "obj-buckets-es-mad-1.linodeobjects.com",
+                    "quota_limit": 1000,
+                    "quota_name": "Number of Buckets",
+                    "resource_metric": "bucket",
+                    "s3_endpoint": "es-mad-1.linodeobjects.com"
+                },
+                {
+                    "description": "Maximum number of bytes this customer is allowed to have on this endpoint",
+                    "endpoint_type": "E1",
+                    "quota_id": "obj-bytes-es-mad-1.linodeobjects.com",
+                    "quota_limit": 109951162777600,
+                    "quota_name": "Total Capacity",
+                    "resource_metric": "byte",
+                    "s3_endpoint": "es-mad-1.linodeobjects.com"
+                }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/object_storage_quota_info.py
+++ b/plugins/module_utils/doc_fragments/object_storage_quota_info.py
@@ -19,5 +19,4 @@ result_object_storage_quota_usage_samples = ['''{
 specdoc_examples = ['''
 - name: Get info about an Object Storage quota
   linode.cloud.object_storage_quota_info: 
-    quota_id: obj-buckets-us-sea-1.linodeobjects.com
-''']
+    quota_id: obj-buckets-us-sea-1.linodeobjects.com''']

--- a/plugins/module_utils/doc_fragments/object_storage_quota_info.py
+++ b/plugins/module_utils/doc_fragments/object_storage_quota_info.py
@@ -1,0 +1,23 @@
+"""Documentation fragments for the object_storage_quota_info module"""
+
+result_object_storage_quota_samples = ['''{
+    "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+    "endpoint_type": "E1",
+    "quota_id": "obj-buckets-us-sea-1.linodeobjects.com",
+    "quota_limit": 1000,
+    "quota_name": "Number of Buckets",
+    "resource_metric": "bucket",
+    "s3_endpoint": "us-sea-1.linodeobjects.com"
+}''']
+
+result_object_storage_quota_usage_samples = ['''{
+    "quota_limit": 1000,
+    "usage": 0
+}''']
+
+
+specdoc_examples = ['''
+- name: Get info about an Object Storage quota
+  linode.cloud.object_storage_quota_info: 
+    quota_id: obj-buckets-us-sea-1.linodeobjects.com
+''']

--- a/plugins/module_utils/doc_fragments/object_storage_quota_list.py
+++ b/plugins/module_utils/doc_fragments/object_storage_quota_list.py
@@ -3,12 +3,10 @@
 specdoc_examples = ['''
 - name: List all of Object Storage Quotas for the current account
   linode.cloud.object_storage_quotas:
-    api_version: v4beta
     filters:
       - name: s3_endpoint
         values:
-          - es-mad-1.linodeobjects.com 
-''']
+          - es-mad-1.linodeobjects.com''']
 
 result_object_storage_quotas_samples = ['''[
         {

--- a/plugins/module_utils/doc_fragments/object_storage_quota_list.py
+++ b/plugins/module_utils/doc_fragments/object_storage_quota_list.py
@@ -1,0 +1,32 @@
+"""Documentation fragments for the object_storage_quota_list module"""
+
+specdoc_examples = ['''
+- name: List all of Object Storage Quotas for the current account
+  linode.cloud.object_storage_quotas:
+    api_version: v4beta
+    filters:
+      - name: s3_endpoint
+        values:
+          - es-mad-1.linodeobjects.com 
+''']
+
+result_object_storage_quotas_samples = ['''[
+        {
+            "description": "Maximum number of buckets this customer is allowed to have on this endpoint",
+            "endpoint_type": "E1",
+            "quota_id": "obj-buckets-es-mad-1.linodeobjects.com",
+            "quota_limit": 1000,
+            "quota_name": "Number of Buckets",
+            "resource_metric": "bucket",
+            "s3_endpoint": "es-mad-1.linodeobjects.com"
+        },
+        {
+            "description": "Maximum number of bytes this customer is allowed to have on this endpoint",
+            "endpoint_type": "E1",
+            "quota_id": "obj-bytes-es-mad-1.linodeobjects.com",
+            "quota_limit": 109951162777600,
+            "quota_name": "Total Capacity",
+            "resource_metric": "byte",
+            "s3_endpoint": "es-mad-1.linodeobjects.com"
+        }
+]''']

--- a/plugins/module_utils/linode_common_list.py
+++ b/plugins/module_utils/linode_common_list.py
@@ -61,6 +61,7 @@ class ListModule(
         deprecation_message: Optional[str] = None,
         custom_options: Optional[Dict[str, SpecField]] = None,
         custom_field_resolver: Optional[callable] = None,
+        custom_api_filter_constructor: Optional[callable] = None,
     ) -> None:
         self.result_display_name = result_display_name
         self.result_field_name = result_field_name
@@ -68,6 +69,9 @@ class ListModule(
 
         # Store the custom field resolver, if provided
         self.custom_field_resolver = custom_field_resolver
+
+        # Store the custom api filter constructor, if provided
+        self.custom_api_filter_constructor = custom_api_filter_constructor
 
         self.result_docs_url = (
             result_docs_url
@@ -102,7 +106,12 @@ class ListModule(
         if self.deprecated:
             self.warn(self.deprecation_message)
 
-        filter_dict = construct_api_filter(self.module.params)
+        # Use custom API filter constructor if provided
+        filter_dict = (
+            self.custom_api_filter_constructor(self.module.params)
+            if self.custom_api_filter_constructor
+            else construct_api_filter(self.module.params)
+        )
 
         # Dynamically resolve fields if custom logic is provided
         if self.custom_field_resolver:

--- a/plugins/modules/object_storage_quota_info.py
+++ b/plugins/modules/object_storage_quota_info.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Object Storage Quota info."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    object_storage_quota_info as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import ObjectStorageQuota
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="Object Storage Quota",
+        field_name="object_storage_quota",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-quota",
+        samples=docs.result_object_storage_quota_samples,
+    ),
+    secondary_results=[
+        InfoModuleResult(
+            display_name="Quota Usage",
+            field_name="quota_usage",
+            field_type=FieldType.dict,
+            docs_url="https://techdocs.akamai.com/linode-api/reference"
+            "/get-object-storage-quota-usage",
+            samples=docs.result_object_storage_quota_usage_samples,
+            get=lambda client, object_storage_quota, params: ObjectStorageQuota(
+                client, object_storage_quota["quota_id"]
+            )
+            .usage()
+            .dict,
+        ),
+    ],
+    attributes=[
+        InfoModuleAttr(
+            name="quota_id",
+            display_name="Quota ID",
+            type=FieldType.string,
+            get=lambda client, params: client.load(
+                ObjectStorageQuota, params.get("quota_id")
+            )._raw_json,
+        ),
+    ],
+    requires_beta=True,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/object_storage_quota_info.py
+++ b/plugins/modules/object_storage_quota_info.py
@@ -50,7 +50,6 @@ module = InfoModule(
             )._raw_json,
         ),
     ],
-    requires_beta=True,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/object_storage_quota_list.py
+++ b/plugins/modules/object_storage_quota_list.py
@@ -20,6 +20,13 @@ def custom_api_filter_constructor(params: Dict[str, Any]) -> Dict[str, Any]:
     Customize a filter string for listing Object Storage Quota,
     because only a single basic filterable parameter can be supported currently by API.
     """
+    if params.get("order_by") is not None or params.get("order") is not None:
+        module.warn(
+            "order or order_by is currently not supported in listing object_storage_quotas, "
+            "and will be ignored if provided. "
+            "Please refer to the API documentation for more information."
+        )
+
     filters = params.get("filters")
 
     if filters is not None:
@@ -31,10 +38,6 @@ def custom_api_filter_constructor(params: Dict[str, Any]) -> Dict[str, Any]:
             "The filterable fields are limited. "
             "Please refer to the API documentation for more information."
         )
-
-    if params.get("order_by") is not None or params.get("order") is not None:
-        module.warn("[warning] order or order_by is currently not supported. "
-                    "Please refer to the API documentation for more information.")
 
     return {}
 

--- a/plugins/modules/object_storage_quota_list.py
+++ b/plugins/modules/object_storage_quota_list.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Object Storage Quotas."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Dict
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    object_storage_quota_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+
+def custom_api_filter_constructor(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Customize a filter string for listing Object Storage Quota,
+    because only a single basic filterable parameter can be supported currently by API.
+    """
+    filters = params.get("filters")
+
+    if filters is not None:
+        if len(filters) == 1 and len(filters[0]["values"]) == 1:
+            return {filters[0]["name"]: filters[0]["values"][0]}
+        module.fail(
+            "[error] The filter is not acceptable. "
+            "Only a single filterable parameter can be supported currently by API. "
+            "The filterable fields are limited. "
+            "Please refer to the API documentation for more information."
+        )
+
+    if params.get("order_by") is not None or params.get("order") is not None:
+        module.warn("[warning] order or order_by is currently not supported. "
+                    "Please refer to the API documentation for more information.")
+
+    return {}
+
+
+module = ListModule(
+    result_display_name="Object Storage Quotas",
+    result_field_name="object_storage_quotas",
+    endpoint_template="/object-storage/quotas",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas",
+    result_samples=docs.result_object_storage_quotas_samples,
+    examples=docs.specdoc_examples,
+    requires_beta=True,
+    custom_api_filter_constructor=custom_api_filter_constructor,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/object_storage_quota_list.py
+++ b/plugins/modules/object_storage_quota_list.py
@@ -49,7 +49,6 @@ module = ListModule(
     result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas",
     result_samples=docs.result_object_storage_quotas_samples,
     examples=docs.specdoc_examples,
-    requires_beta=True,
     custom_api_filter_constructor=custom_api_filter_constructor,
 )
 

--- a/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
@@ -1,0 +1,30 @@
+- name: object_storage_quota_info
+  block:
+    - name: List Object Storage Quotas
+      linode.cloud.object_storage_quota_list:
+        api_version: v4beta
+      register: obj_quota_list
+
+    - name: Assert at least one quota returned for the following test
+      assert:
+        that:
+          - obj_quota_list.object_storage_quotas | length > 0
+
+    - name: Get info about an Object Storage Quota
+      linode.cloud.object_storage_quota_info:
+        quota_id: '{{ obj_quota_list.object_storage_quotas[0].quota_id }}'
+        api_version: v4beta
+      register: obj_quota
+
+    - name: Assert GET Object Storage quota response
+      assert:
+        that:
+          - obj_quota.object_storage_quota.quota_id == obj_quota_list.object_storage_quotas[0].quota_id
+          - obj_quota.quota_usage.quota_limit
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
@@ -2,7 +2,6 @@
   block:
     - name: List Object Storage Quotas
       linode.cloud.object_storage_quota_list:
-        api_version: v4beta
       register: obj_quota_list
 
     - name: Assert at least one quota returned for the following test
@@ -13,7 +12,6 @@
     - name: Get info about an Object Storage Quota
       linode.cloud.object_storage_quota_info:
         quota_id: '{{ obj_quota_list.object_storage_quotas[0].quota_id }}'
-        api_version: v4beta
       register: obj_quota
 
     - name: Assert GET Object Storage quota response

--- a/tests/integration/targets/object_storage_quota_list/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_list/tasks/main.yaml
@@ -2,7 +2,6 @@
   block:
     - name: List and filter Object Storage Quotas by s3_endpoint
       linode.cloud.object_storage_quota_list:
-        api_version: v4beta
         filters:
           - name: s3_endpoint
             values:

--- a/tests/integration/targets/object_storage_quota_list/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_list/tasks/main.yaml
@@ -1,0 +1,23 @@
+- name: object_storage_quota_info
+  block:
+    - name: List and filter Object Storage Quotas by s3_endpoint
+      linode.cloud.object_storage_quota_list:
+        api_version: v4beta
+        filters:
+          - name: s3_endpoint
+            values:
+              - es-mad-1.linodeobjects.com
+      register: obj_quota_list
+
+    - name: Assert the quotas are listed and filtered correctly
+      assert:
+        that:
+          - obj_quota_list.object_storage_quotas | length > 0
+          - obj_quota_list.object_storage_quotas[0].s3_endpoint == "es-mad-1.linodeobjects.com"
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Add info and list modules for object storage quota features. 

## ✔️ How to Test

### Integration test
```
make test-int TEST_SUITE="object_storage_quota_list"
```
```
make test-int TEST_SUITE="object_storage_quota_info"
```

### Manual Test

1. In a sandbox environment, run the following config to list and filter object quotas
```yaml
    - name: List and filter Object Storage Quotas by s3_endpoint
      linode.cloud.object_storage_quota_list:
        api_version: v4beta
        filters:
          - name: s3_endpoint
            values:
              - es-mad-1.linodeobjects.com
      register: obj_quota_list
```
2. Use the following config to get info of a specific object storage quota
```yaml
    - name: Get info about an Object Storage Quota
      linode.cloud.object_storage_quota_info:
        quota_id: '{{ obj_quota_list.object_storage_quotas[0].quota_id }}'
        api_version: v4beta
```
3. Try to filter with a complex filter struct and expect error
```yaml
    - name: List and filter Object Storage Quotas
      linode.cloud.object_storage_quota_list:
        api_version: v4beta
        filters:
          - name: s3_endpoint
            values:
              - es-mad-1.linodeobjects.com
          - name: quota_name
            values:
              - Number of Buckets
      register: obj_quota_list
```