### PR TITLE
Align GHA workflows in the scope of report uploads

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,11 @@ on:
         options:
           - 'true'
           - 'false'
+      test_report_upload:
+        description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
+        type: boolean
+        required: false
+        default: false
   push:
     branches:
       - main
@@ -77,7 +82,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' && github.event_name == 'push' }}
+    if: ${{ always() && github.repository == 'linode/ansible_linode' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
           ANSIBLE_CALLBACKS_ENABLED: "junit"
 
       - name: Upload Test Report as Artifact
-        if: always()
+        if: always() && github.event_name == 'push' 
         uses: actions/upload-artifact@v6
         with:
           name: xml-test-reports

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
           ANSIBLE_CALLBACKS_ENABLED: "junit"
 
       - name: Upload Test Report as Artifact
-        if: always() && github.event_name == 'push' 
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: xml-test-reports
@@ -77,7 +77,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' }}
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' && github.event_name == 'push' }}
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,7 +82,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ always() && github.repository == 'linode/ansible_linode' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
+    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,12 @@ on:
           - 'false'
       test_report_upload:
         description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
-        type: boolean
+        type: choice
         required: false
-        default: false
+        default: 'false'
+        options:
+          - 'true'
+          - 'false'
   push:
     branches:
       - main
@@ -82,7 +85,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/ansible_linode' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
+    if: (success() || failure()) && github.repository == 'linode/ansible_linode' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 


### PR DESCRIPTION
## 📝 Description

GHA workflows upload test results to TOD on push, PR and manual (workflow_dispatch) runs. PR covers aligning integration test workflows to upload results automatically on push/PR and on demand for manual runs.

## ✔️ How to Test
Manual run of the workflow should not upload test results to TOD by default.