### PR TITLE
TPT-4208: Implement support for NB Front-End IP & 40Gbps

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Name | Description |
 [linode.cloud.network_transfer_prices_list](./docs/modules/network_transfer_prices_list.md)|List and filter on Network Transfer Prices.|
 [linode.cloud.nodebalancer_list](./docs/modules/nodebalancer_list.md)|List and filter on Node Balancers.|
 [linode.cloud.nodebalancer_type_list](./docs/modules/nodebalancer_type_list.md)|List and filter on Node Balancer Types.|
+[linode.cloud.nodebalancer_vpc_list](./docs/modules/nodebalancer_vpc_list.md)|List and filter on Node Balancer VPC Configurations.|
 [linode.cloud.object_cluster_list](./docs/modules/object_cluster_list.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.object_storage_endpoint_list](./docs/modules/object_storage_endpoint_list.md)|List and filter on Object Storage Endpoints.|
 [linode.cloud.object_storage_quota_list](./docs/modules/object_storage_quota_list.md)|List and filter on Object Storage Quotas.|

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Name | Description |
 [linode.cloud.lock_info](./docs/modules/lock_info.md)|Get info about a Linode Lock.|
 [linode.cloud.monitor_services_alert_definition_info](./docs/modules/monitor_services_alert_definition_info.md)|Get info about a Linode Alert Definition.|
 [linode.cloud.nodebalancer_info](./docs/modules/nodebalancer_info.md)|Get info about a Linode Node Balancer.|
+[linode.cloud.nodebalancer_vpc_info](./docs/modules/nodebalancer_vpc_info.md)|Get info about a Linode VPC Configuration.|
 [linode.cloud.object_cluster_info](./docs/modules/object_cluster_info.md)|**NOTE: This module has been deprecated because it relies on deprecated API endpoints. Going forward, `region` will be the preferred way to designate where Object Storage resources should be created.**|
 [linode.cloud.object_storage_quota_info](./docs/modules/object_storage_quota_info.md)|Get info about a Linode Object Storage Quota.|
 [linode.cloud.placement_group_info](./docs/modules/placement_group_info.md)|Get info about a Linode Placement Group.|

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -54,6 +54,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `tags` | <center>`list`</center> | <center>Optional</center> | Tags to assign to this NodeBalancer.  **(Updatable)** |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 | `type` | <center>`str`</center> | <center>Optional</center> | The type of this NodeBalancer.  **(Choices: `common`, `premium`, `premium_40gb`)** |
+| [`vpcs` (sub-options)](#vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for backend nodes.   |
 
 ### configs
 
@@ -86,6 +87,14 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `address` | <center>`str`</center> | <center>**Required**</center> | The private IP Address where this backend can be reached. This must be a private IP address.  **(Updatable)** |
 | `weight` | <center>`int`</center> | <center>Optional</center> | Nodes with a higher weight will receive more traffic.  **(Updatable)** |
 | `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`; Updatable)** |
+
+### vpcs
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `subnet_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the subnet to attach this NodeBalancer to.   |
+| `ipv4_range` | <center>`str`</center> | <center>Optional</center> | A CIDR range for the VPC's IPv4 addresses. The NodeBalancer sources IP addresses from this range when routing traffic to the backend VPC nodes.   |
+| `ipv4_range_auto_assign` | <center>`bool`</center> | <center>Optional</center> | Enables the use of a larger ipv4_range subnet for multiple NodeBalancers within the same VPC by allocating smaller /30 subnets for each NodeBalancer's backends.  **(Default: `False`)** |
 
 ## Return Values
 

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -23,7 +23,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
     region: us-east
     tags: [ prod-env ]
     state: present
-    vpcs:
+    backend_vpcs:
       - subnet_id: 12345
         ipv4_range: '10.0.0.4/30'
     frontend_vpcs:
@@ -60,7 +60,8 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `tags` | <center>`list`</center> | <center>Optional</center> | Tags to assign to this NodeBalancer.  **(Updatable)** |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 | `type` | <center>`str`</center> | <center>Optional</center> | The type of this NodeBalancer.  **(Choices: `common`, `premium`, `premium_40gb`)** |
-| [`vpcs` (sub-options)](#vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for backend nodes.   |
+| [`vpcs` (sub-options)](#vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for backend nodes. **Deprecated**: Use `backend_vpcs` instead. This field will be removed in a future major release.   |
+| [`backend_vpcs` (sub-options)](#backend_vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for backend nodes.   |
 | [`frontend_vpcs` (sub-options)](#frontend_vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for frontend nodes.   |
 
 ### configs
@@ -96,6 +97,14 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `mode` | <center>`str`</center> | <center>Optional</center> | The mode this NodeBalancer should use when sending traffic to this backend.  **(Choices: `accept`, `reject`, `drain`, `backup`; Updatable)** |
 
 ### vpcs
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `subnet_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the subnet to attach this NodeBalancer to.   |
+| `ipv4_range` | <center>`str`</center> | <center>Optional</center> | A CIDR range for the VPC's IPv4 addresses. The NodeBalancer sources IP addresses from this range when routing traffic to the backend VPC nodes.   |
+| `ipv4_range_auto_assign` | <center>`bool`</center> | <center>Optional</center> | Enables the use of a larger ipv4_range subnet for multiple NodeBalancers within the same VPC by allocating smaller /30 subnets for each NodeBalancer's backends.  **(Default: `False`)** |
+
+### backend_vpcs
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -53,6 +53,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of the Firewall to assign this NodeBalancer to.   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | Tags to assign to this NodeBalancer.  **(Updatable)** |
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
+| `type` | <center>`str`</center> | <center>Optional</center> | The type of this NodeBalancer.  **(Choices: `common`, `premium`, `premium_40gb`)** |
 
 ### configs
 
@@ -101,6 +102,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
           "ipv6": null,
           "label": "balancer12345",
           "region": "us-east",
+          "type": "common",
           "tags": [
             "example tag",
             "another example"
@@ -151,7 +153,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config) for a list of returned fields
 
 
-- `nodes` - A list of configs applied to the NodeBalancer.
+- `nodes` - A list of nodes applied to the NodeBalancer.
 
     - Sample Response:
         ```json

--- a/docs/modules/nodebalancer.md
+++ b/docs/modules/nodebalancer.md
@@ -23,6 +23,12 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
     region: us-east
     tags: [ prod-env ]
     state: present
+    vpcs:
+      - subnet_id: 12345
+        ipv4_range: '10.0.0.4/30'
+    frontend_vpcs:
+      - subnet_id: 67890
+        ipv4_range: '10.0.0.8/30'
     configs:
       - port: 80
         protocol: http
@@ -55,6 +61,7 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | [`configs` (sub-options)](#configs) | <center>`list`</center> | <center>Optional</center> | A list of configs to apply to the NodeBalancer.  **(Updatable)** |
 | `type` | <center>`str`</center> | <center>Optional</center> | The type of this NodeBalancer.  **(Choices: `common`, `premium`, `premium_40gb`)** |
 | [`vpcs` (sub-options)](#vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for backend nodes.   |
+| [`frontend_vpcs` (sub-options)](#frontend_vpcs) | <center>`list`</center> | <center>Optional</center> | A VPC configuration for frontend nodes.   |
 
 ### configs
 
@@ -96,6 +103,14 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
 | `ipv4_range` | <center>`str`</center> | <center>Optional</center> | A CIDR range for the VPC's IPv4 addresses. The NodeBalancer sources IP addresses from this range when routing traffic to the backend VPC nodes.   |
 | `ipv4_range_auto_assign` | <center>`bool`</center> | <center>Optional</center> | Enables the use of a larger ipv4_range subnet for multiple NodeBalancers within the same VPC by allocating smaller /30 subnets for each NodeBalancer's backends.  **(Default: `False`)** |
 
+### frontend_vpcs
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `subnet_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the subnet to attach this NodeBalancer to.   |
+| `ipv4_range` | <center>`str`</center> | <center>Optional</center> | A CIDR range for the VPC's IPv4 addresses allocated as the NodeBalancer's frontend IPs.   |
+| `ipv6_range` | <center>`str`</center> | <center>Optional</center> | A CIDR range for the VPC's IPv6 addresses allocated as the NodeBalancer's frontend IPs.   |
+
 ## Return Values
 
 - `node_balancer` - The NodeBalancer in JSON serialized form.
@@ -109,6 +124,8 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
           "id": 12345,
           "ipv4": "12.34.56.78",
           "ipv6": null,
+          "frontend_address_type": "public",
+          "frontend_vpc_subnet_id": null,
           "label": "balancer12345",
           "region": "us-east",
           "type": "common",
@@ -192,5 +209,43 @@ NOTE: UDP NodeBalancer may not currently be available to all users.
         ]
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls) for a list of returned fields
+
+
+- `vpcs` - A list of VPC configurations for backend nodes.
+
+    - Sample Response:
+        ```json
+        [
+          {
+            "id": 123,
+            "nodebalancer_id": 12345,
+            "subnet_id": 456,
+            "vpc_id": 789,
+            "ipv4_range": "10.0.0.4/30",
+            "ipv6_range": null,
+            "purpose": "backend"
+          }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
+
+
+- `frontend_vpcs` - A list of VPC configurations for frontend nodes.
+
+    - Sample Response:
+        ```json
+        [
+          {
+            "id": 123,
+            "nodebalancer_id": 12345,
+            "subnet_id": 456,
+            "vpc_id": 789,
+            "ipv4_range": "10.0.0.4/30",
+            "ipv6_range": "2001:db8:1234::/48",
+            "purpose": "frontend"
+          }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
 
 

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -47,6 +47,8 @@ Get info about a Linode Node Balancer.
           "id": 12345,
           "ipv4": "12.34.56.78",
           "ipv6": null,
+          "frontend_address_type": "public",
+          "frontend_vpc_subnet_id": null,
           "label": "balancer12345",
           "region": "us-east",
           "type": "common",
@@ -179,6 +181,25 @@ Get info about a Linode Node Balancer.
             "ipv4_range": "10.0.0.4/30",
             "ipv6_range": null,
             "purpose": "backend"
+          }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
+
+
+- `frontend_vpcs` - The returned frontend_vpcs.
+
+    - Sample Response:
+        ```json
+        [
+          {
+            "id": 123,
+            "nodebalancer_id": 12345,
+            "subnet_id": 456,
+            "vpc_id": 789,
+            "ipv4_range": "10.0.0.4/30",
+            "ipv6_range": "2001:db8:1234::/48",
+            "purpose": "frontend"
           }
         ]
         ```

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -166,3 +166,22 @@ Get info about a Linode Node Balancer.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls) for a list of returned fields
 
 
+- `vpcs` - The returned vpcs.
+
+    - Sample Response:
+        ```json
+        [
+          {
+            "id": 123,
+            "nodebalancer_id": 12345,
+            "subnet_id": 456,
+            "vpc_id": 789,
+            "ipv4_range": "10.0.0.4/30",
+            "ipv6_range": null,
+            "purpose": "backend"
+          }
+        ]
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_info.md
+++ b/docs/modules/nodebalancer_info.md
@@ -49,6 +49,7 @@ Get info about a Linode Node Balancer.
           "ipv6": null,
           "label": "balancer12345",
           "region": "us-east",
+          "type": "common",
           "tags": [
             "example tag",
             "another example"

--- a/docs/modules/nodebalancer_list.md
+++ b/docs/modules/nodebalancer_list.md
@@ -69,7 +69,8 @@ List and filter on Node Balancers.
                 "out": 3.5487728118896484,
                 "total": 32.46078109741211
               },
-              "updated": "2018-03-01T00:01:01"
+              "updated": "2018-03-01T00:01:01",
+              "type": "common"
             }
         ]
         ```

--- a/docs/modules/nodebalancer_list.md
+++ b/docs/modules/nodebalancer_list.md
@@ -58,6 +58,8 @@ List and filter on Node Balancers.
               "id": 12345,
               "ipv4": "203.0.113.1",
               "ipv6": null,
+              "frontend_address_type": "public",
+              "frontend_vpc_subnet_id": null,
               "label": "balancer12345",
               "region": "us-east",
               "tags": [

--- a/docs/modules/nodebalancer_vpc_info.md
+++ b/docs/modules/nodebalancer_vpc_info.md
@@ -1,0 +1,60 @@
+# nodebalancer_vpc_info
+
+Get info about a Linode VPC Configuration.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get a NodeBalancer VPC configuration by its id
+  linode.cloud.nodebalancer_vpc_info:
+    id: 12345
+    vpc_config_id: 123
+```
+
+```yaml
+- name: Get a NodeBalancer by its label
+  linode.cloud.nodebalancer_vpc_info:
+    label: cool_nodebalancer
+    vpc_config_id: 123
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `vpc_config_id` | <center>`int`</center> | <center>**Required**</center> | The ID of the VPC Config for this resource.   |
+| `id` | <center>`int`</center> | <center>Optional</center> | The ID of the NodeBalancer to retrieve the VPC configuration from.  **(Conflicts With: `label`)** |
+| `label` | <center>`str`</center> | <center>Optional</center> | The label of the NodeBalancer to retrieve the VPC configuration from.  **(Conflicts With: `id`)** |
+
+## Return Values
+
+- `vpc_config` - The returned VPC Configuration.
+
+    - Sample Response:
+        ```json
+        
+          {
+            "id": 123,
+            "nodebalancer_id": 12345,
+            "subnet_id": 456,
+            "vpc_id": 789,
+            "ipv4_range": "10.0.0.4/30",
+            "ipv6_range": null,
+            "purpose": "backend"
+          }
+        
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpc-config) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_vpc_list.md
+++ b/docs/modules/nodebalancer_vpc_list.md
@@ -1,0 +1,70 @@
+# nodebalancer_vpc_list
+
+List and filter on Node Balancer VPC Configurations.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Nodebalancer VPC configurations for the current Linode Account
+  linode.cloud.nodebalancer_vpc_list:
+    nodebalancer_id: 123
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `nodebalancer_id` | <center>`int`</center> | <center>**Required**</center> | The parent NodeBalancer for the Node Balancer VPC Configurations.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Node Balancer VPC Configurations in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Node Balancer VPC Configurations by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Node Balancer VPC Configurations.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Node Balancer VPC Configurations to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `nodebalancer_vpc_configs` - The returned Node Balancer VPC Configurations.
+
+    - Sample Response:
+        ```json
+        [
+          {
+              "id": 123,
+              "nodebalancer_id": 456,
+              "vpc_id": 89,
+              "subnet_id": 21,
+              "ipv4_range": "10.0.0.3/32",
+              "ipv6_range": null,
+              "purpose": "frontend"
+          },
+          {
+              "id": 124,
+              "nodebalancer_id": 457,
+              "vpc_id": 90,
+              "subnet_id": 22,
+              "ipv4_range": "10.0.0.4/30",
+              "ipv6_range": "/64",
+              "purpose": "backend"
+          }
+        ],
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
+
+

--- a/docs/modules/nodebalancer_vpc_list.md
+++ b/docs/modules/nodebalancer_vpc_list.md
@@ -15,7 +15,7 @@ List and filter on Node Balancer VPC Configurations.
 ## Examples
 
 ```yaml
-- name: List all of the Nodebalancer VPC configurations for the current Linode Account
+- name: List all of the Nodebalancer VPC configurations for a specific NodeBalancer
   linode.cloud.nodebalancer_vpc_list:
     nodebalancer_id: 123
 ```

--- a/docs/modules/nodebalancer_vpc_list.md
+++ b/docs/modules/nodebalancer_vpc_list.md
@@ -63,7 +63,7 @@ List and filter on Node Balancer VPC Configurations.
               "ipv6_range": "/64",
               "purpose": "backend"
           }
-        ],
+        ]
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs) for a list of returned fields
 

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -7,7 +7,7 @@ specdoc_examples = ['''
     region: us-east
     tags: [ prod-env ]
     state: present
-    vpcs:
+    backend_vpcs:
       - subnet_id: 12345
         ipv4_range: '10.0.0.4/30'
     frontend_vpcs:

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -114,3 +114,15 @@ result_firewalls_data_samples = ['''[
       "updated": "2020-04-10T13:34:01"
   }
 ]''']
+
+result_vpcs_samples = ['''[
+  {
+    "id": 123,
+    "nodebalancer_id": 12345,
+    "subnet_id": 456,
+    "vpc_id": 789,
+    "ipv4_range": "10.0.0.4/30",
+    "ipv6_range": null,
+    "purpose": "backend"
+  }
+]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -7,6 +7,12 @@ specdoc_examples = ['''
     region: us-east
     tags: [ prod-env ]
     state: present
+    vpcs:
+      - subnet_id: 12345
+        ipv4_range: '10.0.0.4/30'
+    frontend_vpcs:
+      - subnet_id: 67890
+        ipv4_range: '10.0.0.8/30'
     configs:
       - port: 80
         protocol: http
@@ -27,6 +33,8 @@ result_node_balancer_samples = ['''{
   "id": 12345,
   "ipv4": "12.34.56.78",
   "ipv6": null,
+  "frontend_address_type": "public",
+  "frontend_vpc_subnet_id": null,
   "label": "balancer12345",
   "region": "us-east",
   "type": "common",
@@ -124,5 +132,17 @@ result_vpcs_samples = ['''[
     "ipv4_range": "10.0.0.4/30",
     "ipv6_range": null,
     "purpose": "backend"
+  }
+]''']
+
+result_frontend_vpcs_samples = ['''[
+  {
+    "id": 123,
+    "nodebalancer_id": 12345,
+    "subnet_id": 456,
+    "vpc_id": 789,
+    "ipv4_range": "10.0.0.4/30",
+    "ipv6_range": "2001:db8:1234::/48",
+    "purpose": "frontend"
   }
 ]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -29,6 +29,7 @@ result_node_balancer_samples = ['''{
   "ipv6": null,
   "label": "balancer12345",
   "region": "us-east",
+  "type": "common",
   "tags": [
     "example tag",
     "another example"

--- a/plugins/module_utils/doc_fragments/nodebalancer.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer.py
@@ -146,3 +146,15 @@ result_frontend_vpcs_samples = ['''[
     "purpose": "frontend"
   }
 ]''']
+
+result_vpc_samples = ['''
+  {
+    "id": 123,
+    "nodebalancer_id": 12345,
+    "subnet_id": 456,
+    "vpc_id": 789,
+    "ipv4_range": "10.0.0.4/30",
+    "ipv6_range": null,
+    "purpose": "backend"
+  }
+''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_list.py
@@ -17,6 +17,8 @@ result_nodebalancers_samples = ['''[
       "id": 12345,
       "ipv4": "203.0.113.1",
       "ipv6": null,
+      "frontend_address_type": "public",
+      "frontend_vpc_subnet_id": null,
       "label": "balancer12345",
       "region": "us-east",
       "tags": [

--- a/plugins/module_utils/doc_fragments/nodebalancer_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_list.py
@@ -28,6 +28,7 @@ result_nodebalancers_samples = ['''[
         "out": 3.5487728118896484,
         "total": 32.46078109741211
       },
-      "updated": "2018-03-01T00:01:01"
+      "updated": "2018-03-01T00:01:01",
+      "type": "common"
     }
 ]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_vpc_info.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_vpc_info.py
@@ -1,0 +1,11 @@
+"""Documentation fragments for the nodebalancer_vpc_info module"""
+
+specdoc_examples = ['''
+- name: Get a NodeBalancer VPC configuration by its id
+  linode.cloud.nodebalancer_vpc_info:
+    id: 12345
+    vpc_config_id: 123''', '''
+- name: Get a NodeBalancer by its label
+  linode.cloud.nodebalancer_vpc_info:
+    label: cool_nodebalancer
+    vpc_config_id: 123''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
@@ -24,4 +24,4 @@ result_nodebalancer_vpcs_samples = ['''[
       "ipv6_range": "/64",
       "purpose": "backend"
   }
-],''']
+]''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
@@ -1,0 +1,27 @@
+"""Documentation fragments for the nodebalancer_vpc_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Nodebalancer VPC configurations for the current Linode Account
+  linode.cloud.nodebalancer_vpc_list:
+    nodebalancer_id: 123''']
+
+result_nodebalancer_vpcs_samples = ['''[
+  {
+      "id": 123,
+      "nodebalancer_id": 456,
+      "vpc_id": 89,
+      "subnet_id": 21,
+      "ipv4_range": "10.0.0.3/32",
+      "ipv6_range": null,
+      "purpose": "frontend"
+  },
+  {
+      "id": 124,
+      "nodebalancer_id": 457,
+      "vpc_id": 90,
+      "subnet_id": 22,
+      "ipv4_range": "10.0.0.4/30",
+      "ipv6_range": "/64",
+      "purpose": "backend"
+  }
+],''']

--- a/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
+++ b/plugins/module_utils/doc_fragments/nodebalancer_vpc_list.py
@@ -1,7 +1,7 @@
 """Documentation fragments for the nodebalancer_vpc_list module"""
 
 specdoc_examples = ['''
-- name: List all of the Nodebalancer VPC configurations for the current Linode Account
+- name: List all of the Nodebalancer VPC configurations for a specific NodeBalancer
   linode.cloud.nodebalancer_vpc_list:
     nodebalancer_id: 123''']
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -283,6 +283,11 @@ linode_nodebalancer_spec = {
         editable=True,
         description=["A list of configs to apply to the NodeBalancer."],
     ),
+    "type": SpecField(
+        type=FieldType.string,
+        description=["The type of this NodeBalancer."],
+        choices=["common", "premium", "premium_40gb"],
+    ),
 }
 
 
@@ -309,7 +314,7 @@ SPECDOC_META = SpecDocMeta(
             sample=docs.result_configs_samples,
         ),
         "nodes": SpecReturnValue(
-            description="A list of configs applied to the NodeBalancer.",
+            description="A list of nodes applied to the NodeBalancer.",
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node",
             type=FieldType.list,
             sample=docs.result_nodes_samples,
@@ -402,6 +407,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
                 "label",
                 "firewall_id",
                 "tags",
+                "type",
             }
         }
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -339,6 +339,16 @@ linode_nodebalancer_spec = {
         type=FieldType.list,
         element_type=FieldType.dict,
         suboptions=linode_nodebalancer_vpc_spec,
+        description=[
+            "A VPC configuration for backend nodes.",
+            "**Deprecated**: Use `backend_vpcs` instead.",
+            "This field will be removed in a future major release.",
+        ],
+    ),
+    "backend_vpcs": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.dict,
+        suboptions=linode_nodebalancer_vpc_spec,
         description=["A VPC configuration for backend nodes."],
     ),
     "frontend_vpcs": SpecField(
@@ -481,10 +491,21 @@ class LinodeNodeBalancer(LinodeModuleBase):
                 "firewall_id",
                 "tags",
                 "type",
-                "vpcs",
                 "frontend_vpcs",
             }
         }
+
+        backend_vpcs = self.module.params.get("backend_vpcs")
+        vpcs_legacy = self.module.params.get("vpcs")
+
+        if backend_vpcs is not None:
+            params["backend_vpcs"] = backend_vpcs
+        elif vpcs_legacy is not None:
+            self.warn(
+                "The 'vpcs' field is deprecated and will be removed in a future major version. "
+                "Use 'backend_vpcs' instead."
+            )
+            params["backend_vpcs"] = vpcs_legacy
 
         try:
             return self.client.nodebalancer_create(

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -259,6 +259,28 @@ linode_nodebalancer_vpc_spec = {
     ),
 }
 
+linode_nodebalancer_frontend_vpc_spec = {
+    "subnet_id": SpecField(
+        type=FieldType.integer,
+        required=True,
+        description=["The ID of the subnet to attach this NodeBalancer to."],
+    ),
+    "ipv4_range": SpecField(
+        type=FieldType.string,
+        description=[
+            "A CIDR range for the VPC's IPv4 addresses allocated "
+            "as the NodeBalancer's frontend IPs."
+        ],
+    ),
+    "ipv6_range": SpecField(
+        type=FieldType.string,
+        description=[
+            "A CIDR range for the VPC's IPv6 addresses allocated "
+            "as the NodeBalancer's frontend IPs."
+        ],
+    ),
+}
+
 linode_nodebalancer_spec = {
     "label": SpecField(
         type=FieldType.string,
@@ -319,6 +341,12 @@ linode_nodebalancer_spec = {
         suboptions=linode_nodebalancer_vpc_spec,
         description=["A VPC configuration for backend nodes."],
     ),
+    "frontend_vpcs": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.dict,
+        suboptions=linode_nodebalancer_frontend_vpc_spec,
+        description=["A VPC configuration for frontend nodes."],
+    ),
 }
 
 
@@ -357,6 +385,18 @@ SPECDOC_META = SpecDocMeta(
             elements=FieldType.integer,
             sample=docs.result_firewalls_samples,
         ),
+        "vpcs": SpecReturnValue(
+            description="A list of VPC configurations for backend nodes.",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
+            type=FieldType.list,
+            sample=docs.result_vpcs_samples,
+        ),
+        "frontend_vpcs": SpecReturnValue(
+            description="A list of VPC configurations for frontend nodes.",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
+            type=FieldType.list,
+            sample=docs.result_frontend_vpcs_samples,
+        ),
     },
 )
 
@@ -387,6 +427,8 @@ class LinodeNodeBalancer(LinodeModuleBase):
             "configs": [],
             "nodes": [],
             "firewalls": [],
+            "vpcs": [],
+            "frontend_vpcs": [],
         }
 
         self._node_balancer: Optional[NodeBalancer] = None
@@ -440,6 +482,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
                 "tags",
                 "type",
                 "vpcs",
+                "frontend_vpcs",
             }
         }
 
@@ -686,6 +729,14 @@ class LinodeNodeBalancer(LinodeModuleBase):
         # the module result.
         self.results["firewalls"] = [
             v.id for v in self._node_balancer.firewalls()
+        ]
+
+        all_vpcs = self._node_balancer.vpcs()
+        self.results["vpcs"] = [
+            vpc._raw_json for vpc in all_vpcs if vpc.purpose == "backend"
+        ]
+        self.results["frontend_vpcs"] = [
+            vpc._raw_json for vpc in all_vpcs if vpc.purpose == "frontend"
         ]
 
         return self.results

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -495,6 +495,8 @@ class LinodeNodeBalancer(LinodeModuleBase):
             }
         }
 
+        # Currently both `vpcs` and `backend_vpcs` are accepted for backward compatibility,
+        # but `vpcs` is deprecated and will be removed in a future major release.
         backend_vpcs = self.module.params.get("backend_vpcs")
         vpcs_legacy = self.module.params.get("vpcs")
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -234,6 +234,31 @@ linode_configs_spec = {
     ),
 }
 
+linode_nodebalancer_vpc_spec = {
+    "subnet_id": SpecField(
+        type=FieldType.integer,
+        required=True,
+        description=["The ID of the subnet to attach this NodeBalancer to."],
+    ),
+    "ipv4_range": SpecField(
+        type=FieldType.string,
+        description=[
+            "A CIDR range for the VPC's IPv4 addresses. "
+            + "The NodeBalancer sources IP addresses from this range "
+            + "when routing traffic to the backend VPC nodes."
+        ],
+    ),
+    "ipv4_range_auto_assign": SpecField(
+        type=FieldType.bool,
+        default=False,
+        description=[
+            "Enables the use of a larger ipv4_range subnet for multiple NodeBalancers "
+            + "within the same VPC by allocating smaller /30 subnets for "
+            + "each NodeBalancer's backends."
+        ],
+    ),
+}
+
 linode_nodebalancer_spec = {
     "label": SpecField(
         type=FieldType.string,
@@ -287,6 +312,12 @@ linode_nodebalancer_spec = {
         type=FieldType.string,
         description=["The type of this NodeBalancer."],
         choices=["common", "premium", "premium_40gb"],
+    ),
+    "vpcs": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.dict,
+        suboptions=linode_nodebalancer_vpc_spec,
+        description=["A VPC configuration for backend nodes."],
     ),
 }
 
@@ -408,6 +439,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
                 "firewall_id",
                 "tags",
                 "type",
+                "vpcs",
             }
         }
 

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -49,6 +49,13 @@ def _get_nodes(
     return nodes_json
 
 
+def _get_vpcs(
+    client: LinodeClient, nodebalancer: NodeBalancer, params: Dict[str, Any]
+) -> List[Any]:
+    vpcs = NodeBalancer(client, nodebalancer["id"]).vpcs()
+    return [vpc._raw_json for vpc in vpcs if vpc.purpose == "backend"]
+
+
 module = InfoModule(
     primary_result=InfoModuleResult(
         field_name="node_balancer",
@@ -97,6 +104,14 @@ module = InfoModule(
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-firewalls",
             samples=docs_parent.result_firewalls_data_samples,
             get=_get_firewalls_data,
+        ),
+        InfoModuleResult(
+            field_name="vpcs",
+            field_type=FieldType.list,
+            display_name="vpcs",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
+            samples=docs_parent.result_vpcs_samples,
+            get=_get_vpcs,
         ),
     ],
     attributes=[

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -56,6 +56,13 @@ def _get_vpcs(
     return [vpc._raw_json for vpc in vpcs if vpc.purpose == "backend"]
 
 
+def _get_frontend_vpcs(
+    client: LinodeClient, nodebalancer: NodeBalancer, params: Dict[str, Any]
+) -> List[Any]:
+    vpcs = NodeBalancer(client, nodebalancer["id"]).vpcs()
+    return [vpc._raw_json for vpc in vpcs if vpc.purpose == "frontend"]
+
+
 module = InfoModule(
     primary_result=InfoModuleResult(
         field_name="node_balancer",
@@ -112,6 +119,14 @@ module = InfoModule(
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
             samples=docs_parent.result_vpcs_samples,
             get=_get_vpcs,
+        ),
+        InfoModuleResult(
+            field_name="frontend_vpcs",
+            field_type=FieldType.list,
+            display_name="frontend_vpcs",
+            docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
+            samples=docs_parent.result_frontend_vpcs_samples,
+            get=_get_frontend_vpcs,
         ),
     ],
     attributes=[

--- a/plugins/modules/nodebalancer_vpc_info.py
+++ b/plugins/modules/nodebalancer_vpc_info.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a
+Linode NodeBalancer VPC configuration."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    nodebalancer as docs_parent,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    nodebalancer_vpc_info as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleParam,
+    InfoModuleResult,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
+    safe_find,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import NodeBalancer
+
+module = InfoModule(
+    primary_result=InfoModuleResult(
+        field_name="vpc_config",
+        field_type=FieldType.dict,
+        display_name="VPC Configuration",
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpc-config",
+        samples=docs_parent.result_vpc_samples,
+    ),
+    params=[
+        InfoModuleParam(
+            display_name="VPC Config",
+            name="vpc_config_id",
+            type=FieldType.integer,
+        )
+    ],
+    attributes=[
+        InfoModuleAttr(
+            display_name="ID",
+            name="id",
+            type=FieldType.integer,
+            description="The ID of the NodeBalancer to retrieve the VPC configuration from.",
+            get=lambda client, params: NodeBalancer(client, params.get("id"))
+            .vpc(params["vpc_config_id"])
+            ._raw_json,
+        ),
+        InfoModuleAttr(
+            display_name="label",
+            name="label",
+            type=FieldType.string,
+            description="The label of the NodeBalancer to retrieve the VPC configuration from.",
+            get=lambda client, params: safe_find(
+                client.nodebalancers,
+                NodeBalancer.label == params.get("label"),
+                raise_not_found=True,
+            )
+            .vpc(params["vpc_config_id"])
+            ._raw_json,
+        ),
+    ],
+    examples=docs.specdoc_examples,
+)
+
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/nodebalancer_vpc_list.py
+++ b/plugins/modules/nodebalancer_vpc_list.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module contains all of the functionality for
+listing Linode Node Balancer VPC configurations."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    nodebalancer_vpc_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+    ListModuleParam,
+)
+from ansible_specdoc.objects import FieldType
+
+module = ListModule(
+    result_display_name="Node Balancer VPC Configurations",
+    result_field_name="nodebalancer_vpc_configs",
+    endpoint_template="/nodebalancers/{nodebalancer_id}/vpcs",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-vpcs",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_nodebalancer_vpcs_samples,
+    params=[
+        ListModuleParam(
+            display_name="NodeBalancer",
+            name="nodebalancer_id",
+            type=FieldType.integer,
+        )
+    ],
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-linode-api4>=5.39.0
+# TODO: Update python-sdk dependency to latest version when merging proj/nb-front-end-ip-in-vpc branch.
+git+https://github.com/linode/linode_api4-python.git@proj/nb-front-end-ip-in-vpc#egg=linode-api4
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/nodebalancer_backend_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_backend_vpc/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: nodebalancer_vpc
+- name: nodebalancer_backend_vpc
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"

--- a/tests/integration/targets/nodebalancer_deprecated_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_deprecated_vpc/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: nodebalancer_vpc
+- name: nodebalancer_deprecated_vpc
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
@@ -27,13 +27,13 @@
         state: present
       register: create_subnet
 
-    - name: create nodebalancer with vpc
+    - name: create nodebalancer with deprecated vpcs attribute
       linode.cloud.nodebalancer:
         label: 'ansible-test-vpc-{{ r }}'
         region: us-ord
         state: present
         firewall_id: '{{ firewall_id }}'
-        backend_vpcs:
+        vpcs:
           - subnet_id: '{{ create_subnet.subnet.id }}'
       register: create_nodebalancer_with_vpc
 

--- a/tests/integration/targets/nodebalancer_frontend_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_frontend_vpc/tasks/main.yaml
@@ -75,6 +75,23 @@
           - nb_info_id.frontend_vpcs[0].ipv6_range != None
           - nb_info_id.frontend_vpcs[0].purpose == "frontend"
 
+    - name: Get info about the NodeBalancer VPC config
+      linode.cloud.nodebalancer_vpc_info:
+        id: '{{ create_nodebalancer_with_frontend_vpc.node_balancer.id }}'
+        vpc_config_id: '{{ create_nodebalancer_with_frontend_vpc.frontend_vpcs[0].id }}'
+      register: nb_vpc_config_info
+
+    - name: Assert that VPC config info is valid
+      assert:
+        that:
+          - nb_vpc_config_info.vpc_config.id == create_nodebalancer_with_frontend_vpc.frontend_vpcs[0].id
+          - nb_vpc_config_info.vpc_config.nodebalancer_id == create_nodebalancer_with_frontend_vpc.node_balancer.id
+          - nb_vpc_config_info.vpc_config.subnet_id == create_subnet.subnet.id
+          - nb_vpc_config_info.vpc_config.vpc_id == create_vpc.vpc.id
+          - nb_vpc_config_info.vpc_config.ipv4_range != None
+          - nb_vpc_config_info.vpc_config.ipv6_range != None
+          - nb_vpc_config_info.vpc_config.purpose == "frontend"
+
     - name: Attempt to update with no differences
       linode.cloud.nodebalancer:
         label: 'ansible-test-frontend{{ r }}'

--- a/tests/integration/targets/nodebalancer_frontend_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_frontend_vpc/tasks/main.yaml
@@ -1,0 +1,129 @@
+- name: nodebalancer_frontend_vpc
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        ipv6:
+          - range: "/52"
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'us-ord'
+          - create_vpc.vpc.description == 'test description'
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet'
+        ipv4: '10.0.0.0/24'
+        ipv6:
+          - range: "auto"
+        state: present
+      register: create_subnet
+
+    - name: create nodebalancer with frontend vpc
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-frontend{{ r }}'
+        region: us-ord
+        state: present
+        type: premium
+        firewall_id: '{{ firewall_id }}'
+        frontend_vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4_range: '10.0.0.4/30'
+            ipv6_range: '{{ create_subnet.subnet.ipv6[0].range }}'
+      register: create_nodebalancer_with_frontend_vpc
+
+    - name: Assert NodeBalancer with frontend VPC is created
+      assert:
+        that:
+          - create_nodebalancer_with_frontend_vpc.changed
+          - create_nodebalancer_with_frontend_vpc.node_balancer.frontend_address_type == 'vpc'
+          - create_nodebalancer_with_frontend_vpc.node_balancer.frontend_vpc_subnet_id == create_subnet.subnet.id
+          - create_nodebalancer_with_frontend_vpc.vpcs|length == 0
+          - create_nodebalancer_with_frontend_vpc.frontend_vpcs|length == 1
+          - create_nodebalancer_with_frontend_vpc.frontend_vpcs[0].subnet_id == create_subnet.subnet.id
+          - create_nodebalancer_with_frontend_vpc.frontend_vpcs[0].purpose == "frontend"
+
+    - name: Get info about the NodeBalancer by id
+      linode.cloud.nodebalancer_info:
+        id: '{{ create_nodebalancer_with_frontend_vpc.node_balancer.id }}'
+      register: nb_info_id
+
+    - name: Assert that info is valid
+      assert:
+        that:
+          - nb_info_id.node_balancer.id == create_nodebalancer_with_frontend_vpc.node_balancer.id
+          - nb_info_id.node_balancer.type == 'premium'        
+          - nb_info_id.node_balancer.frontend_address_type == 'vpc'        
+          - nb_info_id.node_balancer.frontend_vpc_subnet_id == create_subnet.subnet.id        
+          - nb_info_id.frontend_vpcs|length == 1        
+          - nb_info_id.frontend_vpcs[0].nodebalancer_id == create_nodebalancer_with_frontend_vpc.node_balancer.id
+          - nb_info_id.frontend_vpcs[0].subnet_id == create_subnet.subnet.id
+          - nb_info_id.frontend_vpcs[0].vpc_id == create_vpc.vpc.id
+          - nb_info_id.frontend_vpcs[0].ipv4_range != None
+          - nb_info_id.frontend_vpcs[0].ipv6_range != None
+          - nb_info_id.frontend_vpcs[0].purpose == "frontend"
+
+    - name: Attempt to update with no differences
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-frontend{{ r }}'
+        region: us-ord
+        state: present
+        type: premium
+        frontend_vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4_range: '10.0.0.4/30'
+            ipv6_range: '{{ create_subnet.subnet.ipv6[0].range }}'
+      register: update_nodebalancer_nochanges
+
+    - name: Assert NodeBalancer is not updated
+      assert:
+        that:
+          - update_nodebalancer_nochanges.changed == false
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the NodeBalancer with frontend VPC
+          linode.cloud.nodebalancer:
+            label: '{{ create_nodebalancer_with_frontend_vpc.node_balancer.label }}'
+            state: absent
+          register: delete_nodebalancer_with_frontend_vpc
+
+        - name: Assert NodeBalancer with frontend VPC delete
+          assert:
+            that:
+              - delete_nodebalancer_with_frontend_vpc.changed
+              - delete_nodebalancer_with_frontend_vpc.node_balancer.id == create_nodebalancer_with_frontend_vpc.node_balancer.id
+            
+        - name: Delete a subnet
+          linode.cloud.vpc_subnet:
+            vpc_id: '{{ create_vpc.vpc.id }}'
+            label: 'test-subnet'
+            state: absent
+          register: delete_subnet
+
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.vpc.label }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -25,6 +25,7 @@
       assert:
         that:
           - no_filter.nodebalancers | length >= 1
+          - no_filter.nodebalancers[0].type == 'common'
 
     - name: List nodebalancers with filter on region
       linode.cloud.nodebalancer_list:
@@ -40,6 +41,7 @@
         that:
           - filter.nodebalancers | length >= 1
           - filter.nodebalancers[0].region == 'us-ord'
+          - filter.nodebalancers[0].type == 'common'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/nodebalancer_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_list/tasks/main.yaml
@@ -3,19 +3,69 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: create empty nodebalancer
-      linode.cloud.nodebalancer:
-        label: 'ansible-test-empty-{{ r }}'
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
         region: us-ord
+        ipv6:
+          - range: "/52"
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'us-ord'
+          - create_vpc.vpc.description == 'test description'
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet-{{ r }}'
+        ipv4: '10.0.0.0/24'
+        ipv6:
+          - range: "auto"
+        state: present
+      register: create_subnet
+
+    - name: Assert VPC subnet created
+      assert:
+        that:
+          - create_subnet.changed
+          - create_subnet.subnet.label == 'test-subnet-{{ r }}'
+          - create_subnet.subnet.ipv4 == '10.0.0.0/24'
+
+    - name: create nodebalancer with vpcs
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: premium
         state: present
         firewall_id: '{{ firewall_id }}'
+        vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+        frontend_vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4_range: '10.0.0.4/30'
+            ipv6_range: '{{ create_subnet.subnet.ipv6[0].range }}'
       register: create
 
-    - name: Assert empty NodeBalancer is created
+    - name: Assert NodeBalancer with VPCs is created
       assert:
         that:
           - create.changed
           - create.configs|length == 0
+          - create.node_balancer.frontend_address_type == 'vpc'
+          - create.node_balancer.frontend_vpc_subnet_id != None
+          - create.vpcs|length == 1
+          - create.vpcs[0].subnet_id == create_subnet.subnet.id
+          - create.vpcs[0].purpose == "backend"
+          - create.frontend_vpcs|length == 1
+          - create.frontend_vpcs[0].subnet_id == create_subnet.subnet.id
+          - create.frontend_vpcs[0].purpose == "frontend"
 
     - name: List nodebalancers with no filter
       linode.cloud.nodebalancer_list:
@@ -25,7 +75,9 @@
       assert:
         that:
           - no_filter.nodebalancers | length >= 1
-          - no_filter.nodebalancers[0].type == 'common'
+          - no_filter.nodebalancers[0].type == 'premium'
+          - no_filter.nodebalancers[0].frontend_address_type == 'vpc'
+          - no_filter.nodebalancers[0].frontend_vpc_subnet_id != None
 
     - name: List nodebalancers with filter on region
       linode.cloud.nodebalancer_list:
@@ -41,22 +93,37 @@
         that:
           - filter.nodebalancers | length >= 1
           - filter.nodebalancers[0].region == 'us-ord'
-          - filter.nodebalancers[0].type == 'common'
+          - filter.nodebalancers[0].type == 'premium'
+          - filter.nodebalancers[0].frontend_address_type == 'vpc'
+          - filter.nodebalancers[0].frontend_vpc_subnet_id != None
 
   always:
     - ignore_errors: yes
       block:
-        - name: Delete the empty NodeBalancer
+        - name: Delete the NodeBalancer
           linode.cloud.nodebalancer:
             label: '{{ create.node_balancer.label }}'
             state: absent
           register: delete
 
-        - name: Assert empty NodeBalancer delete
+        - name: Assert NodeBalancer delete
           assert:
             that:
               - delete.changed
               - create.node_balancer.id == delete.node_balancer.id
+
+        - name: Delete a subnet
+          linode.cloud.vpc_subnet:
+            vpc_id: '{{ create_vpc.vpc.id }}'
+            label: 'test-subnet-{{ r }}'
+            state: absent
+          register: delete_subnet
+
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.vpc.label }}'
+            state: absent
+          register: delete_vpc
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -93,6 +93,7 @@
         that:
           - create_populated_nodebalancer.changed
           - create_populated_nodebalancer.node_balancer.region == 'us-ord'
+          - create_populated_nodebalancer.node_balancer.type == 'common'
           - create_populated_nodebalancer.configs|length == 1
           - create_populated_nodebalancer.configs[0].port == 80
           - create_populated_nodebalancer.configs[0].protocol == 'http'
@@ -131,6 +132,7 @@
           - update_populated_config.configs[0].port == 81
           - update_populated_config.configs|length == 1
           - update_populated_config.nodes|length == 1
+          - update_populated_config.node_balancer.type == 'common'
 
     - name: Attempt to update with no differences
       linode.cloud.nodebalancer:
@@ -269,6 +271,7 @@
           - nb_info_id.configs|length == 1
           - nb_info_id.nodes|length == 1
           - nb_info_id.nodes[0] != None
+          - nb_info_id.node_balancer.type == 'common'
 
     - name: Get info about a NodeBalancer that doesn't exist
       linode.cloud.nodebalancer_info:

--- a/tests/integration/targets/nodebalancer_premium/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_premium/tasks/main.yaml
@@ -1,0 +1,68 @@
+- name: nodebalancer_basic
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: create empty premium nodebalancer
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-empty-{{ r }}'
+        region: us-ord
+        type: premium
+        state: present
+        firewall_id: '{{ firewall_id }}'
+      register: create_empty_premium_nodebalancer
+
+    - name: Assert empty NodeBalancer is created
+      assert:
+        that:
+          - create_empty_premium_nodebalancer.changed
+          - create_empty_premium_nodebalancer.configs|length == 0
+          - create_empty_premium_nodebalancer.node_balancer.type == 'premium'
+
+    - name: update empty premium nodebalancer
+      linode.cloud.nodebalancer:
+        label: '{{ create_empty_premium_nodebalancer.node_balancer.label }}'
+        region: us-ord
+        client_conn_throttle: 6
+        state: present
+      register: update_empty_premium_nodebalancer
+
+    - name: Assert empty premium NodeBalancer is updated
+      assert:
+        that:
+          - update_empty_premium_nodebalancer.changed
+          - update_empty_premium_nodebalancer.node_balancer.client_conn_throttle == 6
+
+    - name: Get info about the NodeBalancer by id
+      linode.cloud.nodebalancer_info:
+        id: '{{ create_empty_premium_nodebalancer.node_balancer.id }}'
+      register: nb_info_id
+
+    - name: Assert that info is correct
+      assert:
+        that:
+          - nb_info_id.node_balancer.type == 'premium'
+          - nb_info_id.node_balancer.client_conn_throttle == 6
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the empty premium NodeBalancer
+          linode.cloud.nodebalancer:
+            label: '{{ create_empty_premium_nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_empty
+
+        - name: Assert empty premium NodeBalancer delete
+          assert:
+            that:
+              - delete_empty.changed
+              - delete_empty.node_balancer.id == create_empty_premium_nodebalancer.node_balancer.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_premium/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_premium/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: nodebalancer_basic
+- name: nodebalancer_premium
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"

--- a/tests/integration/targets/nodebalancer_premium_40gb/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_premium_40gb/tasks/main.yaml
@@ -1,0 +1,68 @@
+- name: nodebalancer_premium_40gb
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: create empty premium 40GB nodebalancer
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-empty-{{ r }}'
+        region: us-iad
+        type: premium_40gb
+        state: present
+        firewall_id: '{{ firewall_id }}'
+      register: create_empty_premium_40gb_nodebalancer
+
+    - name: Assert empty NodeBalancer is created
+      assert:
+        that:
+          - create_empty_premium_40gb_nodebalancer.changed
+          - create_empty_premium_40gb_nodebalancer.configs|length == 0
+          - create_empty_premium_40gb_nodebalancer.node_balancer.type == 'premium_40gb'
+
+    - name: update empty premium 40GB nodebalancer
+      linode.cloud.nodebalancer:
+        label: '{{ create_empty_premium_40gb_nodebalancer.node_balancer.label }}'
+        region: us-iad
+        client_conn_throttle: 6
+        state: present
+      register: update_empty_premium_40gb_nodebalancer
+
+    - name: Assert empty premium 40GB NodeBalancer is updated
+      assert:
+        that:
+          - update_empty_premium_40gb_nodebalancer.changed
+          - update_empty_premium_40gb_nodebalancer.node_balancer.client_conn_throttle == 6
+
+    - name: Get info about the NodeBalancer by id
+      linode.cloud.nodebalancer_info:
+        id: '{{ create_empty_premium_40gb_nodebalancer.node_balancer.id }}'
+      register: nb_info_id
+
+    - name: Assert that info is correct
+      assert:
+        that:
+          - nb_info_id.node_balancer.type == 'premium_40gb'
+          - nb_info_id.node_balancer.client_conn_throttle == 6
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the empty premium 40GB NodeBalancer
+          linode.cloud.nodebalancer:
+            label: '{{ create_empty_premium_40gb_nodebalancer.node_balancer.label }}'
+            state: absent
+          register: delete_empty
+
+        - name: Assert empty premium 40GB NodeBalancer delete
+          assert:
+            that:
+              - delete_empty.changed
+              - delete_empty.node_balancer.id == create_empty_premium_40gb_nodebalancer.node_balancer.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_stats/tasks/main.yaml
@@ -57,6 +57,7 @@
         that:
           - create_populated_nodebalancer.changed
           - create_populated_nodebalancer.node_balancer.region == 'us-ord'
+          - create_populated_nodebalancer.node_balancer.type == 'common'
           - create_populated_nodebalancer.configs|length == 1
           - create_populated_nodebalancer.configs[0].port == 80
           - create_populated_nodebalancer.configs[0].protocol == 'http'

--- a/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
@@ -18,6 +18,7 @@
           - create_nodebalancer.changed
           - create_nodebalancer.configs|length == 0
           - create_nodebalancer.node_balancer.client_udp_sess_throttle == 3
+          - create_nodebalancer.node_balancer.type == 'common'
 
     - name: Add NodeBalancer config
       linode.cloud.nodebalancer:
@@ -71,6 +72,7 @@
           - nb_info.configs[0].udp_check_port == 1234
           - nb_info.configs[0].udp_session_timeout == 16
           - nb_info.node_balancer.client_udp_sess_throttle == 3
+          - nb_info.node_balancer.type == 'common'
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
@@ -1,0 +1,97 @@
+- name: nodebalancer_vpc
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'us-ord'
+          - create_vpc.vpc.description == 'test description'
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet'
+        ipv4: '10.0.0.0/24'
+        state: present
+      register: create_subnet
+
+    - name: create nodebalancer with vpc
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-vpc-{{ r }}'
+        region: us-ord
+        state: present
+        firewall_id: '{{ firewall_id }}'
+        vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+      register: create_nodebalancer_with_vpc
+
+    - name: Assert NodeBalancer with VPC is created
+      assert:
+        that:
+          - create_nodebalancer_with_vpc.changed
+
+    - name: Get info about the NodeBalancer by id
+      linode.cloud.nodebalancer_info:
+        id: '{{ create_nodebalancer_with_vpc.node_balancer.id }}'
+      register: nb_info_id
+
+    - name: Assert that info is valid
+      assert:
+        that:
+          - nb_info_id.node_balancer.id == create_nodebalancer_with_vpc.node_balancer.id
+          - nb_info_id.node_balancer.type == 'common'        
+          - nb_info_id.vpcs|length == 1        
+          - nb_info_id.vpcs[0].nodebalancer_id == create_nodebalancer_with_vpc.node_balancer.id
+          - nb_info_id.vpcs[0].subnet_id == create_subnet.subnet.id
+          - nb_info_id.vpcs[0].vpc_id == create_vpc.vpc.id
+          - nb_info_id.vpcs[0].ipv4_range != None
+          - nb_info_id.vpcs[0].ipv6_range == None
+          - nb_info_id.vpcs[0].purpose == "backend"
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the NodeBalancer with VPC
+          linode.cloud.nodebalancer:
+            label: '{{ create_nodebalancer_with_vpc.node_balancer.label }}'
+            state: absent
+          register: delete_nodebalancer_with_vpc
+
+        - name: Assert NodeBalancer with VPC delete
+          assert:
+            that:
+              - delete_nodebalancer_with_vpc.changed
+              - delete_nodebalancer_with_vpc.node_balancer.id == create_nodebalancer_with_vpc.node_balancer.id
+            
+        - name: Delete a subnet
+          linode.cloud.vpc_subnet:
+            vpc_id: '{{ create_vpc.vpc.id }}'
+            label: 'test-subnet'
+            state: absent
+          register: delete_subnet
+
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.vpc.label }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
@@ -41,6 +41,10 @@
       assert:
         that:
           - create_nodebalancer_with_vpc.changed
+          - create_nodebalancer_with_vpc.vpcs|length == 1
+          - create_nodebalancer_with_vpc.vpcs[0].subnet_id == create_subnet.subnet.id
+          - create_nodebalancer_with_vpc.vpcs[0].purpose == "backend"
+          - create_nodebalancer_with_vpc.frontend_vpcs|length == 0
 
     - name: Get info about the NodeBalancer by id
       linode.cloud.nodebalancer_info:

--- a/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_vpc/tasks/main.yaml
@@ -64,6 +64,23 @@
           - nb_info_id.vpcs[0].ipv6_range == None
           - nb_info_id.vpcs[0].purpose == "backend"
 
+    - name: Get info about the NodeBalancer VPC config
+      linode.cloud.nodebalancer_vpc_info:
+        id: '{{ create_nodebalancer_with_vpc.node_balancer.id }}'
+        vpc_config_id: '{{ create_nodebalancer_with_vpc.vpcs[0].id }}'
+      register: nb_vpc_config_info
+
+    - name: Assert that VPC config info is valid
+      assert:
+        that:
+          - nb_vpc_config_info.vpc_config.id == create_nodebalancer_with_vpc.vpcs[0].id
+          - nb_vpc_config_info.vpc_config.nodebalancer_id == create_nodebalancer_with_vpc.node_balancer.id
+          - nb_vpc_config_info.vpc_config.subnet_id == create_subnet.subnet.id
+          - nb_vpc_config_info.vpc_config.vpc_id == create_vpc.vpc.id
+          - nb_vpc_config_info.vpc_config.ipv4_range != None
+          - nb_vpc_config_info.vpc_config.ipv6_range == None
+          - nb_vpc_config_info.vpc_config.purpose == "backend"
+
   always:
     - ignore_errors: yes
       block:

--- a/tests/integration/targets/nodebalancer_vpc_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_vpc_list/tasks/main.yaml
@@ -1,0 +1,127 @@
+- name: nodebalancer_vpc_list
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        ipv6:
+          - range: "/52"
+        description: test description
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'us-ord'
+          - create_vpc.vpc.description == 'test description'
+
+    - name: Create a subnet
+      linode.cloud.vpc_subnet:
+        vpc_id: '{{ create_vpc.vpc.id }}'
+        label: 'test-subnet-{{ r }}'
+        ipv4: '10.0.0.0/24'
+        ipv6:
+          - range: "auto"
+        state: present
+      register: create_subnet
+
+    - name: Assert VPC subnet created
+      assert:
+        that:
+          - create_subnet.changed
+          - create_subnet.subnet.label == 'test-subnet-{{ r }}'
+          - create_subnet.subnet.ipv4 == '10.0.0.0/24'
+
+    - name: create nodebalancer with vpcs
+      linode.cloud.nodebalancer:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: premium
+        state: present
+        firewall_id: '{{ firewall_id }}'
+        vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+        frontend_vpcs:
+          - subnet_id: '{{ create_subnet.subnet.id }}'
+            ipv4_range: '10.0.0.4/30'
+            ipv6_range: '{{ create_subnet.subnet.ipv6[0].range }}'
+      register: create
+
+    - name: Assert NodeBalancer with VPCs is created
+      assert:
+        that:
+          - create.changed
+          - create.configs|length == 0
+          - create.node_balancer.frontend_address_type == 'vpc'
+          - create.node_balancer.frontend_vpc_subnet_id != None
+          - create.vpcs|length == 1
+          - create.vpcs[0].subnet_id == create_subnet.subnet.id
+          - create.vpcs[0].purpose == "backend"
+          - create.frontend_vpcs|length == 1
+          - create.frontend_vpcs[0].subnet_id == create_subnet.subnet.id
+          - create.frontend_vpcs[0].purpose == "frontend"
+
+    - name: List nodebalancer VPC configs with no filter
+      linode.cloud.nodebalancer_vpc_list:
+        nodebalancer_id: '{{ create.node_balancer.id }}'
+      register: no_filter
+
+    - name: Assert nodebalancer_vpc_list with no filter
+      assert:
+        that:
+          - no_filter.nodebalancer_vpc_configs | length >= 2
+          - no_filter.nodebalancer_vpc_configs[0].id != None
+          - no_filter.nodebalancer_vpc_configs[0].nodebalancer_id == create.node_balancer.id
+          - no_filter.nodebalancer_vpc_configs[0].vpc_id == create_vpc.vpc.id
+          - no_filter.nodebalancer_vpc_configs[0].subnet_id == create_subnet.subnet.id
+          - no_filter.nodebalancer_vpc_configs[0].ipv4_range != None
+          - no_filter.nodebalancer_vpc_configs[0].ipv6_range != None
+          - no_filter.nodebalancer_vpc_configs[0].purpose == 'frontend'
+          - no_filter.nodebalancer_vpc_configs[1].id != None
+          - no_filter.nodebalancer_vpc_configs[1].nodebalancer_id == create.node_balancer.id
+          - no_filter.nodebalancer_vpc_configs[1].vpc_id == create_vpc.vpc.id
+          - no_filter.nodebalancer_vpc_configs[1].subnet_id == create_subnet.subnet.id
+          - no_filter.nodebalancer_vpc_configs[1].ipv4_range != None
+          - no_filter.nodebalancer_vpc_configs[1].ipv6_range != None
+          - no_filter.nodebalancer_vpc_configs[1].purpose == 'backend'
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete the NodeBalancer
+          linode.cloud.nodebalancer:
+            label: '{{ create.node_balancer.label }}'
+            state: absent
+          register: delete
+
+        - name: Assert NodeBalancer delete
+          assert:
+            that:
+              - delete.changed
+              - create.node_balancer.id == delete.node_balancer.id
+
+        - name: Delete a subnet
+          linode.cloud.vpc_subnet:
+            vpc_id: '{{ create_vpc.vpc.id }}'
+            label: 'test-subnet-{{ r }}'
+            state: absent
+          register: delete_subnet
+
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.vpc.label }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/nodebalancer_vpc_list/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_vpc_list/tasks/main.yaml
@@ -72,24 +72,33 @@
         nodebalancer_id: '{{ create.node_balancer.id }}'
       register: no_filter
 
-    - name: Assert nodebalancer_vpc_list with no filter
+    - name: Select frontend and backend VPC configs by purpose
+      set_fact:
+        frontend_vpc_config: >-
+          {{ (no_filter.nodebalancer_vpc_configs
+              | selectattr('purpose', 'equalto', 'frontend')
+              | list)[0] }}
+        backend_vpc_config: >-
+          {{ (no_filter.nodebalancer_vpc_configs
+              | selectattr('purpose', 'equalto', 'backend')
+              | list)[0] }}
+    - name: Assert frontend and backend VPC configs fields
       assert:
         that:
-          - no_filter.nodebalancer_vpc_configs | length >= 2
-          - no_filter.nodebalancer_vpc_configs[0].id != None
-          - no_filter.nodebalancer_vpc_configs[0].nodebalancer_id == create.node_balancer.id
-          - no_filter.nodebalancer_vpc_configs[0].vpc_id == create_vpc.vpc.id
-          - no_filter.nodebalancer_vpc_configs[0].subnet_id == create_subnet.subnet.id
-          - no_filter.nodebalancer_vpc_configs[0].ipv4_range != None
-          - no_filter.nodebalancer_vpc_configs[0].ipv6_range != None
-          - no_filter.nodebalancer_vpc_configs[0].purpose == 'frontend'
-          - no_filter.nodebalancer_vpc_configs[1].id != None
-          - no_filter.nodebalancer_vpc_configs[1].nodebalancer_id == create.node_balancer.id
-          - no_filter.nodebalancer_vpc_configs[1].vpc_id == create_vpc.vpc.id
-          - no_filter.nodebalancer_vpc_configs[1].subnet_id == create_subnet.subnet.id
-          - no_filter.nodebalancer_vpc_configs[1].ipv4_range != None
-          - no_filter.nodebalancer_vpc_configs[1].ipv6_range != None
-          - no_filter.nodebalancer_vpc_configs[1].purpose == 'backend'
+          - frontend_vpc_config.id != None
+          - frontend_vpc_config.nodebalancer_id == create.node_balancer.id
+          - frontend_vpc_config.vpc_id == create_vpc.vpc.id
+          - frontend_vpc_config.subnet_id == create_subnet.subnet.id
+          - frontend_vpc_config.ipv4_range != None
+          - frontend_vpc_config.ipv6_range != None
+          - frontend_vpc_config.purpose == 'frontend'
+          - backend_vpc_config.id != None
+          - backend_vpc_config.nodebalancer_id == create.node_balancer.id
+          - backend_vpc_config.vpc_id == create_vpc.vpc.id
+          - backend_vpc_config.subnet_id == create_subnet.subnet.id
+          - backend_vpc_config.ipv4_range != None
+          - backend_vpc_config.ipv6_range != None
+          - backend_vpc_config.purpose == 'backend'
 
   always:
     - ignore_errors: yes


### PR DESCRIPTION
## 📝 Description

This PR adds support for Frontend IP in VPC for NodeBalancers and `type` attribute when creating or reading NodeBalancers.

## ✔️ How to Test

Run integration tests:

```
make TEST_SUITE="nodebalancer_basic" test-int 
```

```
make TEST_SUITE="nodebalancer_firewall" test-int
```

```
make TEST_SUITE="nodebalancer_frontend_vpc" test-int
```

```
make TEST_SUITE="nodebalancer_list" test-int
```

```
make TEST_SUITE="nodebalancer_node" test-int
```

```
make TEST_SUITE="nodebalancer_populated" test-int
```

```
make TEST_SUITE="nodebalancer_premium" test-int
```

```
make TEST_SUITE="nodebalancer_reordered_tags" test-int
```

```
make TEST_SUITE="nodebalancer_stats" test-int
```

```
make TEST_SUITE="nodebalancer_type_list" test-int
```

```
make TEST_SUITE="nodebalancer_backend_vpc" test-int
```

```
make TEST_SUITE="nodebalancer_vpc_list" test-int
```

```
make TEST_SUITE="nodebalancer_premium_40gb" test-int
```

```
make TEST_SUITE="nodebalancer_udp" test-int
```