### PR TITLE
Miscellaneous typing fixes

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -113,7 +113,7 @@ def handle_updates(
     obj: linode_api4.Base,
     params: dict,
     mutable_fields: set,
-    register_func: Any,
+    register_func: Callable,
     ignore_keys: Set[str] = None,
 ) -> Set[str]:
     """Handles updates for a linode_api4 object"""
@@ -180,7 +180,7 @@ def handle_updates(
     return result
 
 
-def parse_linode_types(value: any) -> any:
+def parse_linode_types(value: Any) -> Any:
     """Helper function for handle_updates.
     Parses Linode Object types into collections of strings."""
 
@@ -201,6 +201,9 @@ def parse_linode_types(value: any) -> any:
 
     if isinstance(value, MappedObject):
         return mapping_to_dict(value)
+    
+    if isinstance(value, linode_api4.JSONObject):
+        return value._serialize()
 
     return value
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -206,9 +206,6 @@ def parse_linode_types(value: Any) -> Any:
     if isinstance(value, MappedObject):
         return mapping_to_dict(value)
 
-    if isinstance(value, linode_api4.JSONObject):
-        return value._serialize()
-
     return value
 
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -201,7 +201,7 @@ def parse_linode_types(value: Any) -> Any:
 
     if isinstance(value, MappedObject):
         return mapping_to_dict(value)
-    
+
     if isinstance(value, linode_api4.JSONObject):
         return value._serialize()
 


### PR DESCRIPTION
## 📝 Description

~~This is to fix `parse_linode_types` for [`JSONObject`](https://github.com/linode/linode_api4-python/blob/032f29408c13d00e1b985f19f82eed7669ce7437/linode_api4/objects/serializable.py#L43), when an instance of [`Base`](https://github.com/linode/linode_api4-python/blob/032f29408c13d00e1b985f19f82eed7669ce7437/linode_api4/objects/base.py#L147) containing an instance of [`JSONObject`](https://github.com/linode/linode_api4-python/blob/032f29408c13d00e1b985f19f82eed7669ce7437/linode_api4/objects/serializable.py#L43) being passed into `handle_updates`.~~

~~Some other~~ miscellaneous typing fixes are included.

~~I am not 100% sure about this change because I am not familiar with the Ansible utilities recently... let me know if this is the wrong way for handling it.~~

## ✔️ How to Test
~~We can only test via the change introduced in a separated PR which contains a module that passes an instance of [`JSONObject`](https://github.com/linode/linode_api4-python/blob/032f29408c13d00e1b985f19f82eed7669ce7437/linode_api4/objects/serializable.py#L43) into `handle_updates`. I am still working on that.~~
Typing fix won't affect Python execution, so eye reviews should be enough.
