### PR TITLE
TPT-4298: Added PR title checking to lint workflow and clean up release notes workflow

### DIFF
--- a/.github/workflows/clean-release-notes.yml
+++ b/.github/workflows/clean-release-notes.yml
@@ -1,0 +1,37 @@
+name: Clean Release Notes
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  clean-release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Remove ticket prefixes from release notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = context.payload.release;
+
+            let body = release.body;
+
+            if (!body) {
+              console.log("Release body empty, nothing to clean.");
+              return;
+            }
+
+            // Remove ticket prefixes like "TPT-1234: " or "TPT-1234:"
+            body = body.replace(/TPT-\d+:\s*/g, '');
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              body: body
+            });
+
+            console.log("Release notes cleaned.");

--- a/.github/workflows/clean-release-notes.yml
+++ b/.github/workflows/clean-release-notes.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Remove ticket prefixes from release notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const release = context.payload.release;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,35 @@ on: pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      # Enforce TPT-1234: prefix on PR titles, with the following exemptions:
+      # - PRs labeled 'dependencies' (e.g. Dependabot PRs)
+      # - PRs labeled 'hotfix' (urgent fixes that may not have a ticket)
+      # - PRs labeled 'community-contribution' (external contributors without TPT tickets)
+      # - PRs labeled 'ignore-for-release' (release PRs that don't need a ticket prefix)
+      - name: Validate PR Title
+        if: github.event_name == 'pull_request'
+        uses: amannn/action-semantic-pull-request@v6
+        with:
+          types: |
+            TPT-\d+
+          requireScope: false
+          # Override the default header pattern to allow hyphens and digits in the type
+          # (e.g. "TPT-4298: Description"). The default pattern only matches word
+          # characters (\w) which excludes hyphens.
+          headerPattern: '^([\w-]+):\s?(.*)$'
+          headerPatternCorrespondence: type, subject
+          ignoreLabels: |
+            dependencies
+            hotfix
+            community-contribution
+            ignore-for-release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: checkout repo
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## 📝 Description

Added a new step in the lint workflow to fail if the PR title does not begin with "TPT-1234:" (works with and without a space between the colon and description).

Also added a new workflow to run upon release publish to edit the release notes to remove the Jira ticket ID prefixes from patch notes.

## ✔️ How to Test

To test the PR title enforcement, edit the title of this PR to remove the Jira ticket ID and rerun the lint job. It should fail immediately. Then, add the Jira ticket ID back to the PR title and it should pass.

To test the release note cleanup job, check out this PR locally and merge it into your fork. Then, cut a test release to your fork. Upon generating the release notes, the TPT-**** prefix will still be there. Publish the release and verify that the new workflow is triggered. After it finishes, confirm that the release notes were correctly updated.
