### PR TITLE
Added support for Host Maintenance Policy features

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Name | Description |
 [linode.cloud.instance_type_list](./docs/modules/instance_type_list.md)|**NOTE: This module has been deprecated in favor of `type_list`.**|
 [linode.cloud.lke_type_list](./docs/modules/lke_type_list.md)|List and filter on LKE Types.|
 [linode.cloud.lke_version_list](./docs/modules/lke_version_list.md)|List and filter on LKE Versions.|
+[linode.cloud.maintenance_policy_list](./docs/modules/maintenance_policy_list.md)|List and filter on Maintenance Policies.|
 [linode.cloud.network_transfer_prices_list](./docs/modules/network_transfer_prices_list.md)|List and filter on Network Transfer Prices.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Node Balancers.|
 [linode.cloud.nodebalancer_type_list](./docs/modules/nodebalancer_type_list.md)|List and filter on Node Balancer Types.|

--- a/docs/modules/account_settings.md
+++ b/docs/modules/account_settings.md
@@ -29,6 +29,7 @@ Returns information related to your Account settings.
 | `backups_enabled` | <center>`bool`</center> | <center>Optional</center> | Account-wide backups default. If true, all Linodes created will automatically be enrolled in the Backups service. If false, Linodes will not be enrolled by default, but may still be enrolled on creation or later.   |
 | `longview_subscription` | <center>`str`</center> | <center>Optional</center> | The Longview Pro tier you are currently subscribed to. The value must be a Longview subscription ID or null for Longview Free.   |
 | `network_helper` | <center>`bool`</center> | <center>Optional</center> | Enables network helper across all users by default for new Linodes and Linode Configs.   |
+| `maintenance_policy` | <center>`str`</center> | <center>Optional</center> | The Slug of the maintenance policy associated with the account.  **(Choices: `linode/migrate`, `linode/power_off_on`)** |
 
 ## Return Values
 
@@ -42,7 +43,8 @@ Returns information related to your Account settings.
           "longview_subscription": "longview-3",
           "managed": true,
           "network_helper": false,
-          "object_storage": "active"
+          "object_storage": "active",
+          "maintenance_policy": "linode/migrate"
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-account-settings) for a list of returned fields

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -128,6 +128,7 @@ Manage Linode Instances, Configs, and Disks.
 | `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.  **(Conflicts With: `disks`,`configs`)** |
 | `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |
 | `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames.   |
+| `maintenance_policy` | <center>`str`</center> | <center>Optional</center> | The Slug of the maintenance policy to apply during maintenance.  **(Choices: `linode/migrate`, `linode/power_off_on`)** |
 | `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
@@ -354,6 +355,7 @@ Manage Linode Instances, Configs, and Disks.
           "watchdog_enabled": true,
           "disk_encryption": "enabled",
           "lke_cluster_id": null,
+          "maintenance_policy": "linode/migrate,
           "placement_group": {
             "id": 123,
             "label": "test",

--- a/docs/modules/instance_info.md
+++ b/docs/modules/instance_info.md
@@ -85,6 +85,7 @@ Get info about a Linode Instance.
           "watchdog_enabled": true,
           "disk_encryption": "enabled",
           "lke_cluster_id": null,
+          "maintenance_policy": "linode/migrate,
           "placement_group": {
             "id": 123,
             "label": "test",

--- a/docs/modules/instance_list.md
+++ b/docs/modules/instance_list.md
@@ -96,7 +96,8 @@ List and filter on Instances.
               "updated": "2018-01-01T00:01:01",
               "watchdog_enabled": true,
               "disk_encryption": "enabled",
-              "lke_cluster_id": null
+              "lke_cluster_id": null,
+              "maintenance_policy": "linode/migrate
             }
         ]
         ```

--- a/docs/modules/maintenance_policy_list.md
+++ b/docs/modules/maintenance_policy_list.md
@@ -1,0 +1,70 @@
+# maintenance_policy_list
+
+List and filter on Maintenance Policies.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode Maintenance Policies
+  linode.cloud.maintenance_policy_list: {}
+```
+
+```yaml
+
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Maintenance Policies in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Maintenance Policies by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Maintenance Policies.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Maintenance Policies to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/api).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `maintenance_policies` - The returned Maintenance Policies.
+
+    - Sample Response:
+        ```json
+        [
+            {
+              "slug": "linode/migrate",
+              "label": "Migrate",
+              "description": "Migrates the Linode to a new host while it remains fully operational. Recommended for maximizing availability.",
+              "type": "migrate",
+              "notification_period_sec": 300,
+              "is_default": true
+            },
+            {
+              "slug": "linode/power_off_on",
+              "label": "Power-off/on",
+              "description": "Powers off the Linode at the start of the maintenance event and reboots it once the maintenance finishes. Recommended for maximizing performance.",
+              "type": "power_off_on",
+              "notification_period_sec": 1800,
+              "is_default": false
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/api) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/account_settings.py
+++ b/plugins/module_utils/doc_fragments/account_settings.py
@@ -11,5 +11,6 @@ result_account_settings_samples = ['''{
   "longview_subscription": "longview-3",
   "managed": true,
   "network_helper": false,
-  "object_storage": "active"
+  "object_storage": "active",
+  "maintenance_policy": "linode/migrate"
 }''']

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -131,6 +131,7 @@ result_instance_samples = ['''{
   "watchdog_enabled": true,
   "disk_encryption": "enabled",
   "lke_cluster_id": null,
+  "maintenance_policy": "linode/migrate,
   "placement_group": {
     "id": 123,
     "label": "test",

--- a/plugins/module_utils/doc_fragments/instance_list.py
+++ b/plugins/module_utils/doc_fragments/instance_list.py
@@ -9,7 +9,7 @@ specdoc_examples = ['''
       - name: label
         values: myInstanceLabel''']
 
-result_images_samples = ['''[
+result_instances_samples = ['''[
    {
       "alerts": {
         "cpu": 180,
@@ -55,6 +55,7 @@ result_images_samples = ['''[
       "updated": "2018-01-01T00:01:01",
       "watchdog_enabled": true,
       "disk_encryption": "enabled",
-      "lke_cluster_id": null
+      "lke_cluster_id": null,
+      "maintenance_policy": "linode/migrate
     }
 ]''']

--- a/plugins/module_utils/doc_fragments/maintenance_policy_list.py
+++ b/plugins/module_utils/doc_fragments/maintenance_policy_list.py
@@ -1,0 +1,25 @@
+"""Documentation fragments for the maintenance_policy_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode Maintenance Policies
+  linode.cloud.maintenance_policy_list: {}''', '''
+''']
+
+result_maintenance_policy_samples = ['''[
+    {
+      "slug": "linode/migrate",
+      "label": "Migrate",
+      "description": "Migrates the Linode to a new host while it remains fully operational. Recommended for maximizing availability.",
+      "type": "migrate",
+      "notification_period_sec": 300,
+      "is_default": true
+    },
+    {
+      "slug": "linode/power_off_on",
+      "label": "Power-off/on",
+      "description": "Powers off the Linode at the start of the maintenance event and reboots it once the maintenance finishes. Recommended for maximizing performance.",
+      "type": "power_off_on",
+      "notification_period_sec": 1800,
+      "is_default": false
+    }
+]''']

--- a/plugins/modules/account_settings.py
+++ b/plugins/modules/account_settings.py
@@ -57,6 +57,13 @@ SPEC = {
             "for new Linodes and Linode Configs."
         ],
     ),
+    "maintenance_policy": SpecField(
+        type=FieldType.string,
+        description=[
+            "The Slug of the maintenance policy associated with the account."
+        ],
+        choices=["linode/migrate", "linode/power_off_on"]
+    )
 }
 
 SPECDOC_META = SpecDocMeta(
@@ -75,7 +82,7 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-MUTABLE_FIELDS = {"backups_enabled", "network_helper"}
+MUTABLE_FIELDS = {"backups_enabled", "network_helper", "maintenance_policy"}
 
 DOCUMENTATION = r"""
 """

--- a/plugins/modules/account_settings.py
+++ b/plugins/modules/account_settings.py
@@ -62,8 +62,8 @@ SPEC = {
         description=[
             "The Slug of the maintenance policy associated with the account."
         ],
-        choices=["linode/migrate", "linode/power_off_on"]
-    )
+        choices=["linode/migrate", "linode/power_off_on"],
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -356,6 +356,13 @@ linode_instance_spec = {
         element_type=FieldType.string,
         description=["A list of usernames."],
     ),
+    "maintenance_policy": SpecField(
+        type=FieldType.string,
+        description=[
+            "The Slug of the maintenance policy to apply during maintenance."
+        ],
+        choices=["linode/migrate", "linode/power_off_on"],
+    ),
     "root_pass": SpecField(
         type=FieldType.string,
         no_log=True,
@@ -591,7 +598,7 @@ SPECDOC_META = SpecDocMeta(
 )
 
 # Fields that can be updated on an existing instance
-MUTABLE_FIELDS = {"group", "tags"}
+MUTABLE_FIELDS = {"group", "tags", "maintenance_policy"}
 
 linode_instance_config_mutable = {
     "comments",

--- a/plugins/modules/instance_list.py
+++ b/plugins/modules/instance_list.py
@@ -15,7 +15,7 @@ module = ListModule(
     endpoint_template="/linode/instances",
     result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
     examples=docs.specdoc_examples,
-    result_samples=docs.result_images_samples,
+    result_samples=docs.result_instances_samples,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/maintenance_policy_list.py
+++ b/plugins/modules/maintenance_policy_list.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode Maintenance Policies."""
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.maintenance_policy_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Maintenance Policies",
+    result_field_name="maintenance_policies",
+    endpoint_template="/maintenance/policies",
+    # TODO result_docs_url="",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_maintenance_policy_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-linode-api4>=5.32.0
+# TODO: REPLACE WITH LATEST VERSION AFTER RELEASE
+git+https://github.com/linode/linode_api4-python.git@proj/maintenance-policy
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/tests/integration/targets/account_settings/tasks/main.yaml
+++ b/tests/integration/targets/account_settings/tasks/main.yaml
@@ -22,16 +22,25 @@
         original_backups_enabled: "{{ info.account_settings.backups_enabled }}"
         toggled_backups_enabled: "{{ not info.account_settings.backups_enabled }}"
 
+    - name: Determine opposite of maintenance_policy
+      set_fact:
+        original_maintenance_policy: "{{ info.account_settings.maintenance_policy }}"
+        toggled_maintenance_policy: >-
+          {{ 'linode/power_off_on' if info.account_settings.maintenance_policy == 'linode/migrate'
+             else 'linode/migrate' }}
+
     - name: Update account_settings
       linode.cloud.account_settings:
         state: 'present'
         backups_enabled: "{{ toggled_backups_enabled }}"
+        maintenance_policy: "{{ toggled_maintenance_policy }}"
       register: update
 
     - name: Assert account_settings was updated
       assert:
         that:
           - update.account_settings.backups_enabled == toggled_backups_enabled
+          - update.account_settings.maintenance_policy == toggled_maintenance_policy
 
   always:
     - ignore_errors: yes
@@ -40,6 +49,7 @@
           linode.cloud.account_settings:
             state: 'present'
             backups_enabled: "{{ original_backups_enabled }}"
+            maintenance_policy: "{{ original_maintenance_policy }}"
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -10,6 +10,11 @@
     - set_fact:
         pg_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Placement Group") | list)[0].id }}'
 
+    - name: Get account_settings
+      linode.cloud.account_settings:
+        state: 'present'
+      register: account_info
+
     - name: Create a Linode instance without a root password
       linode.cloud.instance:
         label: 'ansible-test-nopass-{{ r }}'
@@ -28,6 +33,7 @@
           - create.changed
           - create.instance.ipv4|length > 1
           - create.networking.ipv4.public[0].address != None
+          - create.instance.maintenance_policy == account_info.account_settings.maintenance_policy
 
     - name: Create a Linode instance with additional ips and without a root password
       linode.cloud.instance:
@@ -105,6 +111,12 @@
       failed_when:
         - "'additional_ipv4' not in invalid_update_remove_ips.msg"
 
+    - name: Determine opposite of maintenance_policy
+      set_fact:
+        toggled_maintenance_policy: >-
+          {{ 'linode/power_off_on' if account_info.account_settings.maintenance_policy == 'linode/migrate'
+             else 'linode/migrate' }}
+
     - name: Update the instance
       linode.cloud.instance:
         label: '{{ create.instance.label }}'
@@ -113,6 +125,7 @@
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        maintenance_policy: '{{ toggled_maintenance_policy }}'
         state: present
       register: update
 
@@ -120,6 +133,7 @@
       assert:
         that:
           - update.instance.group == 'funny'
+          - update.instance.maintenance_policy == toggled_maintenance_policy
 
     - name: Get info about the instance by id
       linode.cloud.instance_info:
@@ -134,6 +148,7 @@
           - info_id.configs|length == 1
           - info_id.networking.ipv4.public[0].address != None
           - info_id.instance.capabilities == create.instance.capabilities
+          - info_id.instance.maintenance_policy == toggled_maintenance_policy
 
     - name: Get info about the instance by label
       linode.cloud.instance_info:

--- a/tests/integration/targets/maintenance_policy_list/tasks/main.yaml
+++ b/tests/integration/targets/maintenance_policy_list/tasks/main.yaml
@@ -1,0 +1,17 @@
+- name: maintenance_policy_list
+  block:
+    - name: List Linode Maintenance Policies
+      linode.cloud.maintenance_policy_list:
+      register: policies
+
+    - name: Assert maintenance_policy_list
+      assert:
+        that:
+          - policies.maintenance_policies | length >= 1
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Added support for Host Maintenance in account settings and instance modules, and added module for maintenance policies.

## ✔️ How to Test

The following steps assume you have pulled down this PR locally

### Integration Tests
For running the integration tests, you will need to point at DevCloud. Note that the account settings tests will not pass due to limitations with changing account settings for DevCloud accounts.

`make test-int TEST_SUITE="account_settings"`
`make test-int TEST_SUITE="instance_basic"`
`make test-int TEST_SUITE="maintenance_policy_list"`