### PR TITLE
Fix handle_updates None filtering issue

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -274,10 +274,10 @@ def handle_updates(
                 " field".format(old_value, new_value, key)
             )
 
-        put_request[key] = new_value
+        put_request[key] = put_value
         result.add(key)
         register_func(
-            'Updated {0}: "{1}" -> "{2}"'.format(key, old_value, new_value)
+            'Updated {0}: "{1}" -> "{2}"'.format(key, old_value, put_value)
         )
 
     if len(put_request.keys()) > 0 and not dry_run:

--- a/plugins/modules/firewall_settings.py
+++ b/plugins/modules/firewall_settings.py
@@ -133,8 +133,9 @@ class LinodeFirewall(LinodeModuleBase):
             self.register_action,
             diff_overrides={
                 # We still want to diff on None values in default_firewall_ids
-                "default_firewall_ids": lambda _, a, b: not matching_keys_eq(
-                    a, b
+                "default_firewall_ids": lambda _, old, new: (
+                    not matching_keys_eq(old, new),
+                    new,
                 )
             },
         )


### PR DESCRIPTION
## 📝 Description

This bug fixes an oversight in #731 that caused None values to not be filtered from the request body for `handle_update` operations without diff overrides.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make test-int TEST_ARGS="-v database_postgresql_v2_engine_config"`
```