### PR TITLE
Fix firewall update logic for `-1`

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1138,7 +1138,7 @@ class LinodeInstance(LinodeModuleBase):
         """
         firewall_id = self.module.params.get("firewall_id")
         # Nothing to do
-        if firewall_id is None:
+        if firewall_id in (None, -1):
             return
 
         # Resolve the expected firewall; fail if firewall doesn't exist

--- a/tests/integration/targets/instance_firewall_minus_one/tasks/main.yaml
+++ b/tests/integration/targets/instance_firewall_minus_one/tasks/main.yaml
@@ -1,0 +1,60 @@
+- name: instance_firewall_minus_one
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a Linode Firewall
+      linode.cloud.firewall:
+        api_version: v4beta
+        label: 'ansible-test-{{ r }}'
+        devices: [ ]
+        rules:
+          inbound_policy: DROP
+          outbound_policy: DROP
+        state: present
+      register: firewall_create
+
+    - name: Create a Linode instance attached to the Firewall
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: g6-standard-1
+        firewall_id: '{{ firewall_create.firewall.id }}'
+        wait: false
+        state: present
+      register: instance_create
+
+    - name: Update the instance with firewall_id -1
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: g6-standard-1
+        firewall_id: -1
+        wait: false
+        state: present
+      register: instance_update
+
+    - name: Assert instance update succeeded without changes
+      assert:
+        that:
+          - instance_update.changed == false
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ instance_create.instance.label }}'
+            state: absent
+
+        - name: Delete a Linode firewall
+          linode.cloud.firewall:
+            label: '{{ firewall_create.firewall.label }}'
+            state: absent
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

`-1` represents explicit no firewall now. We need to handle it in the update logic.

## ✔️ How to Test
Install the collection in this branch
```bash
make install
```
Then run this playbook twice:
```bash
ansible-playbook /path/to/the/test_playbook.yaml
```

```yaml
- name: Test Firewall ID
  hosts: localhost
  collections:
    - linode.cloud
  tasks:
    - name: Create a Linode instance
      linode.cloud.instance:
        label: example-linode
        type: g6-nanode-1
        region: us-central
        image: linode/arch
        root_pass: ReplaceWithAStrwediedekro3ouijqklongPassword123!
        state: present
        firewall_id: -1
        booted: false
      register: create_linode
  environment:
    LINODE_API_VERSION: v4beta

```