### PR TITLE
Require Maintenance Policy capability in instance_basic test

### DIFF
--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -8,7 +8,7 @@
       register: all_regions
 
     - set_fact:
-        pg_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Placement Group") | list)[0].id }}'
+        pg_region: '{{ (all_regions.regions | selectattr("capabilities", "search", "Placement Group") | selectattr("capabilities", "search", "Maintenance Policy") | list)[0].id }}'
 
     - name: Get account_settings
       linode.cloud.account_settings:

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -148,7 +148,7 @@
           - info_id.configs|length == 1
           - info_id.networking.ipv4.public[0].address != None
           - info_id.instance.capabilities == create.instance.capabilities
-          - info_id.instance.maintenance_policy == toggled_maintenance_policy
+          - info_id.instance.maintenance_policy == account_info.account_settings.maintenance_policy
 
     - name: Get info about the instance by label
       linode.cloud.instance_info:

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -132,7 +132,6 @@
     - name: Assert update
       assert:
         that:
-          - update.instance.group == 'funny'
           - update.instance.maintenance_policy == toggled_maintenance_policy
           - update.instance.label == updated_label
 


### PR DESCRIPTION
## 📝 Description

This pull request ensures the test region resolved in the `instance_basic` has the "Maintenance Policy" capability, which will prevent the maintenance_policy assertions from failing.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`:

### Integration Testing

```
make test-int TEST_ARGS="-v instance_basic"