### PR TITLE
Added `account_settings` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Modules for managing Linode infrastructure.
 
 Name | Description |
 --- | ------------ |
+[linode.cloud.account_settings](./docs/modules/account_settings.md)|Returns information related to your Account settings.|
 [linode.cloud.api_request](./docs/modules/api_request.md)|Make an arbitrary Linode API request.|
 [linode.cloud.database_mysql](./docs/modules/database_mysql.md)|Manage a Linode MySQL database.|
 [linode.cloud.database_mysql_v2](./docs/modules/database_mysql_v2.md)|Create, read, and update a Linode MySQL database.|

--- a/docs/modules/account_settings.md
+++ b/docs/modules/account_settings.md
@@ -28,9 +28,7 @@ Returns information related to your Account settings.
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of Account Settings.  **(Choices: `present`)** |
 | `backups_enabled` | <center>`bool`</center> | <center>Optional</center> | Account-wide backups default. If true, all Linodes created will automatically be enrolled in the Backups service. If false, Linodes will not be enrolled by default, but may still be enrolled on creation or later.   |
 | `longview_subscription` | <center>`str`</center> | <center>Optional</center> | The Longview Pro tier you are currently subscribed to. The value must be a Longview subscription ID or null for Longview Free.   |
-| `managed` | <center>`bool`</center> | <center>Optional</center> | Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.   |
 | `network_helper` | <center>`bool`</center> | <center>Optional</center> | Enables network helper across all users by default for new Linodes and Linode Configs.   |
-| `object_storage` | <center>`str`</center> | <center>Optional</center> | A string describing the status of this account's Object Storage service enrollment.   |
 
 ## Return Values
 

--- a/docs/modules/account_settings.md
+++ b/docs/modules/account_settings.md
@@ -1,0 +1,52 @@
+# account_settings
+
+Returns information related to your Account settings.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Retrieve
+  linode.cloud.account_settings:
+    state: present
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `state` | <center>`str`</center> | <center>**Required**</center> | The state of Account Settings.  **(Choices: `present`)** |
+| `backups_enabled` | <center>`bool`</center> | <center>Optional</center> | Account-wide backups default. If true, all Linodes created will automatically be enrolled in the Backups service. If false, Linodes will not be enrolled by default, but may still be enrolled on creation or later.   |
+| `longview_subscription` | <center>`str`</center> | <center>Optional</center> | The Longview Pro tier you are currently subscribed to. The value must be a Longview subscription ID or null for Longview Free.   |
+| `managed` | <center>`bool`</center> | <center>Optional</center> | Our 24/7 incident response service. This robust, multi-homed monitoring system distributes monitoring checks to ensure that your servers remain online and available at all times. Linode Managed can monitor any service or software stack reachable over TCP or HTTP. Once you add a service to Linode Managed, we'll monitor it for connectivity, response, and total request time.   |
+| `network_helper` | <center>`bool`</center> | <center>Optional</center> | Enables network helper across all users by default for new Linodes and Linode Configs.   |
+| `object_storage` | <center>`str`</center> | <center>Optional</center> | A string describing the status of this account's Object Storage service enrollment.   |
+
+## Return Values
+
+- `account_settings` - Account Settings in JSON serialized form.
+
+    - Sample Response:
+        ```json
+        {
+          "backups_enabled": true,
+          "interfaces_for_new_linodes": "linode_only",
+          "longview_subscription": "longview-3",
+          "managed": true,
+          "network_helper": false,
+          "object_storage": "active"
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-account-settings) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/account_settings.py
+++ b/plugins/module_utils/doc_fragments/account_settings.py
@@ -1,0 +1,15 @@
+"""Documentation fragments for the account settings module"""
+
+specdoc_examples = ['''
+- name: Retrieve
+  linode.cloud.account_settings:
+    state: present''']
+
+result_account_settings_samples = ['''{
+  "backups_enabled": true,
+  "interfaces_for_new_linodes": "linode_only",
+  "longview_subscription": "longview-3",
+  "managed": true,
+  "network_helper": false,
+  "object_storage": "active"
+}''']

--- a/plugins/modules/account_settings.py
+++ b/plugins/modules/account_settings.py
@@ -50,29 +50,11 @@ SPEC = {
             "The value must be a Longview subscription ID or null for Longview Free."
         ],
     ),
-    "managed": SpecField(
-        type=FieldType.bool,
-        description=[
-            "Our 24/7 incident response service. This robust, multi-homed "
-            "monitoring system distributes monitoring checks to ensure that "
-            "your servers remain online and available at all times. "
-            "Linode Managed can monitor any service or software stack "
-            "reachable over TCP or HTTP. Once you add a service to Linode Managed, "
-            "we'll monitor it for connectivity, response, and total request time."
-        ],
-    ),
     "network_helper": SpecField(
         type=FieldType.bool,
         description=[
             "Enables network helper across all users by default "
             "for new Linodes and Linode Configs."
-        ],
-    ),
-    "object_storage": SpecField(
-        type=FieldType.string,
-        description=[
-            "A string describing the status of this account's "
-            "Object Storage service enrollment."
         ],
     ),
 }

--- a/plugins/modules/account_settings.py
+++ b/plugins/modules/account_settings.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve and modify Linode account settings."""
+
+from __future__ import absolute_import, division, print_function
+
+from typing import Any, List, Optional
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.account_settings as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
+    LinodeModuleBase,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
+    global_authors,
+    global_requirements,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    filter_null_values,
+    handle_updates,
+)
+from ansible_specdoc.objects import (
+    FieldType,
+    SpecDocMeta,
+    SpecField,
+    SpecReturnValue,
+)
+from linode_api4 import AccountSettings
+
+SPEC = {
+    "state": SpecField(
+        type=FieldType.string,
+        choices=["present"],
+        required=True,
+        description=["The state of Account Settings."],
+    ),
+    "backups_enabled": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Account-wide backups default. If true, all Linodes created "
+            "will automatically be enrolled in the Backups service. "
+            "If false, Linodes will not be enrolled by default, "
+            "but may still be enrolled on creation or later."
+        ],
+    ),
+    "longview_subscription": SpecField(
+        type=FieldType.string,
+        description=[
+            "The Longview Pro tier you are currently subscribed to. "
+            "The value must be a Longview subscription ID or null for Longview Free."
+        ],
+    ),
+    "managed": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Our 24/7 incident response service. This robust, multi-homed "
+            "monitoring system distributes monitoring checks to ensure that "
+            "your servers remain online and available at all times. "
+            "Linode Managed can monitor any service or software stack "
+            "reachable over TCP or HTTP. Once you add a service to Linode Managed, "
+            "we'll monitor it for connectivity, response, and total request time."
+        ],
+    ),
+    "network_helper": SpecField(
+        type=FieldType.bool,
+        description=[
+            "Enables network helper across all users by default "
+            "for new Linodes and Linode Configs."
+        ],
+    ),
+    "object_storage": SpecField(
+        type=FieldType.string,
+        description=[
+            "A string describing the status of this account's "
+            "Object Storage service enrollment."
+        ],
+    ),
+}
+
+SPECDOC_META = SpecDocMeta(
+    description=["Returns information related to your Account settings."],
+    requirements=global_requirements,
+    author=global_authors,
+    options=SPEC,
+    examples=docs.specdoc_examples,
+    return_values={
+        "account_settings": SpecReturnValue(
+            description="Account Settings in JSON serialized form.",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-account-settings",
+            type=FieldType.dict,
+            sample=docs.result_account_settings_samples,
+        )
+    },
+)
+
+MUTABLE_FIELDS = {"backups_enabled", "network_helper"}
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+
+class Module(LinodeModuleBase):
+    """Module for viewing and updating Account Settings"""
+
+    def __init__(self) -> None:
+        self.module_arg_spec = SPECDOC_META.ansible_spec
+        self.required_one_of: List[str] = []
+        self.results = {
+            "changed": False,
+            "actions": [],
+            "account_settings": None,
+        }
+
+        self._account_settings: Optional[AccountSettings] = None
+
+        super().__init__(
+            module_arg_spec=self.module_arg_spec,
+            required_one_of=self.required_one_of,
+        )
+
+    def _update(self) -> None:
+        """Handles all updates for Account Settings"""
+        handle_updates(
+            self._account_settings,
+            filter_null_values(self.module.params),
+            MUTABLE_FIELDS,
+            self.register_action,
+        )
+
+    def _present(self) -> None:
+        self._account_settings = self.client.account.settings()
+        self._update()
+        self._account_settings._api_get()
+        self.results["account_settings"] = self._account_settings._raw_json
+
+    def exec_module(self, **kwargs: Any) -> Optional[dict]:
+        """Entrypoint for Account Settings module"""
+        if kwargs.get("state") == "present":
+            self._present()
+        return self.results
+
+
+if __name__ == "__main__":
+    Module()

--- a/tests/integration/targets/account_settings/tasks/main.yaml
+++ b/tests/integration/targets/account_settings/tasks/main.yaml
@@ -11,9 +11,11 @@
     - name: Assert account_settings response
       assert:
         that:
-          - info.account_settings.longview_subscription is not none
+          - "'longview_subscription' in info.account_settings"
           - info.account_settings.managed is not none
           - info.account_settings.object_storage is not none
+          - info.account_settings.network_helper is not none
+          - info.account_settings.backups_enabled is not none
 
     - name: Determine opposite of backups_enabled
       set_fact:

--- a/tests/integration/targets/account_settings/tasks/main.yaml
+++ b/tests/integration/targets/account_settings/tasks/main.yaml
@@ -1,0 +1,47 @@
+- name: account_settings
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Get account_settings
+      linode.cloud.account_settings:
+        state: 'present'
+      register: info
+
+    - name: Assert account_settings response
+      assert:
+        that:
+          - info.account_settings.longview_subscription is not none
+          - info.account_settings.managed is not none
+          - info.account_settings.object_storage is not none
+
+    - name: Determine opposite of backups_enabled
+      set_fact:
+        original_backups_enabled: "{{ info.account_settings.backups_enabled }}"
+        toggled_backups_enabled: "{{ not info.account_settings.backups_enabled }}"
+
+    - name: Update account_settings
+      linode.cloud.account_settings:
+        state: 'present'
+        backups_enabled: "{{ toggled_backups_enabled }}"
+      register: update
+
+    - name: Assert account_settings was updated
+      assert:
+        that:
+          - update.account_settings.backups_enabled == toggled_backups_enabled
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Revert account settings changes
+          linode.cloud.account_settings:
+            state: 'present'
+            backups_enabled: "{{ original_backups_enabled }}"
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Added support for `GET /account/settings` and `PUT /account/settings` via `account_settings` module, and accompanying integration tests and documentation.

Shoutout to @jriddle-linode for the code!

## ✔️ How to Test
The following test steps assume you have pulled down this PR locally.

### Integration Tests
`make test-int TEST_SUITE="account_settings"`
