### PR TITLE
Add --yes flag to ansible-specdoc for non-interactive CI runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,10 +135,10 @@ endif
 inject:
 	@echo "Injecting documentation into source files"
 	find ./plugins/modules -maxdepth 1 -name '*.py' -print0 | \
-		xargs -I {} -0 -P 5 bash -c 'export TARGET="{}"; echo "$$TARGET" && ansible-specdoc -j -i "$$TARGET";'
+		xargs -I {} -0 -P 5 bash -c 'export TARGET="{}"; echo "$$TARGET" && ansible-specdoc -j -i "$$TARGET" --yes;'
 
 inject-clean:
 	@echo "Removing injected documentation from source files"
 	find ./plugins/modules -maxdepth 1 -name '*.py' -print0 | \
-		xargs -I {} -0 -P 5 bash -c 'export TARGET="{}"; echo "$$TARGET" && ansible-specdoc -jc -i "$$TARGET";'
+		xargs -I {} -0 -P 5 bash -c 'export TARGET="{}"; echo "$$TARGET" && ansible-specdoc -jc -i "$$TARGET" --yes;'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 linode-api4>=5.39.0
 polling==0.3.2
-ansible-specdoc>=0.0.19
+ansible-specdoc>=0.0.20

--- a/scripts/specdoc_generate.sh
+++ b/scripts/specdoc_generate.sh
@@ -9,7 +9,7 @@ render_module_doc() {
 
   echo "Rendering: $MODULE_NAME"
 
-  ansible-specdoc -i "$1" -f jinja2 -t template/module.md.j2 -o "$DOCS_PATH/modules/$MODULE_NAME.md"
+  ansible-specdoc -i "$1" -f jinja2 -t template/module.md.j2 -o "$DOCS_PATH/modules/$MODULE_NAME.md" --yes
 }
 
 export -f render_module_doc


### PR DESCRIPTION
## 📝 Description

Added the new --yes flag to skip the warning when importing and executing module code in CI.