### PR TITLE
TPT-4417: Resolve `nodebalancer` module ordering and sync issues; support in-place config updates

### DIFF
--- a/plugins/module_utils/linode_helper.py
+++ b/plugins/module_utils/linode_helper.py
@@ -660,6 +660,32 @@ def retry_on_response_status(
     )
 
 
+def poll_for_response_status(
+    timeout_ctx: TimeoutContext, func: Callable[[], None], *statuses: int
+):
+    """
+    Polls a given function until it raises an ApiError with one of the
+    specified response statuses.
+    """
+
+    def __attempt() -> bool:
+        try:
+            func()
+        except ApiError as err:
+            if err.status in statuses:
+                return True
+
+            raise err
+
+        return False
+
+    poll_condition(
+        __attempt,
+        step=4,
+        timeout=timeout_ctx.seconds_remaining,
+    )
+
+
 def api_filter_constructor_for_aclp_monitor_services(
     params: Dict[str, Any],
 ) -> Dict[str, Any]:

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -585,9 +585,11 @@ class LinodeNodeBalancer(LinodeModuleBase):
     def _handle_configs(self) -> list:
         """Updates the configs defined in new_configs under this NodeBalancer"""
 
-        new_configs = self.module.params.get("configs") or []
-        if not new_configs:
+        configs_param = self.module.params.get("configs")
+        if configs_param is None:
             return []
+
+        new_configs = configs_param
 
         to_create, to_update, to_delete = self._plan_configs(new_configs)
 
@@ -670,7 +672,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
     def _sync_config_nodes(
         self,
-        config: Optional[NodeBalancerConfig],
+        config: NodeBalancerConfig,
         nodes: Optional[List[dict]],
     ) -> None:
         """Sync nodes against the given config if provided."""

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -355,6 +355,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
         }
 
         self._node_balancer: Optional[NodeBalancer] = None
+        self._deleted_config_ids: Set[int] = set()
 
         super().__init__(
             module_arg_spec=self.module_arg_spec,
@@ -420,7 +421,9 @@ class LinodeNodeBalancer(LinodeModuleBase):
         Creates a config with the given kwargs within the given NodeBalancer.
 
         Retries config_create(...) on 400s while a conflicting config's
-        deletion is still propagating.
+        deletion is still propagating. If a matching remote surfaces while
+        the caller asked for a recreate, the remote is deleted and polling
+        continues until the create succeeds.
         """
 
         result: Optional[NodeBalancerConfig] = None
@@ -435,23 +438,24 @@ class LinodeNodeBalancer(LinodeModuleBase):
                 return True
             except ApiError as err:
                 if err.status != 400 or "already using port" not in str(err):
-                    # This is a real error
                     raise
 
-                node_balancer.invalidate()
-                exists, remote = self._check_config_exists(
-                    node_balancer.configs, config_params
-                )
+            node_balancer.invalidate()
+            exists, remote = self._check_config_exists(
+                set(node_balancer.configs), config_params
+            )
 
-                if exists:
-                    # Config already exists so we can reuse it
-                    result = remote
-                    changed = False
+            if not exists or remote.id in self._deleted_config_ids:
+                # No live match yet
+                return False
 
-                    return True
+            if config_params.get("recreate"):
+                self._delete_config_register(remote)
+                return False
 
-            # Config doesn't exist, keep polling for propagation
-            return False
+            result = remote
+            changed = False
+            return True
 
         try:
             poll_condition(_attempt, step=2, timeout=120)
@@ -494,6 +498,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         self.register_action("Deleted config: {0}".format(config.id))
         config.delete()
+        self._deleted_config_ids.add(config.id)
 
     def _create_node_register(
         self, config: NodeBalancerConfig, node_params: dict
@@ -589,6 +594,11 @@ class LinodeNodeBalancer(LinodeModuleBase):
         for config in to_delete:
             self._delete_config_register(config)
 
+        # Wait for deletions to propagate before attempting creates; otherwise
+        # the API returns "already using port" 400s on overlapping ports.
+        if to_delete:
+            self._wait_for_configs_synced(len(to_update))
+
         result_configs = []
 
         for config in to_create:
@@ -610,16 +620,27 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         return result_configs
 
-    def _wait_for_configs_synced(self, n: int) -> None:
+    def _wait_for_configs_synced(
+        self, num_configs: int, consecutive_threshold: int = 3
+    ) -> None:
         """Workaround for config deletion eventual consistency issue."""
 
-        nb = self._node_balancer
+        successful_requests = 0
 
         def _synced() -> bool:
-            nb.invalidate()
-            return len(nb.configs) == n
+            nonlocal successful_requests
 
-        poll_condition(_synced, step=2, timeout=120)
+            self._node_balancer.invalidate()
+
+            successful_requests = (
+                successful_requests + 1
+                if len(self._node_balancer.configs) == num_configs
+                else 0
+            )
+
+            return successful_requests >= consecutive_threshold
+
+        poll_condition(_synced, step=2, timeout=180)
 
     def _plan_configs(self, new_configs: list[dict]) -> tuple[
         list[dict],

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -36,6 +36,15 @@ from linode_api4 import (
     NodeBalancerNode,
 )
 
+# tcp/http/https share a port namespace; udp is independent. Used to detect
+# which existing config is blocking a create on a given port.
+_TCP_FAMILY = {"tcp", "http", "https"}
+
+
+def _protocol_family(protocol: Optional[str]) -> Optional[str]:
+    return "tcp" if protocol in _TCP_FAMILY else protocol
+
+
 linode_nodes_spec = {
     "label": SpecField(
         type=FieldType.string,
@@ -441,21 +450,27 @@ class LinodeNodeBalancer(LinodeModuleBase):
                     raise
 
             node_balancer.invalidate()
+
+            remote_configs = set(node_balancer.configs)
+
             exists, remote = self._check_config_exists(
-                set(node_balancer.configs), config_params
+                remote_configs, config_params
             )
 
-            if not exists or remote.id in self._deleted_config_ids:
-                # No live match yet
-                return False
+            if exists and remote.id not in self._deleted_config_ids:
+                if config_params.get("recreate"):
+                    self._delete_config_register(remote)
+                    return False
 
-            if config_params.get("recreate"):
-                self._delete_config_register(remote)
-                return False
+                result = remote
+                changed = False
+                return True
 
-            result = remote
-            changed = False
-            return True
+            conflict = self._find_port_conflict(remote_configs, config_params)
+            if conflict is not None:
+                self._delete_config_register(conflict)
+
+            return False
 
         try:
             poll_condition(_attempt, step=2, timeout=120)
@@ -582,6 +597,28 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         return False, None
 
+    def _find_port_conflict(
+        self,
+        target: Set[NodeBalancerConfig],
+        config: dict[str, Any],
+    ) -> Optional[NodeBalancerConfig]:
+        """Return a remote config in conflict."""
+
+        port = config.get("port")
+        family = _protocol_family(config.get("protocol"))
+
+        for remote_config in target:
+            if (
+                remote_config.id in self._deleted_config_ids
+                or remote_config.port != port
+                or _protocol_family(remote_config.protocol) != family
+            ):
+                continue
+
+            return remote_config
+
+        return None
+
     def _handle_configs(self) -> list:
         """Updates the configs defined in new_configs under this NodeBalancer"""
 
@@ -625,21 +662,22 @@ class LinodeNodeBalancer(LinodeModuleBase):
     def _wait_for_configs_synced(
         self, num_configs: int, consecutive_threshold: int = 3
     ) -> None:
-        """Workaround for config deletion eventual consistency issue."""
-
+        """
+        Wait for the list endpoint to consistently show the expected config
+        count. Requires consecutive matching polls — the list is eventually
+        consistent across API nodes, so a single match can be transient.
+        """
         successful_requests = 0
 
         def _synced() -> bool:
             nonlocal successful_requests
-
             self._node_balancer.invalidate()
 
-            successful_requests = (
-                successful_requests + 1
-                if len(self._node_balancer.configs) == num_configs
-                else 0
-            )
+            if len(self._node_balancer.configs) != num_configs:
+                successful_requests = 0
+                return False
 
+            successful_requests += 1
             return successful_requests >= consecutive_threshold
 
         poll_condition(_synced, step=2, timeout=180)

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -545,7 +545,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
         # Wait for nodes to propagate
         expected_node_count = len(new_nodes)
 
-        def _nodes_synced():
+        def _nodes_synced() -> bool:
             if hasattr(config, "_nodes"):
                 # In the future we should fix the invalidation behavior in the Python SDK,
                 # but this works as a workaround

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -610,35 +610,40 @@ class LinodeNodeBalancer(LinodeModuleBase):
             self._sync_config_nodes(remote_config, config.get("nodes"))
             result_configs.append(remote_config)
 
-        self._wait_for_configs_synced(len(new_configs))
-
         cast(list, self.results["configs"]).extend(
             [c._raw_json for c in result_configs]
         )
 
         return result_configs
 
-    def _wait_for_configs_synced(
-        self, num_configs: int, consecutive_threshold: int = 3
-    ) -> None:
+    def _stable_configs(
+        self, consecutive_threshold: int = 3
+    ) -> List[NodeBalancerConfig]:
         """
         Wait for the list endpoint to consistently show the expected config
-        count. Workaround for API propagation behavior
+        count. Workaround for API propagation behavior.
         """
         successful_requests = 0
+        last_len = -1
+        last_configs: List[NodeBalancerConfig] = []
 
-        def _synced() -> bool:
-            nonlocal successful_requests
+        def _stable() -> bool:
+            nonlocal successful_requests, last_len, last_configs
             self._node_balancer.invalidate()
+            last_configs = list(self._node_balancer.configs)
 
-            if len(self._node_balancer.configs) != num_configs:
+            if len(last_configs) != last_len:
                 successful_requests = 0
+                last_len = len(last_configs)
+
                 return False
 
             successful_requests += 1
             return successful_requests >= consecutive_threshold
 
-        poll_condition(_synced, step=2, timeout=180)
+        poll_condition(_stable, step=2, timeout=180)
+
+        return last_configs
 
     def _plan_configs(self, new_configs: list[dict]) -> tuple[
         list[dict],
@@ -647,7 +652,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
     ]:
         """Partition desired configs into (create, update, delete) sets."""
 
-        remote_configs = set(self._node_balancer.configs)
+        remote_configs = set(self._stable_configs())
         to_create: list[dict] = []
         to_update: list[tuple[dict, NodeBalancerConfig]] = []
         to_delete = remote_configs

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -354,8 +354,6 @@ MUTABLE_CONFIG_FIELDS: set[str] = {
     "port",
     "protocol",
     "proxy_protocol",
-    "ssl_cert",
-    "ssl_key",
     "stickiness",
     "udp_check_port",
 }
@@ -748,8 +746,13 @@ class LinodeNodeBalancer(LinodeModuleBase):
         self._handle_nodebalancer()
         result_configs = self._handle_configs()
 
-        # Append all nodes to the result
-        for config in result_configs or self._node_balancer.configs:
+        result_configs = (
+            result_configs
+            if self.module.params.get("configs") is not None
+            else self._node_balancer.configs
+        )
+
+        for config in result_configs:
             for node in config.nodes:
                 node._api_get()
                 cast(list, self.results["nodes"]).append(node._raw_json)

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -29,11 +29,11 @@ from ansible_specdoc.objects import (
     SpecReturnValue,
 )
 from linode_api4 import (
+    ApiError,
     Firewall,
     NodeBalancer,
     NodeBalancerConfig,
     NodeBalancerNode,
-    ApiError,
 )
 
 linode_nodes_spec = {

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
 from typing import Any, List, Optional, Set, Tuple, cast
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.nodebalancer as docs
@@ -21,6 +20,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     filter_null_values,
     handle_updates,
     poll_condition,
+    poll_for_response_status,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -35,6 +35,7 @@ from linode_api4 import (
     NodeBalancerConfig,
     NodeBalancerNode,
 )
+from linode_api4.polling import TimeoutContext
 
 # tcp/http/https share a port namespace; udp is independent. Used to detect
 # which existing config is blocking a create on a given port.
@@ -340,6 +341,25 @@ MUTABLE_FIELDS: Set[str] = {
     "client_udp_sess_throttle",
 }
 
+MUTABLE_CONFIG_FIELDS: set[str] = {
+    "algorithm",
+    "check",
+    "check_attempts",
+    "check_body",
+    "check_interval",
+    "check_passive",
+    "check_path",
+    "check_timeout",
+    "cipher_suite",
+    "port",
+    "protocol",
+    "proxy_protocol",
+    "ssl_cert",
+    "ssl_key",
+    "stickiness",
+    "udp_check_port",
+}
+
 DOCUMENTATION = r"""
 """
 EXAMPLES = r"""
@@ -426,62 +446,15 @@ class LinodeNodeBalancer(LinodeModuleBase):
     def _create_config(
         self, node_balancer: NodeBalancer, config_params: dict
     ) -> tuple[Optional[NodeBalancerConfig], bool]:
-        """
-        Creates a config with the given kwargs within the given NodeBalancer.
-
-        Retries config_create(...) on 400s while a conflicting config's
-        deletion is still propagating. If a matching remote surfaces while
-        the caller asked for a recreate, the remote is deleted and polling
-        continues until the create succeeds.
-        """
-
-        result: Optional[NodeBalancerConfig] = None
-        changed = False
-
-        def _attempt() -> bool:
-            nonlocal result, changed
-
-            try:
-                result = node_balancer.config_create(**config_params)
-                changed = True
-                return True
-            except ApiError as err:
-                if err.status != 400 or "already using port" not in str(err):
-                    raise
-
-            node_balancer.invalidate()
-
-            remote_configs = set(node_balancer.configs)
-
-            exists, remote = self._check_config_exists(
-                remote_configs, config_params
-            )
-
-            if exists and remote.id not in self._deleted_config_ids:
-                if config_params.get("recreate"):
-                    self._delete_config_register(remote)
-                    return False
-
-                result = remote
-                changed = False
-                return True
-
-            conflict = self._find_port_conflict(remote_configs, config_params)
-            if conflict is not None:
-                self._delete_config_register(conflict)
-
-            return False
+        """Creates a config with the given kwargs within the given NodeBalancer."""
 
         try:
-            poll_condition(_attempt, step=2, timeout=120)
-        except Exception as exception:
+            return node_balancer.config_create(**config_params), True
+        except ApiError as err:
             self.fail(
-                msg="failed to create nodebalancer config: {0}".format(
-                    exception
-                )
+                msg="failed to create nodebalancer config: {0}".format(err)
             )
-
-        return result, changed
+            return None, False
 
     def _create_node(
         self, config: NodeBalancerConfig, node_params: dict
@@ -575,34 +548,12 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         poll_condition(_nodes_synced, step=2, timeout=120)
 
-    @staticmethod
-    def _check_config_exists(
-        target: Set[NodeBalancerConfig], config: dict
-    ) -> Tuple[bool, Optional[NodeBalancerConfig]]:
-        """Returns whether a config exists in the target set"""
-
-        tmp_config = copy.deepcopy(config)
-
-        # These fields will return as <REDACTED> so we should not diff on them
-        tmp_config.pop("ssl_cert", None)
-        tmp_config.pop("ssl_key", None)
-
-        for remote_config in target:
-            config_match, remote_config_match = dict_select_matching(
-                filter_null_values(tmp_config), remote_config._raw_json
-            )
-
-            if config_match == remote_config_match:
-                return True, remote_config
-
-        return False, None
-
     def _find_port_conflict(
         self,
         target: Set[NodeBalancerConfig],
         config: dict[str, Any],
     ) -> Optional[NodeBalancerConfig]:
-        """Return a remote config in conflict."""
+        """Return a remote config matching on port+protocol-family."""
 
         port = config.get("port")
         family = _protocol_family(config.get("protocol"))
@@ -635,8 +586,10 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         # Wait for deletions to propagate before attempting creates; otherwise
         # the API returns "already using port" 400s on overlapping ports.
-        if to_delete:
-            self._wait_for_configs_synced(len(to_update))
+        for config in to_delete:
+            poll_for_response_status(
+                TimeoutContext(timeout_seconds=120), config._api_get, 404
+            )
 
         result_configs = []
 
@@ -648,6 +601,12 @@ class LinodeNodeBalancer(LinodeModuleBase):
             result_configs.append(new_config)
 
         for config, remote_config in to_update:
+            handle_updates(
+                remote_config,
+                filter_null_values(config),
+                MUTABLE_CONFIG_FIELDS,
+                self.register_action,
+            )
             self._sync_config_nodes(remote_config, config.get("nodes"))
             result_configs.append(remote_config)
 
@@ -664,8 +623,7 @@ class LinodeNodeBalancer(LinodeModuleBase):
     ) -> None:
         """
         Wait for the list endpoint to consistently show the expected config
-        count. Requires consecutive matching polls — the list is eventually
-        consistent across API nodes, so a single match can be transient.
+        count. Workaround for API propagation behavior
         """
         successful_requests = 0
 
@@ -695,16 +653,14 @@ class LinodeNodeBalancer(LinodeModuleBase):
         to_delete = remote_configs
 
         for config in new_configs:
-            exists, remote_config = self._check_config_exists(
-                remote_configs, config
-            )
+            match = self._find_port_conflict(to_delete, config)
 
-            if not exists or config.get("recreate"):
-                to_create.append(config)
+            if match is not None and not config.get("recreate"):
+                to_update.append((config, match))
+                to_delete.remove(match)
                 continue
 
-            to_update.append((config, remote_config))
-            to_delete.remove(remote_config)
+            to_create.append(config)
 
         return to_create, to_update, to_delete
 

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -20,6 +20,7 @@ from ansible_collections.linode.cloud.plugins.module_utils.linode_helper import 
     dict_select_matching,
     filter_null_values,
     handle_updates,
+    poll_condition,
 )
 from ansible_specdoc.objects import (
     FieldType,
@@ -32,6 +33,7 @@ from linode_api4 import (
     NodeBalancer,
     NodeBalancerConfig,
     NodeBalancerNode,
+    ApiError,
 )
 
 linode_nodes_spec = {
@@ -413,17 +415,54 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
     def _create_config(
         self, node_balancer: NodeBalancer, config_params: dict
-    ) -> Optional[NodeBalancerConfig]:
-        """Creates a config with the given kwargs within the given NodeBalancer"""
+    ) -> tuple[Optional[NodeBalancerConfig], bool]:
+        """
+        Creates a config with the given kwargs within the given NodeBalancer.
+
+        Retries config_create(...) on 400s while a conflicting config's
+        deletion is still propagating.
+        """
+
+        result: Optional[NodeBalancerConfig] = None
+        changed = False
+
+        def _attempt() -> bool:
+            nonlocal result, changed
+
+            try:
+                result = node_balancer.config_create(**config_params)
+                changed = True
+                return True
+            except ApiError as err:
+                if err.status != 400 or "already using port" not in str(err):
+                    # This is a real error
+                    raise
+
+                node_balancer.invalidate()
+                exists, remote = self._check_config_exists(
+                    node_balancer.configs, config_params
+                )
+
+                if exists:
+                    # Config already exists so we can reuse it
+                    result = remote
+                    changed = False
+
+                    return True
+
+            # Config doesn't exist, keep polling for propagation
+            return False
 
         try:
-            return node_balancer.config_create(**config_params)
+            poll_condition(_attempt, step=2, timeout=120)
         except Exception as exception:
-            return self.fail(
+            self.fail(
                 msg="failed to create nodebalancer config: {0}".format(
                     exception
                 )
             )
+
+        return result, changed
 
     def _create_node(
         self, config: NodeBalancerConfig, node_params: dict
@@ -441,13 +480,14 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
     def _create_config_register(
         self, node_balancer: NodeBalancer, config_params: dict
-    ) -> NodeBalancerConfig:
+    ) -> Tuple[NodeBalancerConfig, bool]:
         """Registers a create action for the given config"""
 
-        config = self._create_config(node_balancer, config_params)
-        self.register_action("Created config: {0}".format(config.id))
+        config, created = self._create_config(node_balancer, config_params)
+        if created:
+            self.register_action("Created config: {0}".format(config.id))
 
-        return config
+        return config, created
 
     def _delete_config_register(self, config: NodeBalancerConfig) -> None:
         """Registers a delete action for the given config"""
@@ -502,6 +542,19 @@ class LinodeNodeBalancer(LinodeModuleBase):
         for node in node_map.values():
             self._delete_node_register(node)
 
+        # Wait for nodes to propagate
+        expected_node_count = len(new_nodes)
+
+        def _nodes_synced():
+            if hasattr(config, "_nodes"):
+                # In the future we should fix the invalidation behavior in the Python SDK,
+                # but this works as a workaround
+                object.__delattr__(config, "_nodes")
+
+            return len(config.nodes) == expected_node_count
+
+        poll_condition(_nodes_synced, step=2, timeout=120)
+
     @staticmethod
     def _check_config_exists(
         target: Set[NodeBalancerConfig], config: dict
@@ -511,8 +564,8 @@ class LinodeNodeBalancer(LinodeModuleBase):
         tmp_config = copy.deepcopy(config)
 
         # These fields will return as <REDACTED> so we should not diff on them
-        tmp_config.pop("ssl_cert")
-        tmp_config.pop("ssl_key")
+        tmp_config.pop("ssl_cert", None)
+        tmp_config.pop("ssl_key", None)
 
         for remote_config in target:
             config_match, remote_config_match = dict_select_matching(
@@ -524,56 +577,87 @@ class LinodeNodeBalancer(LinodeModuleBase):
 
         return False, None
 
-    def _handle_configs(self) -> None:
+    def _handle_configs(self) -> list:
         """Updates the configs defined in new_configs under this NodeBalancer"""
 
         new_configs = self.module.params.get("configs") or []
-        remote_configs = set(self._node_balancer.configs)
+        if not new_configs:
+            return []
 
-        to_create = []
-        to_update = []
-        to_delete = remote_configs
+        to_create, to_update, to_delete = self._plan_configs(new_configs)
 
-        for config in new_configs:
-            config_exists, remote_config = self._check_config_exists(
-                remote_configs, config
-            )
-
-            if not config_exists:
-                to_create.append((config, remote_config))
-                continue
-
-            if config.get("recreate"):
-                to_create.append((config, remote_config))
-                continue
-
-            to_update.append((config, remote_config))
-            to_delete.remove(remote_config)
-
-        # Remove remaining configs
         for config in to_delete:
             self._delete_config_register(config)
 
         result_configs = []
 
-        for config, remote_config in to_create:
-            new_config = self._create_config_register(
+        for config in to_create:
+            new_config, _ = self._create_config_register(
                 self._node_balancer, config
             )
-            if config.get("nodes") is not None:
-                self._handle_config_nodes(new_config, config.get("nodes"))
-            new_config._api_get()
+            self._sync_config_nodes(new_config, config.get("nodes"))
             result_configs.append(new_config)
 
         for config, remote_config in to_update:
-            if config.get("nodes") is not None:
-                self._handle_config_nodes(remote_config, config.get("nodes"))
-            remote_config._api_get()
+            self._sync_config_nodes(remote_config, config.get("nodes"))
             result_configs.append(remote_config)
+
+        self._wait_for_configs_synced(len(new_configs))
 
         cast(list, self.results["configs"]).extend(
             [c._raw_json for c in result_configs]
         )
+
+        return result_configs
+
+    def _wait_for_configs_synced(self, n: int) -> None:
+        """Workaround for config deletion eventual consistency issue."""
+
+        nb = self._node_balancer
+
+        def _synced() -> bool:
+            nb.invalidate()
+            return len(nb.configs) == n
+
+        poll_condition(_synced, step=2, timeout=120)
+
+    def _plan_configs(self, new_configs: list[dict]) -> tuple[
+        list[dict],
+        list[tuple[dict, NodeBalancerConfig]],
+        set[NodeBalancerConfig],
+    ]:
+        """Partition desired configs into (create, update, delete) sets."""
+
+        remote_configs = set(self._node_balancer.configs)
+        to_create: list[dict] = []
+        to_update: list[tuple[dict, NodeBalancerConfig]] = []
+        to_delete = remote_configs
+
+        for config in new_configs:
+            exists, remote_config = self._check_config_exists(
+                remote_configs, config
+            )
+
+            if not exists or config.get("recreate"):
+                to_create.append(config)
+                continue
+
+            to_update.append((config, remote_config))
+            to_delete.remove(remote_config)
+
+        return to_create, to_update, to_delete
+
+    def _sync_config_nodes(
+        self,
+        config: Optional[NodeBalancerConfig],
+        nodes: Optional[List[dict]],
+    ) -> None:
+        """Sync nodes against the given config if provided."""
+
+        if nodes is not None:
+            self._handle_config_nodes(config, nodes)
+
+        config._api_get()
 
     def _update_nodebalancer(self) -> None:
         """Handles updating the current NodeBalancer"""
@@ -640,10 +724,10 @@ class LinodeNodeBalancer(LinodeModuleBase):
             return self.results
 
         self._handle_nodebalancer()
-        self._handle_configs()
+        result_configs = self._handle_configs()
 
         # Append all nodes to the result
-        for config in self._node_balancer.configs:
+        for config in result_configs or self._node_balancer.configs:
             for node in config.nodes:
                 node._api_get()
                 cast(list, self.results["nodes"]).append(node._raw_json)

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -3,7 +3,7 @@
     - set_fact:
         r: "{{ 1000000000 | random }}"
 
-    # Create node instances
+    # Create node instances in parallel
     - name: Create node1
       linode.cloud.instance:
         label: 'ansible-test-node1-{{ r }}'
@@ -12,15 +12,12 @@
         image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
+        booted: false
         state: present
         firewall_id: '{{ firewall_id }}'
-      register: node1_inst
-
-    - name: Assert node1 is created
-      assert:
-        that:
-          - node1_inst.changed
-          - node1_inst.instance.ipv4|length > 1
+      register: node1_job
+      async: 600
+      poll: 0
 
     - name: Create node2
       linode.cloud.instance:
@@ -30,15 +27,11 @@
         image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
+        booted: false
         state: present
-
-      register: node2_inst
-
-    - name: Assert node2 is created
-      assert:
-        that:
-          - node2_inst.changed
-          - node2_inst.instance.ipv4|length > 1
+      register: node2_job
+      async: 600
+      poll: 0
 
     - name: Create node3
       linode.cloud.instance:
@@ -48,13 +41,36 @@
         image: linode/ubuntu22.04
         root_pass: Fn$$oobar123
         private_ip: true
+        booted: false
         state: present
+      register: node3_job
+      async: 600
+      poll: 0
 
-      register: node3_inst
+    - name: Wait for all node instances to be created
+      async_status:
+        jid: '{{ item }}'
+      loop:
+        - '{{ node1_job.ansible_job_id }}'
+        - '{{ node2_job.ansible_job_id }}'
+        - '{{ node3_job.ansible_job_id }}'
+      register: node_jobs
+      until: node_jobs.finished
+      retries: 60
+      delay: 10
 
-    - name: Assert node3 is created
+    - set_fact:
+        node1_inst: '{{ node_jobs.results[0] }}'
+        node2_inst: '{{ node_jobs.results[1] }}'
+        node3_inst: '{{ node_jobs.results[2] }}'
+
+    - name: Assert node instances are created
       assert:
         that:
+          - node1_inst.changed
+          - node1_inst.instance.ipv4|length > 1
+          - node2_inst.changed
+          - node2_inst.instance.ipv4|length > 1
           - node3_inst.changed
           - node3_inst.instance.ipv4|length > 1
 
@@ -217,15 +233,20 @@
 
       register: add_config
 
+    - name: Ensure order is safe for comparison
+      set_fact:
+        add_config_nodes_sorted: "{{ add_config.nodes | sort(attribute='id') }}"
+        add_config_configs_sorted: "{{ add_config.configs | sort(attribute='id') }}"
+
     - name: Assert Config was added
       assert:
         that:
           - add_config.changed
           - add_config.configs|length == 2
           - add_config.nodes|length == 3
-          - add_config.nodes[0].config_id == add_config.configs[0].id
-          - add_config.nodes[1].config_id == add_config.configs[0].id
-          - add_config.nodes[2].config_id == add_config.configs[1].id
+          - add_config_nodes_sorted[0].config_id == add_config_configs_sorted[0].id
+          - add_config_nodes_sorted[1].config_id == add_config_configs_sorted[0].id
+          - add_config_nodes_sorted[2].config_id == add_config_configs_sorted[1].id
 
     - name: Remove a config from the NodeBalancer
       linode.cloud.nodebalancer:

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -61,9 +61,9 @@
       delay: 10
 
     - set_fact:
-        node1_inst: '{{ node_jobs.results[0] }}'
-        node2_inst: '{{ node_jobs.results[1] }}'
-        node3_inst: '{{ node_jobs.results[2] }}'
+        node1_inst: '{{ node_jobs.results[0].result }}'
+        node2_inst: '{{ node_jobs.results[1].result }}'
+        node3_inst: '{{ node_jobs.results[2].result }}'
 
     - name: Assert node instances are created
       assert:

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -55,15 +55,14 @@
         - '{{ node2_job.ansible_job_id }}'
         - '{{ node3_job.ansible_job_id }}'
       register: node_jobs
-      until: node_jobs.results is defined and
-             (node_jobs.results | map(attribute='finished') | select('equalto', true) | list | length) == (node_jobs.results | length)
+      until: node_jobs.finished
       retries: 60
       delay: 10
 
     - set_fact:
-        node1_inst: '{{ node_jobs.results[0].result }}'
-        node2_inst: '{{ node_jobs.results[1].result }}'
-        node3_inst: '{{ node_jobs.results[2].result }}'
+        node1_inst: '{{ node_jobs.results[0] }}'
+        node2_inst: '{{ node_jobs.results[1] }}'
+        node3_inst: '{{ node_jobs.results[2] }}'
 
     - name: Assert node instances are created
       assert:

--- a/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
+++ b/tests/integration/targets/nodebalancer_populated/tasks/main.yaml
@@ -55,7 +55,8 @@
         - '{{ node2_job.ansible_job_id }}'
         - '{{ node3_job.ansible_job_id }}'
       register: node_jobs
-      until: node_jobs.finished
+      until: node_jobs.results is defined and
+             (node_jobs.results | map(attribute='finished') | select('equalto', true) | list | length) == (node_jobs.results | length)
       retries: 60
       delay: 10
 


### PR DESCRIPTION
## 📝 Description

This pull request introduces retry and sync logic to account for the the propagation of NodeBalancer configs and nodes that occurs asynchronously on the backend.

This change also parallelizes the node instance creations in the `nodebalancer_populated` test to allow for quicker iteration.

## ✔️ How to Test

```
make test-int TEST_ARGS="-v $(ls tests/integration/targets/ | grep -i nodebalancer | tr '\n' ' ' )"
```