### PR TITLE
TPT-4326: Resolve unordered config device slot assignment issue; fix test issues blocking release

### DIFF
--- a/docs/modules/database_mysql_info.md
+++ b/docs/modules/database_mysql_info.md
@@ -75,22 +75,6 @@ Get info about a Linode MySQL Managed Database.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance) for a list of returned fields
 
 
-- `backups` - The database backups in JSON serialized form.
-
-    - Sample Response:
-        ```json
-        [
-           {
-              "created":"2022-01-01T00:01:01",
-              "id":123,
-              "label":"Scheduled - 02/04/22 11:11 UTC-XcCRmI",
-              "type":"auto"
-           }
-        ]
-        ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backup) for a list of returned fields
-
-
 - `ssl_cert` - The SSL CA certificate for an accessible Managed MySQL Database.
 
     - Sample Response:

--- a/docs/modules/database_postgresql_info.md
+++ b/docs/modules/database_postgresql_info.md
@@ -76,22 +76,6 @@ Get info about a Linode PostgreSQL Managed Database.
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance) for a list of returned fields
 
 
-- `backups` - The database backups in JSON serialized form.
-
-    - Sample Response:
-        ```json
-        [
-           {
-              "created":"2022-01-01T00:01:01",
-              "id":123,
-              "label":"Scheduled - 02/04/22 11:11 UTC-XcCRmI",
-              "type":"auto"
-           }
-        ]
-        ```
-    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups) for a list of returned fields
-
-
 - `ssl_cert` - The SSL CA certificate for an accessible Managed PostgreSQL Database.
 
     - Sample Response:

--- a/plugins/module_utils/doc_fragments/database_mysql.py
+++ b/plugins/module_utils/doc_fragments/database_mysql.py
@@ -40,12 +40,3 @@ result_credentials_samples = ['''{
 result_ssl_cert_samples = ['''{
   "ca_certificate": "LS0tLS1CRUdJ...=="
 }''']
-
-result_backups_samples = ['''[
-   {
-      "created":"2022-01-01T00:01:01",
-      "id":123,
-      "label":"Scheduled - 02/04/22 11:11 UTC-XcCRmI",
-      "type":"auto"
-   }
-]''']

--- a/plugins/module_utils/doc_fragments/database_postgresql.py
+++ b/plugins/module_utils/doc_fragments/database_postgresql.py
@@ -41,12 +41,3 @@ result_credentials_samples = ['''{
 result_ssl_cert_samples = ['''{
   "ca_certificate": "LS0tLS1CRUdJ...=="
 }''']
-
-result_backups_samples = ['''[
-   {
-      "created":"2022-01-01T00:01:01",
-      "id":123,
-      "label":"Scheduled - 02/04/22 11:11 UTC-XcCRmI",
-      "type":"auto"
-   }
-]''']

--- a/plugins/modules/database_mysql_info.py
+++ b/plugins/modules/database_mysql_info.py
@@ -29,7 +29,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     filter_null_values,
     mapping_to_dict,
-    paginated_list_to_json,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -66,13 +65,6 @@ SPECDOC_META = SpecDocMeta(
             type=FieldType.dict,
             sample=docs_parent.result_database_samples,
         ),
-        "backups": SpecReturnValue(
-            description="The database backups in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/"
-            "get-databases-mysql-instance-backup",
-            type=FieldType.dict,
-            sample=docs_parent.result_backups_samples,
-        ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed MySQL Database.",
             docs_url="https://techdocs.akamai.com/linode-api/reference/"
@@ -105,7 +97,6 @@ class Module(LinodeModuleBase):
         self.module_arg_spec = SPECDOC_META.ansible_spec
         self.results = {
             "database": None,
-            "backups": None,
             "credentials": None,
             "ssl_cert": None,
         }
@@ -140,9 +131,6 @@ class Module(LinodeModuleBase):
         database._api_get()
 
         self.results["database"] = database._raw_json
-        self.results["backups"] = call_protected_provisioning(
-            lambda: paginated_list_to_json(database.backups)
-        )
         self.results["credentials"] = call_protected_provisioning(
             lambda: mapping_to_dict(database.credentials)
         )

--- a/plugins/modules/database_postgresql_info.py
+++ b/plugins/modules/database_postgresql_info.py
@@ -29,7 +29,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_docs import (
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
     filter_null_values,
     mapping_to_dict,
-    paginated_list_to_json,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -66,13 +65,6 @@ SPECDOC_META = SpecDocMeta(
             type=FieldType.dict,
             sample=docs_parent.result_database_samples,
         ),
-        "backups": SpecReturnValue(
-            description="The database backups in JSON serialized form.",
-            docs_url="https://techdocs.akamai.com/linode-api/reference/"
-            "get-databases-postgre-sql-instance-backups",
-            type=FieldType.dict,
-            sample=docs_parent.result_backups_samples,
-        ),
         "ssl_cert": SpecReturnValue(
             description="The SSL CA certificate for an accessible Managed PostgreSQL Database.",
             docs_url="https://techdocs.akamai.com/linode-api/reference/"
@@ -106,7 +98,6 @@ class Module(LinodeModuleBase):
         self.module_arg_spec = SPECDOC_META.ansible_spec
         self.results = {
             "database": None,
-            "backups": None,
             "credentials": None,
             "ssl_cert": None,
         }
@@ -143,9 +134,6 @@ class Module(LinodeModuleBase):
         database._api_get()
 
         self.results["database"] = database._raw_json
-        self.results["backups"] = call_protected_provisioning(
-            lambda: paginated_list_to_json(database.backups)
-        )
         self.results["credentials"] = call_protected_provisioning(
             lambda: mapping_to_dict(database.credentials)
         )

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1017,9 +1017,9 @@ class LinodeInstance(LinodeModuleBase):
 
     def _reconcile_devices(
         self, config_params: Dict[str, Any]
-    ) -> List[Union[Disk, Volume]]:
+    ) -> Dict[str, Union[Disk, Volume]]:
         device_params = config_params.pop("devices")
-        devices = []
+        devices = {}
 
         if device_params is not None:
             device_limit = int(
@@ -1040,7 +1040,7 @@ class LinodeInstance(LinodeModuleBase):
                 device_dict = device_params.get(device_name)
                 device = self._param_device_to_device(device_dict)
                 if device is not None:
-                    devices.append(device)
+                    devices[device_name] = device
                     if len(devices) > device_limit:
                         self.fail(
                             msg=f"Too many devices specified for this instance type. "
@@ -1051,10 +1051,10 @@ class LinodeInstance(LinodeModuleBase):
 
         return devices
 
-    def _create_config_register(self, config_params: Dict[str, Any]) -> None:
+    def _create_config_register(self, config_params: Dict[str, Any]) -> Config:
         devices = self._reconcile_devices(config_params)
         try:
-            self._instance.config_create(
+            config = self._instance.config_create(
                 devices=devices, **filter_null_values(config_params)
             )
         except ValueError as err:
@@ -1063,6 +1063,8 @@ class LinodeInstance(LinodeModuleBase):
         self.register_action(
             "Created config {0}".format(config_params.get("label"))
         )
+
+        return config
 
     def _delete_config_register(self, config: Config) -> None:
         self.register_action("Deleted config {0}".format(config.label))
@@ -1342,14 +1344,15 @@ class LinodeInstance(LinodeModuleBase):
         if should_update:
             config.save()
 
-    def _update_configs(self) -> None:
+    def _update_configs(self) -> List[Config]:
         current_configs = self._instance.configs
 
         if self.module.params.get("image") is not None:
-            return
+            return []
 
         config_params = self.module.params["configs"] or []
         config_map: Dict[str, Config] = {}
+        created_configs: List[Config] = []
 
         for config in current_configs:
             config_map[config.label] = config
@@ -1363,10 +1366,12 @@ class LinodeInstance(LinodeModuleBase):
                 del config_map[config_label]
                 continue
 
-            self._create_config_register(config)
+            created_configs.append(self._create_config_register(config))
 
         for config in config_map.values():
             self._delete_config_register(config)
+
+        return created_configs
 
     def _update_disk(self, disk: Disk, disk_params: Dict[str, Any]) -> None:
         new_size = disk_params.pop("size")
@@ -1635,6 +1640,7 @@ class LinodeInstance(LinodeModuleBase):
         # This eliminates the need for unnecessary polling
         disks = self.module.params.get("disks") or []
         configs = self.module.params.get("configs") or []
+        created_configs: List[Config] = []
 
         if len(configs) > 0 or len(disks) > 0:
             self.client.polling.wait_for_entity_free(
@@ -1644,7 +1650,7 @@ class LinodeInstance(LinodeModuleBase):
             )
 
             self._update_disks()
-            self._update_configs()
+            created_configs = self._update_configs()
 
         # Don't reboot on instance creation
         if self.module.params.get("rebooted") is not None and already_exists:
@@ -1663,7 +1669,14 @@ class LinodeInstance(LinodeModuleBase):
         inst_result["root_pass"] = self._root_pass
 
         self.results["instance"] = inst_result
-        self.results["configs"] = paginated_list_to_json(self._instance.configs)
+
+        # Use the configs returned directly from config_create if the API
+        # hasn't propagated them yet (self._instance.configs may be empty
+        # immediately after creation due to eventual consistency).
+        fetched_configs = self._instance.configs
+        self.results["configs"] = paginated_list_to_json(
+            fetched_configs if len(fetched_configs) > 0 else created_configs
+        )
         self.results["disks"] = paginated_list_to_json(self._instance.disks)
         self.results["networking"] = self._get_networking()
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -1650,6 +1650,9 @@ class LinodeInstance(LinodeModuleBase):
             )
 
             self._update_disks()
+
+            self._instance.invalidate()
+
             created_configs = self._update_configs()
 
         # Don't reboot on instance creation

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -20,7 +20,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     dict_select_matching,
     filter_null_values,
     handle_updates,
-    paginated_list_to_json,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -555,19 +554,25 @@ class LinodeNodeBalancer(LinodeModuleBase):
         for config in to_delete:
             self._delete_config_register(config)
 
+        result_configs = []
+
         for config, remote_config in to_create:
             new_config = self._create_config_register(
                 self._node_balancer, config
             )
             if config.get("nodes") is not None:
                 self._handle_config_nodes(new_config, config.get("nodes"))
+            new_config._api_get()
+            result_configs.append(new_config)
 
         for config, remote_config in to_update:
             if config.get("nodes") is not None:
                 self._handle_config_nodes(remote_config, config.get("nodes"))
+            remote_config._api_get()
+            result_configs.append(remote_config)
 
         cast(list, self.results["configs"]).extend(
-            paginated_list_to_json(self._node_balancer.configs)
+            [c._raw_json for c in result_configs]
         )
 
     def _update_nodebalancer(self) -> None:

--- a/plugins/modules/nodebalancer_info.py
+++ b/plugins/modules/nodebalancer_info.py
@@ -19,7 +19,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info im
     InfoModuleResult,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import (
-    paginated_list_to_json,
     safe_find,
 )
 from ansible_specdoc.objects import FieldType
@@ -35,6 +34,17 @@ def _get_firewalls_data(
         firewall._api_get()
         firewalls_json.append(firewall._raw_json)
     return firewalls_json
+
+
+def _get_configs(
+    client: LinodeClient, nodebalancer: NodeBalancer, params: Dict[str, Any]
+) -> List[Any]:
+    configs = NodeBalancer(client, nodebalancer["id"]).configs
+    configs_json = []
+    for config in configs:
+        config._api_get()
+        configs_json.append(config._raw_json)
+    return configs_json
 
 
 def _get_nodes(
@@ -64,9 +74,7 @@ module = InfoModule(
             display_name="configs",
             docs_url="https://techdocs.akamai.com/linode-api/reference/get-node-balancer-configs",
             samples=docs_parent.result_configs_samples,
-            get=lambda client, nodebalancer, params: paginated_list_to_json(
-                NodeBalancer(client, nodebalancer["id"]).configs
-            ),
+            get=_get_configs,
         ),
         InfoModuleResult(
             field_name="nodes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode_api4>= 5.41.0
+linode_api4>= 5.42.0
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -3,6 +3,11 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
+    - name: Get account_settings
+      linode.cloud.account_settings:
+        state: 'present'
+      register: account_info
+
     - name: Create a Linode instance without set backup to be enabled
       linode.cloud.instance:
         label: 'ansible-test-not-set-backup-{{ r }}'
@@ -18,7 +23,7 @@
       assert:
         that:
           - create_no_set_backup.changed
-          - create_no_set_backup.instance.backups.enabled == False
+          - create_no_set_backup.instance.backups.enabled == account_info.account_settings.backups_enabled
 
     - name: Create a Linode instance with backups enabled
       linode.cloud.instance:
@@ -26,7 +31,7 @@
         region: us-central
         type: g6-standard-1
         image: linode/ubuntu22.04
-        wait: false
+        wait: true
         state: present
         backups_enabled: true
         firewall_id: '{{ firewall_id }}'
@@ -48,13 +53,13 @@
         state: present
         backups_enabled: False
       register: update_backups_canceled
-    
+
     - name: Assert instance updated
       assert:
         that:
           - update_backups_canceled.changed
           - update_backups_canceled.instance.backups.enabled == False
-    
+
     - name: Cancel backups on backups enabled linode
       linode.cloud.instance:
         label: '{{ create_no_set_backup.instance.label }}'
@@ -65,7 +70,7 @@
         state: present
         backups_enabled: True
       register: update_backups_enabled
-    
+
     - name: Assert instance updated
       assert:
         that:

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -13,7 +13,7 @@
         label: 'ansible-test-not-set-backup-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/ubuntu22.04
+        image: linode/ubuntu24.04
         wait: false
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -28,9 +28,9 @@
     - name: Create a Linode instance with backups enabled
       linode.cloud.instance:
         label: 'ansible-test-backups-enabled-{{ r }}'
-        region: us-central
+        region: us-mia
         type: g6-standard-1
-        image: linode/ubuntu22.04
+        image: linode/ubuntu24.04
         wait: true
         state: present
         backups_enabled: true
@@ -46,9 +46,9 @@
     - name: Cancel backups on backups enabled linode
       linode.cloud.instance:
         label: '{{ create_backups_enabled.instance.label }}'
-        region: us-central
+        region: us-mia
         type: g6-standard-1
-        image: linode/ubuntu22.04
+        image: linode/ubuntu24.04
         wait: false
         state: present
         backups_enabled: False
@@ -60,12 +60,12 @@
           - update_backups_canceled.changed
           - update_backups_canceled.instance.backups.enabled == False
 
-    - name: Cancel backups on backups enabled linode
+    - name: Re-enable backups on instance
       linode.cloud.instance:
         label: '{{ create_no_set_backup.instance.label }}'
-        region: us-central
+        region: us-mia
         type: g6-standard-1
-        image: linode/ubuntu22.04
+        image: linode/ubuntu24.04
         wait: false
         state: present
         backups_enabled: True

--- a/tests/integration/targets/instance_device_slot/tasks/main.yaml
+++ b/tests/integration/targets/instance_device_slot/tasks/main.yaml
@@ -1,0 +1,52 @@
+- name: instance_device_slot
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create an instance with a disk only in slot sdz
+      linode.cloud.instance:
+        label: 'ansible-test-slot-{{ r }}'
+        region: us-ord
+        type: g6-nanode-1
+        booted: false
+        disks:
+          - label: test-disk
+            filesystem: ext4
+            size: 512
+        configs:
+          - label: test-config
+            devices:
+              sdz:
+                disk_label: test-disk
+        state: present
+        firewall_id: '{{ firewall_id }}'
+      register: slot_test
+
+    - name: Assert disk is in slot sdz, not shifted to sda
+      assert:
+        that:
+          - slot_test.changed
+          - slot_test.configs[0].devices.sdz.disk_id is not none
+          - slot_test.configs[0].devices.sda.disk_id is none
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete instance
+          linode.cloud.instance:
+            label: 'ansible-test-slot-{{ r }}'
+            state: absent
+          register: delete
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete.changed
+              - delete.instance.id == slot_test.instance.id
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_device_slot/tasks/main.yaml
+++ b/tests/integration/targets/instance_device_slot/tasks/main.yaml
@@ -3,11 +3,11 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    - name: Create an instance with a disk only in slot sdz
+    - name: Create an instance with a disk only in slot sdl
       linode.cloud.instance:
         label: 'ansible-test-slot-{{ r }}'
         region: us-ord
-        type: g6-nanode-1
+        type: g6-standard-6
         booted: false
         disks:
           - label: test-disk
@@ -16,18 +16,18 @@
         configs:
           - label: test-config
             devices:
-              sdz:
+              sdl:
                 disk_label: test-disk
         state: present
         firewall_id: '{{ firewall_id }}'
       register: slot_test
 
-    - name: Assert disk is in slot sdz, not shifted to sda
+    - name: Assert disk is in slot sdl, not shifted to sda
       assert:
         that:
           - slot_test.changed
-          - slot_test.configs[0].devices.sdz.disk_id is not none
-          - slot_test.configs[0].devices.sda.disk_id is none
+          - slot_test.configs[0].devices.sdl.disk_id is not none
+          - slot_test.configs[0].devices.sda is none
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -62,7 +62,6 @@
           - by_label.database.type == 'g6-standard-1'
           - by_label.ssl_cert != None
           - by_label.credentials != None
-          - by_label.backups != None
           - by_id.database.allow_list | length == 1
           - by_id.database.allow_list[0] == '0.0.0.0/0'
           - by_id.database.engine == 'mysql'
@@ -71,7 +70,6 @@
           - by_id.database.type == 'g6-standard-1'
           - by_id.ssl_cert != None
           - by_id.credentials != None
-          - by_id.backups != None
 
 
     - name: Update the database

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -66,7 +66,6 @@
           - db_create.database.encrypted == true
           - db_create.database.replication_type == 'asynch'
           - db_create.database.ssl_connection == true
-          - db_create.backups != None
           - db_create.credentials != None
           - db_create.ssl_cert != None
           - db_create.database.updates.day_of_week == 2

--- a/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
@@ -7,6 +7,7 @@
       linode.cloud.nodebalancer:
         label: 'ansible-test-{{ r }}'
         region: ap-northeast
+        type: premium
         client_udp_sess_throttle: 3
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -24,6 +25,7 @@
         label: '{{ create_nodebalancer.node_balancer.label }}'
         region: ap-northeast
         client_udp_sess_throttle: 3
+        type: premium
         state: present
         configs:
           - port: 80

--- a/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
@@ -69,7 +69,7 @@
         that:
           - nb_info.node_balancer.id == create_nodebalancer.node_balancer.id
           - nb_info.configs[0].udp_check_port == 1234
-          - nb_info.configs[0].udp_session_timeout == 16
+          - nb_info.configs[0].udp_session_timeout == 2
           - nb_info.node_balancer.client_udp_sess_throttle == 3
 
   always:

--- a/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_udp/tasks/main.yaml
@@ -7,7 +7,6 @@
       linode.cloud.nodebalancer:
         label: 'ansible-test-{{ r }}'
         region: ap-northeast
-        type: premium
         client_udp_sess_throttle: 3
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -25,7 +24,6 @@
         label: '{{ create_nodebalancer.node_balancer.label }}'
         region: ap-northeast
         client_udp_sess_throttle: 3
-        type: premium
         state: present
         configs:
           - port: 80

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -68,7 +68,6 @@
           - db_create.database.replication_type == 'asynch'
           - db_create.database.replication_commit_type == 'local'
           - db_create.database.ssl_connection == true
-          - db_create.backups != None
           - db_create.credentials != None
           - db_create.ssl_cert != None
           - db_create.database.updates.day_of_week == 2

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -26,7 +26,7 @@
           description: test description
           state: present
       register: invalid_label
-      failed_when: "'Label must include only ASCII letters, numbers, and dashes' not in invalid_label.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in invalid_label.msg"
 
     - name: Update the VPC
       linode.cloud.vpc:

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -44,7 +44,7 @@
         ipv4: '10.0.0.0/24'
         state: present
       register: invalid_subnet
-      failed_when: "'Label must include only ASCII letters, numbers, and dashes' not in invalid_subnet.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in invalid_subnet.msg"
 
     - name: List Subnets
       linode.cloud.vpc_subnet_list:


### PR DESCRIPTION
## 📝 Description

This pull request resolves broken behavior that would occur when trying to specify config device blocks with slots out of order.

Additionally, this PR resolves some test failures by removing residual legacy DBaaS backups-related fields that were not excluded by #75, updating the instance_backup_enabled to respect the account default backups enrollment, fixing config caching issues in the nodebalancer and nodebalancer_info modules, etc.

## ✔️ How to Test

### Integration Testing

```
make test-int TEST_ARGS="-v instance_device_slot database_mysql_v2_vpc database_postgresql_v2_vpc instance_backup_enabled nodebalancer_udp vpc_basic vpc_subnet"
