### PR TITLE
Fixed issue with db engine config test

### DIFF
--- a/tests/integration/targets/database_config_info/tasks/main.yaml
+++ b/tests/integration/targets/database_config_info/tasks/main.yaml
@@ -86,7 +86,7 @@
           - get_database_config_postgresql.config.pg.max_standby_streaming_delay.type == "integer"
           - get_database_config_postgresql.config.pg.max_wal_senders.type == "integer"
           - get_database_config_postgresql.config.pg.max_worker_processes.type == "integer"
-          - get_database_config_postgresql.config.pg.password_encryption.default == "md5"
+          - get_database_config_postgresql.config.pg.password_encryption.type == "string"
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'


### PR DESCRIPTION
## 📝 Description

Updated db engine config test to no longer reference outdated field.

## ✔️ How to Test

`make test-int TEST_SUITE="database_config_info"`