### PR TITLE
Remove longview_subscription field from account_settings documentation and module specification

### DIFF
--- a/docs/modules/account_settings.md
+++ b/docs/modules/account_settings.md
@@ -27,7 +27,6 @@ Returns information related to your Account settings.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `state` | <center>`str`</center> | <center>**Required**</center> | The state of Account Settings.  **(Choices: `present`)** |
 | `backups_enabled` | <center>`bool`</center> | <center>Optional</center> | Account-wide backups default. If true, all Linodes created will automatically be enrolled in the Backups service. If false, Linodes will not be enrolled by default, but may still be enrolled on creation or later.   |
-| `longview_subscription` | <center>`str`</center> | <center>Optional</center> | The Longview Pro tier you are currently subscribed to. The value must be a Longview subscription ID or null for Longview Free.   |
 | `network_helper` | <center>`bool`</center> | <center>Optional</center> | Enables network helper across all users by default for new Linodes and Linode Configs.   |
 | `maintenance_policy` | <center>`str`</center> | <center>Optional</center> | The Slug of the maintenance policy associated with the account. NOTE: This field is under v4beta.  **(Choices: `linode/migrate`, `linode/power_off_on`)** |
 

--- a/plugins/modules/account_settings.py
+++ b/plugins/modules/account_settings.py
@@ -43,13 +43,6 @@ SPEC = {
             "but may still be enrolled on creation or later."
         ],
     ),
-    "longview_subscription": SpecField(
-        type=FieldType.string,
-        description=[
-            "The Longview Pro tier you are currently subscribed to. "
-            "The value must be a Longview subscription ID or null for Longview Free."
-        ],
-    ),
     "network_helper": SpecField(
         type=FieldType.bool,
         description=[


### PR DESCRIPTION
## 📝 Description

Remove longview_subscription field from account_settings documentation and module specification

## ✔️ How to Test

```bash
make test-int TEST_SUITE=account_settings
```