### PR TITLE
Respond to `parse_linode_types(...)` JSONObject serialization in instance module

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1089,7 +1089,8 @@ class LinodeInstance(LinodeModuleBase):
             if key == "interfaces":
                 old_value = filter_null_values_recursive(
                     [
-                        drop_empty_strings(v._serialize(), recursive=True)
+                        # v is implicitly flattened to a dict in parse_linode_types(...)
+                        drop_empty_strings(v, recursive=True)
                         for v in old_value
                     ]
                 )


### PR DESCRIPTION
## 📝 Description

This pull request updates the `instance` module to account for the serialization of JSONObjects in the `parse_linode_types(...)` helper, which was implemented in #670.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make TEST_ARGS="-v instance_config_vlan instance_config_vpc" test-int 
```

### Manual Testing

**N/A**