### PR TITLE
Add support for increased block storage volume limits

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -286,6 +286,62 @@ Manage Linode Instances, Configs, and Disks.
 | [`sdf` (sub-options)](#sdf) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdf   |
 | [`sdg` (sub-options)](#sdg) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdg   |
 | [`sdh` (sub-options)](#sdh) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdh   |
+| [`sdi` (sub-options)](#sdi) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdi   |
+| [`sdj` (sub-options)](#sdj) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdj   |
+| [`sdk` (sub-options)](#sdk) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdk   |
+| [`sdl` (sub-options)](#sdl) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdl   |
+| [`sdm` (sub-options)](#sdm) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdm   |
+| [`sdn` (sub-options)](#sdn) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdn   |
+| [`sdo` (sub-options)](#sdo) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdo   |
+| [`sdp` (sub-options)](#sdp) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdp   |
+| [`sdq` (sub-options)](#sdq) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdq   |
+| [`sdr` (sub-options)](#sdr) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdr   |
+| [`sds` (sub-options)](#sds) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sds   |
+| [`sdt` (sub-options)](#sdt) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdt   |
+| [`sdu` (sub-options)](#sdu) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdu   |
+| [`sdv` (sub-options)](#sdv) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdv   |
+| [`sdw` (sub-options)](#sdw) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdw   |
+| [`sdx` (sub-options)](#sdx) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdx   |
+| [`sdy` (sub-options)](#sdy) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdy   |
+| [`sdz` (sub-options)](#sdz) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdz   |
+| [`sdaa` (sub-options)](#sdaa) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaa   |
+| [`sdab` (sub-options)](#sdab) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdab   |
+| [`sdac` (sub-options)](#sdac) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdac   |
+| [`sdad` (sub-options)](#sdad) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdad   |
+| [`sdae` (sub-options)](#sdae) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdae   |
+| [`sdaf` (sub-options)](#sdaf) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaf   |
+| [`sdag` (sub-options)](#sdag) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdag   |
+| [`sdah` (sub-options)](#sdah) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdah   |
+| [`sdai` (sub-options)](#sdai) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdai   |
+| [`sdaj` (sub-options)](#sdaj) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaj   |
+| [`sdak` (sub-options)](#sdak) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdak   |
+| [`sdal` (sub-options)](#sdal) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdal   |
+| [`sdam` (sub-options)](#sdam) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdam   |
+| [`sdan` (sub-options)](#sdan) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdan   |
+| [`sdao` (sub-options)](#sdao) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdao   |
+| [`sdap` (sub-options)](#sdap) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdap   |
+| [`sdaq` (sub-options)](#sdaq) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaq   |
+| [`sdar` (sub-options)](#sdar) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdar   |
+| [`sdas` (sub-options)](#sdas) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdas   |
+| [`sdat` (sub-options)](#sdat) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdat   |
+| [`sdau` (sub-options)](#sdau) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdau   |
+| [`sdav` (sub-options)](#sdav) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdav   |
+| [`sdaw` (sub-options)](#sdaw) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaw   |
+| [`sdax` (sub-options)](#sdax) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdax   |
+| [`sday` (sub-options)](#sday) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sday   |
+| [`sdaz` (sub-options)](#sdaz) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdaz   |
+| [`sdba` (sub-options)](#sdba) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdba   |
+| [`sdbb` (sub-options)](#sdbb) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbb   |
+| [`sdbc` (sub-options)](#sdbc) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbc   |
+| [`sdbd` (sub-options)](#sdbd) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbd   |
+| [`sdbe` (sub-options)](#sdbe) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbe   |
+| [`sdbf` (sub-options)](#sdbf) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbf   |
+| [`sdbg` (sub-options)](#sdbg) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbg   |
+| [`sdbh` (sub-options)](#sdbh) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbh   |
+| [`sdbi` (sub-options)](#sdbi) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbi   |
+| [`sdbj` (sub-options)](#sdbj) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbj   |
+| [`sdbk` (sub-options)](#sdbk) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbk   |
+| [`sdbl` (sub-options)](#sdbl) | <center>`dict`</center> | <center>Optional</center> | The device to be mapped to /dev/sdbl   |
 
 ### sda
 
@@ -344,6 +400,454 @@ Manage Linode Instances, Configs, and Disks.
 | `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
 
 ### sdh
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdi
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdj
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdk
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdl
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdm
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdn
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdo
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdp
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdq
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdr
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sds
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdt
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdu
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdv
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdw
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdx
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdy
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdz
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaa
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdab
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdac
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdad
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdae
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaf
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdag
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdah
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdai
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaj
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdak
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdal
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdam
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdan
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdao
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdap
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaq
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdar
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdas
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdat
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdau
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdav
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaw
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdax
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sday
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdaz
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdba
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbb
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbc
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbd
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbe
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbf
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbg
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbh
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbi
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbj
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbk
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `disk_label` | <center>`str`</center> | <center>Optional</center> | The label of the disk to attach to this Linode.   |
+| `disk_id` | <center>`int`</center> | <center>Optional</center> | The ID of the disk to attach to this Linode.   |
+| `volume_id` | <center>`int`</center> | <center>Optional</center> | The ID of the volume to attach to this Linode.   |
+
+### sdbl
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -35,8 +35,6 @@ from linode_api4.objects.filtering import (
 )
 from linode_api4.polling import TimeoutContext
 
-MAX_DEVICES_PER_CONFIG = 64
-
 
 def dict_select_spec(target: dict, spec: dict) -> dict:
     """Returns a new dictionary that only selects the keys from target that are specified in spec"""
@@ -698,14 +696,14 @@ def api_filter_constructor_for_aclp_monitor_services(
     return value_filters
 
 
-def generate_device_suffixes() -> List[str]:
+def generate_device_suffixes(max_device_limit: int) -> List[str]:
     """
     Generates a list of device suffixes. Currently supports up to 64 devices,
     which is the maximum number of devices supported by Linode instances.
     The suffixes are generated in the format of a, b, c, ..., z, aa, ab, ..., az, ba, bb, ..., bl.
     """
     result = []
-    for i in range(MAX_DEVICES_PER_CONFIG):
+    for i in range(max_device_limit):
         if i < 26:
             result.append(chr(ord("a") + i))
         else:

--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -35,6 +35,8 @@ from linode_api4.objects.filtering import (
 )
 from linode_api4.polling import TimeoutContext
 
+MAX_DEVICES_PER_CONFIG = 64
+
 
 def dict_select_spec(target: dict, spec: dict) -> dict:
     """Returns a new dictionary that only selects the keys from target that are specified in spec"""
@@ -694,3 +696,22 @@ def api_filter_constructor_for_aclp_monitor_services(
             value_filters = {"+and": result}
 
     return value_filters
+
+
+def generate_device_suffixes() -> List[str]:
+    """
+    Generates a list of device suffixes. Currently supports up to 64 devices,
+    which is the maximum number of devices supported by Linode instances.
+    The suffixes are generated in the format of a, b, c, ..., z, aa, ab, ..., az, ba, bb, ..., bl.
+    """
+    result = []
+    for i in range(MAX_DEVICES_PER_CONFIG):
+        if i < 26:
+            result.append(chr(ord("a") + i))
+        else:
+            shifted = i - 26
+            first_letter = chr(ord("a") + (shifted // 26))
+            second_letter = chr(ord("a") + (shifted % 26))
+            result.append(first_letter + second_letter)
+
+    return result

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1018,7 +1018,7 @@ class LinodeInstance(LinodeModuleBase):
 
         return None
 
-    def _calculate_devices(
+    def _reconcile_devices(
         self, config_params: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         device_params = config_params.pop("devices")
@@ -1055,7 +1055,7 @@ class LinodeInstance(LinodeModuleBase):
         return devices
 
     def _create_config_register(self, config_params: Dict[str, Any]) -> None:
-        devices = self._calculate_devices(config_params)
+        devices = self._reconcile_devices(config_params)
         try:
             self._instance.config_create(
                 devices=devices, **filter_null_values(config_params)

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -23,6 +23,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     drop_empty_strings,
     filter_null_values,
     filter_null_values_recursive,
+    generate_device_suffixes,
     handle_updates,
     matching_keys_eq,
     paginated_list_to_json,
@@ -162,7 +163,7 @@ linode_instance_devices_spec = {
         description=[f"The device to be mapped to /dev/sd{k}"],
         suboptions=linode_instance_device_spec,
     )
-    for k in "abcdefgh"
+    for k in generate_device_suffixes()
 }
 
 linode_instance_helpers_spec = {
@@ -723,6 +724,10 @@ RETURN = r"""
 class LinodeInstance(LinodeModuleBase):
     """Module for creating and destroying Linode Instances"""
 
+    MB_PER_GB = 1024
+    MAX_DEVICE_LIMIT = 64
+    MIN_DEVICE_LIMIT = 8
+
     def __init__(self) -> None:
         self.module_arg_spec = SPECDOC_META.ansible_spec
 
@@ -1013,19 +1018,44 @@ class LinodeInstance(LinodeModuleBase):
 
         return None
 
-    def _create_config_register(self, config_params: Dict[str, Any]) -> None:
+    def _calculate_devices(
+        self, config_params: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         device_params = config_params.pop("devices")
         devices = []
 
         if device_params is not None:
-            for device_suffix in ["a", "b", "c", "d", "e", "f", "g", "h"]:
+            device_limit = int(
+                max(
+                    self.MIN_DEVICE_LIMIT,
+                    min(
+                        self._instance.specs.memory // self.MB_PER_GB,
+                        self.MAX_DEVICE_LIMIT,
+                    ),
+                )
+            )
+
+            for device_suffix in generate_device_suffixes():
                 device_name = "sd{0}".format(device_suffix)
                 if device_name not in device_params:
                     continue
 
                 device_dict = device_params.get(device_name)
-                devices.append(self._param_device_to_device(device_dict))
+                device = self._param_device_to_device(device_dict)
+                if device is not None:
+                    devices.append(device)
+                    if len(devices) > device_limit:
+                        self.fail(
+                            msg=f"Too many devices specified for this instance type. "
+                            f"Instance '{self._instance.label}' (type: {self._instance.type.id}, "
+                            f"memory: {self._instance.specs.memory}MB) supports a maximum of "
+                            f"{device_limit} devices."
+                        )
 
+        return devices
+
+    def _create_config_register(self, config_params: Dict[str, Any]) -> None:
+        devices = self._calculate_devices(config_params)
         try:
             self._instance.config_create(
                 devices=devices, **filter_null_values(config_params)

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -63,6 +63,10 @@ except ImportError:
     # handled in module_utils.linode_common
     pass
 
+MB_PER_GB = 1024
+MAX_DEVICE_LIMIT = 64
+MIN_DEVICE_LIMIT = 8
+
 linode_instance_metadata_spec = {
     "user_data": SpecField(
         type=FieldType.string,
@@ -163,7 +167,7 @@ linode_instance_devices_spec = {
         description=[f"The device to be mapped to /dev/sd{k}"],
         suboptions=linode_instance_device_spec,
     )
-    for k in generate_device_suffixes()
+    for k in generate_device_suffixes(MAX_DEVICE_LIMIT)
 }
 
 linode_instance_helpers_spec = {
@@ -724,10 +728,6 @@ RETURN = r"""
 class LinodeInstance(LinodeModuleBase):
     """Module for creating and destroying Linode Instances"""
 
-    MB_PER_GB = 1024
-    MAX_DEVICE_LIMIT = 64
-    MIN_DEVICE_LIMIT = 8
-
     def __init__(self) -> None:
         self.module_arg_spec = SPECDOC_META.ansible_spec
 
@@ -1020,22 +1020,22 @@ class LinodeInstance(LinodeModuleBase):
 
     def _reconcile_devices(
         self, config_params: Dict[str, Any]
-    ) -> List[Dict[str, Any]]:
+    ) -> List[Union[Disk, Volume]]:
         device_params = config_params.pop("devices")
         devices = []
 
         if device_params is not None:
             device_limit = int(
                 max(
-                    self.MIN_DEVICE_LIMIT,
+                    MIN_DEVICE_LIMIT,
                     min(
-                        self._instance.specs.memory // self.MB_PER_GB,
-                        self.MAX_DEVICE_LIMIT,
+                        self._instance.specs.memory // MB_PER_GB,
+                        MAX_DEVICE_LIMIT,
                     ),
                 )
             )
 
-            for device_suffix in generate_device_suffixes():
+            for device_suffix in generate_device_suffixes(MAX_DEVICE_LIMIT):
                 device_name = "sd{0}".format(device_suffix)
                 if device_name not in device_params:
                     continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# TODO: Update python-sdk dependency to latest version when merging proj/block-storage-volume-limit-increase branch.
 git+https://github.com/linode/linode_api4-python.git@proj/block-storage-volume-limit-increase#egg=linode-api4
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode-api4>=5.39.0
+git+https://github.com/linode/linode_api4-python.git@proj/block-storage-volume-limit-increase#egg=linode-api4
 polling==0.3.2
 ansible-specdoc>=0.0.19

--- a/tests/integration/targets/instance_volumes_limit/tasks/main.yaml
+++ b/tests/integration/targets/instance_volumes_limit/tasks/main.yaml
@@ -11,22 +11,22 @@
         size: "{{ item.size }}"
         state: present
       loop:
-        - { label: 'sdy', region: 'us-ord', size: 10 }
-        - { label: 'sdz', region: 'us-ord', size: 10 }
-        - { label: 'sdaa', region: 'us-ord', size: 10 }
-        - { label: 'sdaz', region: 'us-ord', size: 10 }
-        - { label: 'sdba', region: 'us-ord', size: 10 }
-        - { label: 'sdbb', region: 'us-ord', size: 10 }
-        - { label: 'sdbc', region: 'us-ord', size: 10 }
-        - { label: 'sdbd', region: 'us-ord', size: 10 }
-        - { label: 'sdbe', region: 'us-ord', size: 10 }
-        - { label: 'sdbf', region: 'us-ord', size: 10 }
-        - { label: 'sdbg', region: 'us-ord', size: 10 }
-        - { label: 'sdbh', region: 'us-ord', size: 10 }
-        - { label: 'sdbi', region: 'us-ord', size: 10 }
-        - { label: 'sdbj', region: 'us-ord', size: 10 }
-        - { label: 'sdbk', region: 'us-ord', size: 10 }
-        - { label: 'sdbl', region: 'us-ord', size: 10 }
+        - { label: 'sdy-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdz-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdaa-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdaz-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdba-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbb-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbc-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbd-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbe-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbf-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbg-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbh-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbi-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbj-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbk-{{ r }}', region: 'us-ord', size: 10 }
+        - { label: 'sdbl-{{ r }}', region: 'us-ord', size: 10 }
       register: volumes_output
 
     - name: Create a Linode instance with 16 volumes
@@ -111,7 +111,7 @@
     - name: Create extra volume for the instance to exceed the max limit
       linode.cloud.volume:
         region: 'us-ord'
-        label: 'sda-extra'
+        label: 'sda-extra-{{ r2 }}'
         size: 10
         state: present
       register: extra_volume
@@ -199,23 +199,23 @@
             label: '{{ item.label }}'
             state: absent
           loop:
-            - { label: 'sdy' }
-            - { label: 'sdz' }
-            - { label: 'sdaa' }
-            - { label: 'sdaz' }
-            - { label: 'sdba' }
-            - { label: 'sdbb' }
-            - { label: 'sdbc' }
-            - { label: 'sdbd' }
-            - { label: 'sdbe' }
-            - { label: 'sdbf' }
-            - { label: 'sdbg' }
-            - { label: 'sdbh' }
-            - { label: 'sdbi' }
-            - { label: 'sdbj' }
-            - { label: 'sdbk' }
-            - { label: 'sdbl' }
-            - { label: 'sda-extra' }
+            - { label: 'sdy-{{ r }}' }
+            - { label: 'sdz-{{ r }}' }
+            - { label: 'sdaa-{{ r }}' }
+            - { label: 'sdaz-{{ r }}' }
+            - { label: 'sdba-{{ r }}' }
+            - { label: 'sdbb-{{ r }}' }
+            - { label: 'sdbc-{{ r }}' }
+            - { label: 'sdbd-{{ r }}' }
+            - { label: 'sdbe-{{ r }}' }
+            - { label: 'sdbf-{{ r }}' }
+            - { label: 'sdbg-{{ r }}' }
+            - { label: 'sdbh-{{ r }}' }
+            - { label: 'sdbi-{{ r }}' }
+            - { label: 'sdbj-{{ r }}' }
+            - { label: 'sdbk-{{ r }}' }
+            - { label: 'sdbl-{{ r }}' }
+            - { label: 'sda-extra-{{ r2 }}' }
           register: delete_volumes
 
         - name: Assert volumes delete succeeded

--- a/tests/integration/targets/instance_volumes_limit/tasks/main.yaml
+++ b/tests/integration/targets/instance_volumes_limit/tasks/main.yaml
@@ -1,0 +1,249 @@
+- name: instance_volumes_limit
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+        r2: "{{ 1000000000 | random }}"
+
+    - name: Create 16 volumes 
+      linode.cloud.volume:
+        region: 'us-ord'
+        label: "{{ item.label }}"
+        size: "{{ item.size }}"
+        state: present
+      loop:
+        - { label: 'sdy', region: 'us-ord', size: 10 }
+        - { label: 'sdz', region: 'us-ord', size: 10 }
+        - { label: 'sdaa', region: 'us-ord', size: 10 }
+        - { label: 'sdaz', region: 'us-ord', size: 10 }
+        - { label: 'sdba', region: 'us-ord', size: 10 }
+        - { label: 'sdbb', region: 'us-ord', size: 10 }
+        - { label: 'sdbc', region: 'us-ord', size: 10 }
+        - { label: 'sdbd', region: 'us-ord', size: 10 }
+        - { label: 'sdbe', region: 'us-ord', size: 10 }
+        - { label: 'sdbf', region: 'us-ord', size: 10 }
+        - { label: 'sdbg', region: 'us-ord', size: 10 }
+        - { label: 'sdbh', region: 'us-ord', size: 10 }
+        - { label: 'sdbi', region: 'us-ord', size: 10 }
+        - { label: 'sdbj', region: 'us-ord', size: 10 }
+        - { label: 'sdbk', region: 'us-ord', size: 10 }
+        - { label: 'sdbl', region: 'us-ord', size: 10 }
+      register: volumes_output
+
+    - name: Create a Linode instance with 16 volumes
+      linode.cloud.instance:
+        label: 'ansible-test-volumes-limit-{{ r }}'
+        region: 'us-ord'
+        type: g6-standard-6
+        private_ip: true
+        wait: false
+        state: present
+        firewall_id: '{{ firewall_id }}'
+        configs:
+          - label: linode-config-max-volumes
+            devices:
+              sdy:
+                volume_id: "{{ volumes_output.results[0].volume.id }}"
+              sdz:
+                volume_id: "{{ volumes_output.results[1].volume.id }}"
+              sdaa:
+                volume_id: "{{ volumes_output.results[2].volume.id }}"
+              sdaz:
+                volume_id: "{{ volumes_output.results[3].volume.id }}"
+              sdba:
+                volume_id: "{{ volumes_output.results[4].volume.id }}"
+              sdbb:
+                volume_id: "{{ volumes_output.results[5].volume.id }}"
+              sdbc:
+                volume_id: "{{ volumes_output.results[6].volume.id }}"
+              sdbd:
+                volume_id: "{{ volumes_output.results[7].volume.id }}"
+              sdbe:
+                volume_id: "{{ volumes_output.results[8].volume.id }}"
+              sdbf:
+                volume_id: "{{ volumes_output.results[9].volume.id }}"
+              sdbg:
+                volume_id: "{{ volumes_output.results[10].volume.id }}"
+              sdbh:
+                volume_id: "{{ volumes_output.results[11].volume.id }}"
+              sdbi:
+                volume_id: "{{ volumes_output.results[12].volume.id }}"
+              sdbj:
+                volume_id: "{{ volumes_output.results[13].volume.id }}"
+              sdbk:
+                volume_id: "{{ volumes_output.results[14].volume.id }}"
+              sdbl:
+                volume_id: "{{ volumes_output.results[15].volume.id }}"
+      register: create
+
+    - name: Assert instance created
+      assert:
+        that:
+          - create.changed
+          - create.instance.ipv4|length > 1
+          - create.networking.ipv4.public[0].address != None
+
+    - name: Fetch every volume's information
+      linode.cloud.volume_info:
+        id: "{{ item.volume.id }}"
+      loop: "{{ volumes_output.results }}"
+      register: volume_info_output
+
+    - name: Assert volumes are attached to the instance
+      assert:
+        that:
+          - volume_info_output.results[0].volume.linode_id == create.instance.id
+          - volume_info_output.results[1].volume.linode_id == create.instance.id
+          - volume_info_output.results[2].volume.linode_id == create.instance.id
+          - volume_info_output.results[3].volume.linode_id == create.instance.id
+          - volume_info_output.results[4].volume.linode_id == create.instance.id
+          - volume_info_output.results[5].volume.linode_id == create.instance.id
+          - volume_info_output.results[6].volume.linode_id == create.instance.id
+          - volume_info_output.results[7].volume.linode_id == create.instance.id
+          - volume_info_output.results[8].volume.linode_id == create.instance.id
+          - volume_info_output.results[9].volume.linode_id == create.instance.id
+          - volume_info_output.results[10].volume.linode_id == create.instance.id
+          - volume_info_output.results[11].volume.linode_id == create.instance.id
+          - volume_info_output.results[12].volume.linode_id == create.instance.id
+          - volume_info_output.results[13].volume.linode_id == create.instance.id
+          - volume_info_output.results[14].volume.linode_id == create.instance.id
+          - volume_info_output.results[15].volume.linode_id == create.instance.id
+
+    - name: Create extra volume for the instance to exceed the max limit
+      linode.cloud.volume:
+        region: 'us-ord'
+        label: 'sda-extra'
+        size: 10
+        state: present
+      register: extra_volume
+
+    - name: Attempt to create an instance with 17 volumes
+      linode.cloud.instance:
+        region: 'us-ord'
+        label: 'ansible-test-volumes-limit-exceeded-{{ r2 }}'
+        type: g6-standard-6
+        private_ip: true
+        wait: false
+        state: present
+        firewall_id: '{{ firewall_id }}'
+        configs:
+          - label: linode-config-max-volumes-exceeded
+            devices:
+              sdy:
+                volume_id: "{{ volumes_output.results[0].volume.id }}"
+              sdz:
+                volume_id: "{{ volumes_output.results[1].volume.id }}"
+              sdaa:
+                volume_id: "{{ volumes_output.results[2].volume.id }}"
+              sdaz:
+                volume_id: "{{ volumes_output.results[3].volume.id }}"
+              sdba:
+                volume_id: "{{ volumes_output.results[4].volume.id }}"
+              sdbb:
+                volume_id: "{{ volumes_output.results[5].volume.id }}"
+              sdbc:
+                volume_id: "{{ volumes_output.results[6].volume.id }}"
+              sdbd:
+                volume_id: "{{ volumes_output.results[7].volume.id }}"
+              sdbe:
+                volume_id: "{{ volumes_output.results[8].volume.id }}"
+              sdbf:
+                volume_id: "{{ volumes_output.results[9].volume.id }}"
+              sdbg:
+                volume_id: "{{ volumes_output.results[10].volume.id }}"
+              sdbh:
+                volume_id: "{{ volumes_output.results[11].volume.id }}"
+              sdbi:
+                volume_id: "{{ volumes_output.results[12].volume.id }}"
+              sdbj:
+                volume_id: "{{ volumes_output.results[13].volume.id }}"
+              sdbk:
+                volume_id: "{{ volumes_output.results[14].volume.id }}"
+              sdbl:
+                volume_id: "{{ volumes_output.results[15].volume.id }}"
+              sda:
+                volume_id: "{{ extra_volume.volume.id }}"
+      register: invalid_create
+      failed_when:
+        - invalid_create.changed == true
+        - '"Too many devices specified for this instance type." not in invalid_create.msg'
+
+  always:
+    - ignore_errors: true
+      block:
+        - name: Delete first Linode instance
+          linode.cloud.instance:
+            label: '{{ create.instance.label }}'
+            state: absent
+          register: delete_instance
+
+        - name: Delete second Linode instance
+          linode.cloud.instance:
+            label: 'ansible-test-volumes-limit-exceeded-{{ r2 }}'
+            state: absent
+          register: delete_instance_2
+
+        - name: Assert first instance delete succeeded
+          assert:
+            that:
+              - delete_instance.changed
+              - delete_instance.instance.id == create.instance.id
+
+        - name: Assert second instance delete succeeded
+          assert:
+            that:
+              - delete_instance_2.changed == false or delete_instance_2.instance.id is defined
+          when: not invalid_create.failed
+
+        - name: Delete volumes
+          linode.cloud.volume:
+            label: '{{ item.label }}'
+            state: absent
+          loop:
+            - { label: 'sdy' }
+            - { label: 'sdz' }
+            - { label: 'sdaa' }
+            - { label: 'sdaz' }
+            - { label: 'sdba' }
+            - { label: 'sdbb' }
+            - { label: 'sdbc' }
+            - { label: 'sdbd' }
+            - { label: 'sdbe' }
+            - { label: 'sdbf' }
+            - { label: 'sdbg' }
+            - { label: 'sdbh' }
+            - { label: 'sdbi' }
+            - { label: 'sdbj' }
+            - { label: 'sdbk' }
+            - { label: 'sdbl' }
+            - { label: 'sda-extra' }
+          register: delete_volumes
+
+        - name: Assert volumes delete succeeded
+          assert:
+            that:
+              - delete_volumes.changed
+              - delete_volumes.results[0].volume.id == volumes_output.results[0].volume.id
+              - delete_volumes.results[1].volume.id == volumes_output.results[1].volume.id
+              - delete_volumes.results[2].volume.id == volumes_output.results[2].volume.id
+              - delete_volumes.results[3].volume.id == volumes_output.results[3].volume.id
+              - delete_volumes.results[4].volume.id == volumes_output.results[4].volume.id
+              - delete_volumes.results[5].volume.id == volumes_output.results[5].volume.id
+              - delete_volumes.results[6].volume.id == volumes_output.results[6].volume.id
+              - delete_volumes.results[7].volume.id == volumes_output.results[7].volume.id
+              - delete_volumes.results[8].volume.id == volumes_output.results[8].volume.id
+              - delete_volumes.results[9].volume.id == volumes_output.results[9].volume.id
+              - delete_volumes.results[10].volume.id == volumes_output.results[10].volume.id
+              - delete_volumes.results[11].volume.id == volumes_output.results[11].volume.id
+              - delete_volumes.results[12].volume.id == volumes_output.results[12].volume.id
+              - delete_volumes.results[13].volume.id == volumes_output.results[13].volume.id
+              - delete_volumes.results[14].volume.id == volumes_output.results[14].volume.id
+              - delete_volumes.results[15].volume.id == volumes_output.results[15].volume.id
+              - delete_volumes.results[16].volume.id == extra_volume.volume.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/unit/module_utils/test_linode_helper.py
+++ b/tests/unit/module_utils/test_linode_helper.py
@@ -1,8 +1,9 @@
 import pytest
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     dict_select_spec,
-    filter_null_values,
     drop_empty_strings,
+    filter_null_values,
+    generate_device_suffixes,
     validate_required,
 )
 
@@ -80,3 +81,13 @@ class TestLinodeHelper:
             pytest.fail(
                 f"validate_required raised an unexpected exception: {e}"
             )
+
+    def test_generate_device_suffixes(self):
+        expected_suffixes = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 
+                             'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                             'aa', 'ab', 'ac', 'ad', 'ae', 'af', 'ag', 'ah', 'ai', 'aj', 'ak', 
+                             'al', 'am', 'an', 'ao', 'ap', 'aq', 'ar', 'as', 'at', 'au', 'av', 
+                             'aw', 'ax', 'ay', 'az', 'ba', 'bb', 'bc', 'bd', 'be', 'bf', 'bg', 
+                             'bh', 'bi', 'bj', 'bk', 'bl']
+        result = generate_device_suffixes()
+        assert result == expected_suffixes

--- a/tests/unit/module_utils/test_linode_helper.py
+++ b/tests/unit/module_utils/test_linode_helper.py
@@ -6,6 +6,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     generate_device_suffixes,
     validate_required,
 )
+from ansible_collections.linode.cloud.plugins.modules.instance import MAX_DEVICE_LIMIT
 
 
 class TestLinodeHelper:
@@ -89,5 +90,5 @@ class TestLinodeHelper:
                              'al', 'am', 'an', 'ao', 'ap', 'aq', 'ar', 'as', 'at', 'au', 'av', 
                              'aw', 'ax', 'ay', 'az', 'ba', 'bb', 'bc', 'bd', 'be', 'bf', 'bg', 
                              'bh', 'bi', 'bj', 'bk', 'bl']
-        result = generate_device_suffixes()
+        result = generate_device_suffixes(MAX_DEVICE_LIMIT)
         assert result == expected_suffixes


### PR DESCRIPTION
## 📝 Description

This PR adds support for configuring up to 64 devices (volumes/disks) per Linode Instance Configuration, depending on the Linode's RAM. 
Previously you could define 8 slots: `sda-sdh`. 
Now you can define `sda-sdz`, `sdaa-sdaz` and `sdba-sdbl`.

There was also a bug in the logic, when if you have skipped consecutive device from configuration, it was added anyway as a `Null` object.

## ✔️ How to Test

In order to utilize the logic for increased block storage volume limits, make sure to use `proj/block-storage-volume-limit-increase` branch inside `linode_api4-python` repository. (I have used: `pip install -e .`) 

To run unit tests (1 new unit test case):
`make test-unit`

To run Integration tests:
`make integration-test TEST_SUITE=instance_volumes_limit`
