### PR TITLE
Update LDE Node Pool Assertion and Test env variable Handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,9 @@ else
 	exit 1;
 endif
 	@echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)
-	@echo "api_url: $(TEST_API_URL)" >> $(INTEGRATION_CONFIG)
-	@echo "api_version: $(TEST_API_VERSION)" >> $(INTEGRATION_CONFIG)
-	@echo "ca_file: $(TEST_API_CA)" >> $(INTEGRATION_CONFIG)
+	@echo "api_url: $${LINODE_API_URL:-$${TEST_API_URL:-https://api.linode.com/}}" >> $(INTEGRATION_CONFIG)
+	@echo "api_version: $${LINODE_API_VERSION:-$${TEST_API_VERSION:-v4beta}}" >> $(INTEGRATION_CONFIG)
+	@echo "ca_file: $${LINODE_CA:-$${TEST_API_CA}}" >> $(INTEGRATION_CONFIG)
 
 inject:
 	@echo "Injecting documentation into source files"

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ else
 	exit 1;
 endif
 	@echo "ua_prefix: E2E" >> $(INTEGRATION_CONFIG)
-	@echo "api_url: $${LINODE_API_URL:-$${TEST_API_URL:-https://api.linode.com/}}" >> $(INTEGRATION_CONFIG)
+	@echo "api_url: $$(url=$${LINODE_API_URL:-$${TEST_API_URL:-https://api.linode.com}}; echo $${url%/}/)" >> $(INTEGRATION_CONFIG)
 	@echo "api_version: $${LINODE_API_VERSION:-$${TEST_API_VERSION:-v4beta}}" >> $(INTEGRATION_CONFIG)
 	@echo "ca_file: $${LINODE_CA:-$${TEST_API_CA}}" >> $(INTEGRATION_CONFIG)
 

--- a/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_cluster_basic/tasks/main.yaml
@@ -179,7 +179,7 @@
           - info_by_label.node_pools[0].count == 1
           - info_by_label.node_pools[0].id == create_cluster.node_pools[0].id
 
-    - name: Create a Linode LKE cluster with a pool with disk encryption enabled
+    - name: Create a Linode LKE cluster with a pool has disk encryption explicitly set
       linode.cloud.lke_cluster:
         label: 'ansible-test-de-{{ r }}'
         region: '{{ lde_region }}'
@@ -194,7 +194,7 @@
     - name: Assert LKE cluster is created
       assert:
         that:
-          - create_cluster_disk_encryption.node_pools[0].disk_encryption == 'disabled'
+          - create_cluster_disk_encryption.node_pools[0].disk_encryption in ['enabled', 'disabled']
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
+++ b/tests/integration/targets/lke_node_pool_basic/tasks/main.yaml
@@ -148,7 +148,7 @@
         that:
           - new_pool_de.node_pool.count == 2
           - new_pool_de.node_pool.type == 'g6-standard-1'
-          - new_pool_de.node_pool.disk_encryption == 'disabled'
+          - new_pool_de.node_pool.disk_encryption in ['enabled', 'disabled']
           - new_pool_de.node_pool.nodes[0].status == 'ready'
           - new_pool_de.node_pool.nodes[1].status == 'ready'
 


### PR DESCRIPTION
## 📝 Description

Address assertion failure, changed it to be more flexible asserting if lde has an explicitly set value upon cluster creation

Now makefile uses LINODE_ env vars if set, falls back to TEST_ if not, and finally uses hardcoded defaults when neither is available — making the setup more consistent with other repositories


## ✔️ How to Test
Test environment variables:
```
# run it against alpha or staging
unset TEST_API_URL TEST_API_VERSION TEST_API_CA
export LINODE_TOKEN="token"
export TEST_API_URL="https://api.dev.linode.com" 
export LINODE_API_VERSION="v4beta"
export LINODE_CA="/tmp/test_ca.pem"

make test-int TEST_SUITE=api_request_basic

# unset these test vars
unset LINODE_API_URL LINODE_API_VERSION LINODE_CA

export LINODE_API_TOKEN="alpha_token"
export TEST_API_URL="https://api.dev.linode.com/"
export TEST_API_VERSION="v4beta"
export TEST_API_CA="/tmp/test_ca.pem"

make test-int TEST_SUITE=api_request_basic
```

Test LKE assertion changes:
```
make TEST_SUITE="lke_cluster_basic" test-int 
 make TEST_SUITE="lke_node_pool_basic" test-int
```


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**