### PR TITLE
Firewall settings modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Name | Description |
 [linode.cloud.domain_info](./docs/modules/domain_info.md)|Get info about a Linode Domain.|
 [linode.cloud.domain_record_info](./docs/modules/domain_record_info.md)|Get info about a Linode Domain Records.|
 [linode.cloud.firewall_info](./docs/modules/firewall_info.md)|Get info about a Linode Firewall.|
+[linode.cloud.firewall_settings_info](./docs/modules/firewall_settings_info.md)|Get info about a Linode Firewall Settings.|
 [linode.cloud.image_info](./docs/modules/image_info.md)|Get info about a Linode Image.|
 [linode.cloud.instance_info](./docs/modules/instance_info.md)|Get info about a Linode Instance.|
 [linode.cloud.ip_info](./docs/modules/ip_info.md)|Get info about a Linode IP.|

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Name | Description |
 [linode.cloud.domain_record](./docs/modules/domain_record.md)|Manage Linode Domain Records.|
 [linode.cloud.firewall](./docs/modules/firewall.md)|Manage Linode Firewalls.|
 [linode.cloud.firewall_device](./docs/modules/firewall_device.md)|Manage Linode Firewall Devices.|
+[linode.cloud.firewall_settings](./docs/modules/firewall_settings.md)|Configure the firewall settings for the account.|
 [linode.cloud.image](./docs/modules/image.md)|Manage a Linode Image.|
 [linode.cloud.instance](./docs/modules/instance.md)|Manage Linode Instances, Configs, and Disks.|
 [linode.cloud.ip](./docs/modules/ip.md)|Allocates a new IPv4 Address on your Account. The Linode must be configured to support additional addresses - please Open a support ticket requesting additional addresses before attempting allocation.|

--- a/docs/modules/firewall_settings.md
+++ b/docs/modules/firewall_settings.md
@@ -1,0 +1,61 @@
+# firewall_settings
+
+Configure the firewall settings for the account.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Update the default firewall settings
+  linode.cloud.firewall_settings:
+    default_firewall_ids:
+      linode: 123456
+      nodebalancer: 123456
+      public_interface: 123456
+      vpc_interface: 123456
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| [`default_firewall_ids` (sub-options)](#default_firewall_ids) | <center>`dict`</center> | <center>Optional</center> | The default firewall ID for a `linode`, `nodebalancer`, `public_interface`, or `vpc_interface`. Default firewalls can't be deleted or disabled.  **(Updatable)** |
+| `state` | <center>`str`</center> | <center>Optional</center> | The desired state of the target.  **(Choices: `present`)** |
+
+### default_firewall_ids
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `linode` | <center>`int`</center> | <center>Optional</center> | The Linode's default firewall.   |
+| `nodebalancer` | <center>`int`</center> | <center>Optional</center> | The NodeBalancer's default firewall.   |
+| `public_interface` | <center>`int`</center> | <center>Optional</center> | The public interface's default firewall.   |
+| `vpc_interface` | <center>`int`</center> | <center>Optional</center> | The VPC interface's default firewall.   |
+
+## Return Values
+
+- `default_firewall_ids` - The default firewall ID for a `linode`, `nodebalancer`, `public_interface`, or `vpc_interface`. Default firewalls can't be deleted or disabled.
+
+    - Sample Response:
+        ```json
+        {
+          "default_firewall_ids": {
+            "linode": 123456,
+            "nodebalancer": 123456,
+            "public_interface": 123456,
+            "vpc_interface": 123456
+          }
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/put-firewall-settings) for a list of returned fields
+
+

--- a/docs/modules/firewall_settings_info.md
+++ b/docs/modules/firewall_settings_info.md
@@ -1,0 +1,40 @@
+# firewall_settings_info
+
+Get info about a Linode Firewall Settings.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Update the default firewall settings
+  linode.cloud.firewall_settings_info: {}
+```
+
+
+## Return Values
+
+- `firewall_settings` - The returned Firewall Settings.
+
+    - Sample Response:
+        ```json
+        {
+          "default_firewall_ids": {
+            "linode": 123456,
+            "nodebalancer": 123456,
+            "public_interface": 123456,
+            "vpc_interface": 123456
+          }
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-firewall-settings) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/firewall_settings.py
+++ b/plugins/module_utils/doc_fragments/firewall_settings.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the firewall_settings module"""
+
 specdoc_examples = ['''
 - name: Update the default firewall settings
   linode.cloud.firewall_settings:

--- a/plugins/module_utils/doc_fragments/firewall_settings.py
+++ b/plugins/module_utils/doc_fragments/firewall_settings.py
@@ -1,0 +1,18 @@
+specdoc_examples = ['''
+- name: Update the default firewall settings
+  linode.cloud.firewall_settings:
+    default_firewall_ids:
+      linode: 123456
+      nodebalancer: 123456
+      public_interface: 123456
+      vpc_interface: 123456'''
+]
+
+result_firewall_settings_samples = ['''{
+  "default_firewall_ids": {
+    "linode": 123456,
+    "nodebalancer": 123456,
+    "public_interface": 123456,
+    "vpc_interface": 123456
+  }
+}''']

--- a/plugins/module_utils/doc_fragments/firewall_settings_info.py
+++ b/plugins/module_utils/doc_fragments/firewall_settings_info.py
@@ -1,0 +1,4 @@
+specdoc_examples = ['''
+- name: Update the default firewall settings
+  linode.cloud.firewall_settings_info: {}'''
+]

--- a/plugins/module_utils/doc_fragments/firewall_settings_info.py
+++ b/plugins/module_utils/doc_fragments/firewall_settings_info.py
@@ -1,3 +1,5 @@
+"""Documentation fragments for the firewall_settings_info module"""
+
 specdoc_examples = ['''
 - name: Update the default firewall settings
   linode.cloud.firewall_settings_info: {}'''

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -113,7 +113,7 @@ def handle_updates(
     obj: linode_api4.Base,
     params: dict,
     mutable_fields: set,
-    register_func: Any,
+    register_func: Callable,
     ignore_keys: Set[str] = None,
 ) -> Set[str]:
     """Handles updates for a linode_api4 object"""
@@ -180,7 +180,7 @@ def handle_updates(
     return result
 
 
-def parse_linode_types(value: any) -> any:
+def parse_linode_types(value: Any) -> Any:
     """Helper function for handle_updates.
     Parses Linode Object types into collections of strings."""
 
@@ -201,6 +201,9 @@ def parse_linode_types(value: any) -> any:
 
     if isinstance(value, MappedObject):
         return mapping_to_dict(value)
+    
+    if isinstance(value, linode_api4.JSONObject):
+        return value._serialize()
 
     return value
 

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 import linode_api4
 import polling
 from linode_api4 import (
+    JSONObject,
     LinodeClient,
     LKENodePool,
     LKENodePoolNode,
@@ -190,6 +191,9 @@ def parse_linode_types(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: parse_linode_types(elem) for k, elem in value.items()}
 
+    if issubclass(type(value), JSONObject):
+        return parse_linode_types(value.dict)
+
     if type(value) in {
         linode_api4.objects.linode.Type,
         linode_api4.objects.linode.Region,
@@ -201,9 +205,6 @@ def parse_linode_types(value: Any) -> Any:
 
     if isinstance(value, MappedObject):
         return mapping_to_dict(value)
-    
-    if isinstance(value, linode_api4.JSONObject):
-        return value._serialize()
 
     return value
 

--- a/plugins/modules/firewall_settings.py
+++ b/plugins/modules/firewall_settings.py
@@ -51,7 +51,11 @@ default_firewall_ids_spec: dict = {
     ),
 }
 
-DEFAULT_FIREWALL_SETTING_DESCRIPTION = "The default firewall ID for a `linode`, `nodebalancer`, `public_interface`, or `vpc_interface`. Default firewalls can't be deleted or disabled."
+DEFAULT_FIREWALL_SETTING_DESCRIPTION = (
+    "The default firewall ID for a `linode`, `nodebalancer`, "
+    "`public_interface`, or `vpc_interface`. Default firewalls "
+    "can't be deleted or disabled."
+)
 
 firewall_settings_spec: dict = {
     "default_firewall_ids": SpecField(
@@ -64,7 +68,9 @@ firewall_settings_spec: dict = {
         type=FieldType.string,
         description=["The desired state of the target."],
         choices=["present"],
-        required=False,  # Firewall settings cannot be removed. So marking `state` field as optional here.
+        # Firewall settings cannot be removed.
+        # Thus marking `state` field as optional here.
+        required=False,
     ),
 }
 

--- a/plugins/modules/firewall_settings.py
+++ b/plugins/modules/firewall_settings.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Firewalls Settings."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_settings as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    handle_updates,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+
+try:
+    from linode_api4 import FirewallSettings
+except ImportError:
+    # handled in module_utils.linode_common
+    pass
+
+default_firewall_ids_spec: dict = {
+    "linode": SpecField(
+        type=FieldType.integer,
+        description=["The Linode's default firewall."],
+    ),
+    "nodebalancer": SpecField(
+        type=FieldType.integer,
+        description=["The NodeBalancer's default firewall."],
+    ),
+    "public_interface": SpecField(
+        type=FieldType.integer,
+        description=["The public interface's default firewall."],
+    ),
+    "vpc_interface": SpecField(
+        type=FieldType.integer,
+        description=["The VPC interface's default firewall."],
+    ),
+}
+
+DEFAULT_FIREWALL_SETTING_DESCRIPTION = "The default firewall ID for a `linode`, `nodebalancer`, `public_interface`, or `vpc_interface`. Default firewalls can't be deleted or disabled."
+
+firewall_settings_spec: dict = {
+    "default_firewall_ids": SpecField(
+        type=FieldType.dict,
+        suboptions=default_firewall_ids_spec,
+        editable=True,
+        description=[DEFAULT_FIREWALL_SETTING_DESCRIPTION],
+    ),
+    "state": SpecField(
+        type=FieldType.string,
+        description=["The desired state of the target."],
+        choices=["present"],
+        required=False,  # Firewall settings cannot be removed. So marking `state` field as optional here.
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Configure the firewall settings for the account."],
+    requirements=global_requirements,
+    author=global_authors,
+    options=firewall_settings_spec,
+    examples=docs.specdoc_examples,
+    return_values={
+        "default_firewall_ids": SpecReturnValue(
+            description=DEFAULT_FIREWALL_SETTING_DESCRIPTION,
+            docs_url="https://techdocs.akamai.com/linode-api/reference/put-firewall-settings",
+            type=FieldType.dict,
+            sample=docs.result_firewall_settings_samples,
+        ),
+    },
+)
+
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+
+class LinodeFirewall(LinodeModuleBase):
+    """Module for creating and destroying Linode Firewalls"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+
+        self.results: dict = {
+            "changed": False,
+            "actions": [],
+            "firewall_settings": None,
+        }
+
+        self._firewall_settings: Optional[FirewallSettings] = None
+
+        self._state = "present"
+
+        super().__init__(module_arg_spec=self.module_arg_spec)
+
+    def _get_firewall_settings(self) -> Optional[FirewallSettings]:
+        try:
+            return self.client.networking.firewall_settings()
+        except Exception as exception:
+            return self.fail(
+                msg=f"failed to get firewall settings: {exception}"
+            )
+
+    def _update_firewall_settings(self) -> None:
+        """Update the firewall settings"""
+
+        self._firewall_settings = self._get_firewall_settings()
+
+        handle_updates(
+            self._firewall_settings,
+            filter_null_values(self.module.params),
+            set(["default_firewall_ids"]),
+            self.register_action,
+        )
+
+        self._firewall_settings._api_get()
+        self.results["firewall_settings"] = self._firewall_settings._raw_json
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Firewall Settings module"""
+
+        self._state = self.module.params.get("state", "present")
+        self._update_firewall_settings()
+
+        return self.results
+
+
+def main() -> None:
+    """Constructs and calls the Linode Firewall Settings module"""
+
+    LinodeFirewall()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/firewall_settings_info.py
+++ b/plugins/modules/firewall_settings_info.py
@@ -5,8 +5,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_settings as docs_parent
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_settings_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    firewall_settings as docs_parent,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    firewall_settings_info as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleResult,

--- a/plugins/modules/firewall_settings_info.py
+++ b/plugins/modules/firewall_settings_info.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for Linode Firewalls Settings."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_settings as docs_parent
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.firewall_settings_info as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+)
+from linode_api4 import FirewallSettings
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="Firewall Settings",
+        field_name="firewall_settings",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-firewall-settings",
+        samples=docs_parent.result_firewall_settings_samples,
+        get=lambda client, _: client.load(FirewallSettings, None)._raw_json,
+    ),
+    attributes=[],
+)
+
+SPECDOC_META = module.spec
+
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/tests/integration/targets/firewall_settings/tasks/main.yaml
+++ b/tests/integration/targets/firewall_settings/tasks/main.yaml
@@ -1,0 +1,61 @@
+# this test case only works if you have configured default firewall to your account 
+
+- name: firewall_device
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Get the default firewall settings
+      linode.cloud.firewall_settings_info: {}
+      register: default_firewall_settings
+
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+        api_version: v4beta
+        label: 'ansible-test-{{ r }}'
+        rules:
+          inbound: []
+          inbound_policy: DROP
+          outbound: []
+          outbound_policy: DROP
+        state: present
+      register: fw
+    
+    - name: Assert firewall created
+      assert:
+        that:
+          - fw.changed
+
+    - name: Update firewall settings
+      linode.cloud.firewall_settings:
+        api_version: v4beta
+        default_firewall_ids:
+          linode: '{{ fw.firewall.id }}'
+      register: updated_firewall_settings
+
+    - name: Assert firewall settings updated
+      assert:
+        that:
+          - updated_firewall_settings.changed
+          - updated_firewall_settings.firewall_settings.default_firewall_ids.linode == fw.firewall.id
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Restore default firewall settings
+          linode.cloud.firewall_settings:
+            api_version: v4beta
+            default_firewall_ids:
+              linode: '{{ default_firewall_settings.firewall_settings.default_firewall_ids.linode }}'
+
+        - name: Delete Firewall
+          linode.cloud.firewall:
+            label: '{{ fw.firewall.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This is to add `firewall_settings` and `firewall_settings_info` module.

## ✔️ How to Test

You **might** need to enable default firewall for your account to test it.

**Note that once it's enabled for an account, it cannot be turned off, which means you will have to permanently have a default firewall for each of the resources in you account.**

```bash
curl --request PUT \
     --url https://api.linode.com/v4beta/networking/firewalls/settings \
     --header 'accept: application/json' \
     --header "authorization: Bearer $TOKEN" \   
     --header 'content-type: application/json' \
     --data '
{
    "default_firewall_ids": { 
        "public_interface": YOUR_DEFAULT_FIREWALL_ID,
        "vpc_interface": YOUR_DEFAULT_FIREWALL_ID,
        "linode": YOUR_DEFAULT_FIREWALL_ID,
        "nodebalancer": YOUR_DEFAULT_FIREWALL_ID
    }                 
}

'
```

Testing the modules:
 
```bash
make test-int TEST_SUITE=firewall_settings
```