### PR TITLE
Add interface as an allowed firewall device

### DIFF
--- a/docs/modules/firewall_device.md
+++ b/docs/modules/firewall_device.md
@@ -47,7 +47,7 @@ Manage Linode Firewall Devices.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `firewall_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the Firewall that contains this device.   |
 | `entity_id` | <center>`int`</center> | <center>**Required**</center> | The ID for this Firewall Device. This will be the ID of the Linode Entity.   |
-| `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode and nodebalancer.  **(Choices: `linode`, `nodebalancer`)** |
+| `entity_type` | <center>`str`</center> | <center>**Required**</center> | The type of Linode Entity. Currently only supports linode and nodebalancer.  **(Choices: `linode`, `nodebalancer`, `interface`)** |
 | `state` | <center>`str`</center> | <center>**Required**</center> | The desired state of the target.  **(Choices: `present`, `absent`)** |
 
 ## Return Values

--- a/plugins/modules/firewall_device.py
+++ b/plugins/modules/firewall_device.py
@@ -41,7 +41,7 @@ MODULE_SPEC = {
         description=[
             "The type of Linode Entity. Currently only supports linode and nodebalancer."
         ],
-        choices=["linode", "nodebalancer"],
+        choices=["linode", "nodebalancer", "interface"],
     ),
     "label": SpecField(
         type=FieldType.string,

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -2,7 +2,7 @@
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
-
+    # TODO: Add a test for the interface entity type before merging into dev
     - name: Create a Linode Instance
       linode.cloud.instance:
         label: 'ansible-test-{{ r }}'


### PR DESCRIPTION
## 📝 Description

Add `interface` as an allowed firewall device.

## ✔️ How to Test

Automated testing blocked by the Ansible work of supporting Linode Interfaces in the instance module.

Consider using this playbook for testing for now, and I will add the automated test before merging the project branch into `dev` branch.

1. Create a Linode with a Linode Interface
2. Run the Ansible Playbook below:

```yaml
---
- name: Create a Linode instance
  hosts: localhost
  gather_facts: no
  tasks:
    - name: Create a Linode Firewall
      linode.cloud.firewall:
        api_version: v4beta
        label: 'ansible-test'
        devices: []
        rules:
          inbound: []
          inbound_policy: DROP
          outbound: []
          outbound_policy: ACCEPT
        state: present
      register: fw

    - name: Add Device to Linode Firewall
      linode.cloud.firewall_device:
        api_version: v4beta
        firewall_id: '{{ fw.firewall.id }}'
        entity_id: 5602 # Replace with ID of the interface of your Linode
        entity_type: 'interface'
        state: present
      register: fw_device
```