### PR TITLE
Fix maintenance policy documentation

### DIFF
--- a/docs/modules/maintenance_policy_list.md
+++ b/docs/modules/maintenance_policy_list.md
@@ -67,10 +67,6 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
             }
         ]
         ```
-<<<<<<< HEAD
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-maintenance-policies) for a list of returned fields
-=======
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-policies) for a list of returned fields
->>>>>>> main
 
 


### PR DESCRIPTION
## 📝 Description

Run `make gendocs` to clean up a documentation issue introduced from conflict. 
