### PR TITLE
Fix Image filter test issue

### DIFF
--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -32,8 +32,8 @@
     - name: List image_list with empty filter
       linode.cloud.image_list:
         filters:
-          - name: vendor
-            values: DefinitelyRealVendor
+          - name: label
+            values: DefinitelyRealLabel
       register: filter_empty
 
     - name: Assert image_list with empty filter


### PR DESCRIPTION
## 📝 Description

Image currently can't be filtered on `vendor`. Switch to filter on another field to have the test passed. 

## ✔️ How to Test

```
make test-int TEST_SUITE=image_list TEST_ARGS=-vvv
```