### PR TITLE
TPT-4395: update VPC task names and fix error messages assertion

### DIFF
--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -50,7 +50,7 @@
         description: test description updated
         state: present
       register: modify_vpc
-      failed_when: "'Label must include only ASCII letters, numbers, and dashes' not in modify_vpc.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in modify_vpc.msg"
 
     - name: Don't update the VPC
       linode.cloud.vpc:

--- a/tests/integration/targets/vpc_ip_list/tasks/main.yaml
+++ b/tests/integration/targets/vpc_ip_list/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: vpc_basic
+- name: vpc_ip_list
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: vpc_basic
+- name: vpc_subnet
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"


### PR DESCRIPTION
## 📝 Description

Fix VPC test task names and error messages assertion

## Testing

```bash
make test-int TEST_SUITE="vpc_basic"
```