### PR TITLE
TPT-4111: Add info and list modules for regions vpc availability endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Name | Description |
 [linode.cloud.placement_group_info](./docs/modules/placement_group_info.md)|Get info about a Linode Placement Group.|
 [linode.cloud.profile_info](./docs/modules/profile_info.md)|Get info about a Linode Profile.|
 [linode.cloud.region_info](./docs/modules/region_info.md)|Get info about a Linode Region.|
+[linode.cloud.region_vpc_availability_info](./docs/modules/region_vpc_availability_info.md)|Get info about a Linode Region VPC Availability.|
 [linode.cloud.ssh_key_info](./docs/modules/ssh_key_info.md)|Get info about a Linode SSH Key.|
 [linode.cloud.stackscript_info](./docs/modules/stackscript_info.md)|Get info about a Linode StackScript.|
 [linode.cloud.token_info](./docs/modules/token_info.md)|Get info about a Linode Personal Access Token.|

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Name | Description |
 [linode.cloud.object_storage_quota_list](./docs/modules/object_storage_quota_list.md)|List and filter on Object Storage Quotas.|
 [linode.cloud.placement_group_list](./docs/modules/placement_group_list.md)|List and filter on Placement Groups.|
 [linode.cloud.region_list](./docs/modules/region_list.md)|List and filter on Regions.|
+[linode.cloud.regions_vpc_availability_list](./docs/modules/regions_vpc_availability_list.md)|List and filter on Regions VPC Availability.|
 [linode.cloud.ssh_key_list](./docs/modules/ssh_key_list.md)|List and filter on SSH Keys.|
 [linode.cloud.stackscript_list](./docs/modules/stackscript_list.md)|List and filter on StackScripts.|
 [linode.cloud.token_list](./docs/modules/token_list.md)|List and filter on Tokens.|

--- a/docs/modules/region_vpc_availability_info.md
+++ b/docs/modules/region_vpc_availability_info.md
@@ -1,0 +1,49 @@
+# region_vpc_availability_info
+
+Get info about a Linode Region VPC Availability.
+
+WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get Info of a Linode Region VPC Availability
+  linode.cloud.region_vpc_availability_info:
+    id: us-mia
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `id` | <center>`str`</center> | <center>**Required**</center> | The ID of the Region VPC Availability to resolve.   |
+
+## Return Values
+
+- `region_vpc_availability` - The returned Region VPC Availability.
+
+    - Sample Response:
+        ```json
+        {
+            "region": "us-mia",
+            "available": true,
+            "available_ipv6_prefix_lengths": [
+                48,
+                52
+            ]
+        }
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-region-vpc-availability) for a list of returned fields
+
+

--- a/docs/modules/region_vpc_availability_info.md
+++ b/docs/modules/region_vpc_availability_info.md
@@ -19,6 +19,7 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 ```yaml
 - name: Get Info of a Linode Region VPC Availability
   linode.cloud.region_vpc_availability_info:
+    api_version: v4beta
     id: us-mia
 ```
 

--- a/docs/modules/regions_vpc_availability_list.md
+++ b/docs/modules/regions_vpc_availability_list.md
@@ -18,7 +18,8 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 
 ```yaml
 - name: List all of the Linode regions VPC availability
-  linode.cloud.regions_vpc_availability_list: {}
+  linode.cloud.regions_vpc_availability_list:
+    api_version: v4beta
 ```
 
 

--- a/docs/modules/regions_vpc_availability_list.md
+++ b/docs/modules/regions_vpc_availability_list.md
@@ -35,7 +35,7 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 
 | Field     | Type | Required | Description                                                                  |
 |-----------|------|----------|------------------------------------------------------------------------------|
-| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](TODO).   |
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](https://techdocs.akamai.com/linode-api/reference/get-regions-vpc-availability).   |
 | `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
@@ -71,6 +71,6 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
             }
         ]
         ```
-    - See the [Linode API response documentation](TODO) for a list of returned fields
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-regions-vpc-availability) for a list of returned fields
 
 

--- a/docs/modules/regions_vpc_availability_list.md
+++ b/docs/modules/regions_vpc_availability_list.md
@@ -1,0 +1,76 @@
+# regions_vpc_availability_list
+
+List and filter on Regions VPC Availability.
+
+WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all of the Linode regions VPC availability
+  linode.cloud.regions_vpc_availability_list: {}
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Regions VPC Availability in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Regions VPC Availability by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Regions VPC Availability.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Regions VPC Availability to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](TODO).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
+
+## Return Values
+
+- `regions_vpc_availability` - The returned Regions VPC Availability.
+
+    - Sample Response:
+        ```json
+        [
+            {
+                "region": "nl-ams",
+                "available": true,
+                "available_ipv6_prefix_lengths": [
+                    48,
+                    52
+                ]
+            },
+            {
+                "region": "fr-par-2",
+                "available": true,
+                "available_ipv6_prefix_lengths": [
+                    48,
+                    52
+                ]
+            },
+            {
+                "region": "jp-tyo-3",
+                "available": true,
+                "available_ipv6_prefix_lengths": [
+                    48,
+                    52
+                ]
+            }
+        ]
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/plugins/module_utils/doc_fragments/region_vpc_availability_info.py
+++ b/plugins/module_utils/doc_fragments/region_vpc_availability_info.py
@@ -3,6 +3,7 @@
 specdoc_examples = ['''
 - name: Get Info of a Linode Region VPC Availability
   linode.cloud.region_vpc_availability_info:
+    api_version: v4beta
     id: us-mia''']
 
 result_region_vpc_availability_samples = ['''{

--- a/plugins/module_utils/doc_fragments/region_vpc_availability_info.py
+++ b/plugins/module_utils/doc_fragments/region_vpc_availability_info.py
@@ -1,0 +1,15 @@
+"""Documentation fragments for the region_vpc_availability_info module"""
+
+specdoc_examples = ['''
+- name: Get Info of a Linode Region VPC Availability
+  linode.cloud.region_vpc_availability_info:
+    id: us-mia''']
+
+result_region_vpc_availability_samples = ['''{
+    "region": "us-mia",
+    "available": true,
+    "available_ipv6_prefix_lengths": [
+        48,
+        52
+    ]
+}''']

--- a/plugins/module_utils/doc_fragments/regions_vpc_availability_list.py
+++ b/plugins/module_utils/doc_fragments/regions_vpc_availability_list.py
@@ -2,7 +2,8 @@
 
 specdoc_examples = ['''
 - name: List all of the Linode regions VPC availability
-  linode.cloud.regions_vpc_availability_list: {}''']
+  linode.cloud.regions_vpc_availability_list:
+    api_version: v4beta''']
 
 result_regions_vpc_availability_samples = ['''[
     {

--- a/plugins/module_utils/doc_fragments/regions_vpc_availability_list.py
+++ b/plugins/module_utils/doc_fragments/regions_vpc_availability_list.py
@@ -1,0 +1,32 @@
+"""Documentation fragments for the regions_vpc_availability_list module"""
+
+specdoc_examples = ['''
+- name: List all of the Linode regions VPC availability
+  linode.cloud.regions_vpc_availability_list: {}''']
+
+result_regions_vpc_availability_samples = ['''[
+    {
+        "region": "nl-ams",
+        "available": true,
+        "available_ipv6_prefix_lengths": [
+            48,
+            52
+        ]
+    },
+    {
+        "region": "fr-par-2",
+        "available": true,
+        "available_ipv6_prefix_lengths": [
+            48,
+            52
+        ]
+    },
+    {
+        "region": "jp-tyo-3",
+        "available": true,
+        "available_ipv6_prefix_lengths": [
+            48,
+            52
+        ]
+    }
+]''']

--- a/plugins/modules/region_vpc_availability_info.py
+++ b/plugins/modules/region_vpc_availability_info.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to retrieve information about a Linode Region VPC Availability."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    region_vpc_availability_info as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleAttr,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+from linode_api4 import Region
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="Region VPC Availability",
+        field_name="region_vpc_availability",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-region-vpc-availability",
+        samples=docs.result_region_vpc_availability_samples,
+    ),
+    attributes=[
+        InfoModuleAttr(
+            name="id",
+            display_name="ID",
+            type=FieldType.string,
+            get=lambda client, params: client.load(
+                Region, params.get("id")
+            ).vpc_availability.dict,
+        ),
+    ],
+    requires_beta=True,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/regions_vpc_availability_list.py
+++ b/plugins/modules/regions_vpc_availability_list.py
@@ -5,7 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.regions_vpc_availability_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    regions_vpc_availability_list as docs,
+)
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
     ListModule,
 )
@@ -14,7 +16,7 @@ module = ListModule(
     result_display_name="Regions VPC Availability",
     result_field_name="regions_vpc_availability",
     endpoint_template="/regions/vpc-availability",
-    result_docs_url="TODO",
+    result_docs_url="https://techdocs.akamai.com/linode-api/reference/get-regions-vpc-availability",
     requires_beta=True,
     examples=docs.specdoc_examples,
     result_samples=docs.result_regions_vpc_availability_samples,

--- a/plugins/modules/regions_vpc_availability_list.py
+++ b/plugins/modules/regions_vpc_availability_list.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list Linode regions VPC availability."""
+
+from __future__ import absolute_import, division, print_function
+
+import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.regions_vpc_availability_list as docs
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+)
+
+module = ListModule(
+    result_display_name="Regions VPC Availability",
+    result_field_name="regions_vpc_availability",
+    endpoint_template="/regions/vpc-availability",
+    result_docs_url="TODO",
+    requires_beta=True,
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_regions_vpc_availability_samples,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/tests/integration/targets/region_vpc_availability_info/tasks/main.yaml
+++ b/tests/integration/targets/region_vpc_availability_info/tasks/main.yaml
@@ -1,0 +1,20 @@
+- name: region_vpc_availability_info
+  block:
+    - name: Get Info of a Linode Region VPC Availability
+      linode.cloud.region_vpc_availability_info:
+        id: us-mia
+      register: result
+
+    - name: Assert region_vpc_availability_info
+      assert:
+        that:
+          - result.region_vpc_availability.region == 'us-mia'
+          - result.region_vpc_availability.available == true
+          - result.region_vpc_availability.available_ipv6_prefix_lengths == [48, 52]
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/regions_vpc_availability_list/tasks/main.yaml
+++ b/tests/integration/targets/regions_vpc_availability_list/tasks/main.yaml
@@ -1,0 +1,17 @@
+- name: regions_vpc_availability_list
+  block:
+    - name: List regions VPC availability
+      linode.cloud.regions_vpc_availability_list:
+      register: result
+
+    - name: Assert regions_vpc_availability_list
+      assert:
+        that:
+          - result.regions_vpc_availability | length >= 0
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

This PR add two modules:
* `regions_vpc_availability_list` - lists regions VPC availability info.
* `region_vpc_availability_info` - fetches info about a single region VPC availability.

## ✔️ How to Test

```
make TEST_SUITE="regions_vpc_availability_list" test-int
```

```
make TEST_SUITE="region_vpc_availability_info" test-int
```
