### PR TITLE
TPT-4303: Support alert definition entities and update new fields for creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Name | Description |
 [linode.cloud.lock_list](./docs/modules/lock_list.md)|List and filter on Locks.|
 [linode.cloud.maintenance_policy_list](./docs/modules/maintenance_policy_list.md)|List and filter on Maintenance Policies.|
 [linode.cloud.monitor_alert_channel_list](./docs/modules/monitor_alert_channel_list.md)|List and filter on Alert Channels.|
+[linode.cloud.monitor_alert_definition_entities_list](./docs/modules/monitor_alert_definition_entities_list.md)|List and filter on Alert Definition Entities.|
 [linode.cloud.monitor_services_alert_definition_by_service_type_list](./docs/modules/monitor_services_alert_definition_by_service_type_list.md)|The return alert definitions by service type. **Note: filters and order are currently NOT supported by this endpoint.|
 [linode.cloud.monitor_services_alert_definition_list](./docs/modules/monitor_services_alert_definition_list.md)|List and filter on Alert Definitions.|
 [linode.cloud.network_transfer_prices_list](./docs/modules/network_transfer_prices_list.md)|List and filter on Network Transfer Prices.|

--- a/docs/modules/monitor_alert_definition_entities_list.md
+++ b/docs/modules/monitor_alert_definition_entities_list.md
@@ -31,7 +31,17 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `service_type` | <center>`str`</center> | <center>**Required**</center> | The parent Service Type for the Alert Definition Entities.   |
 | `id` | <center>`int`</center> | <center>**Required**</center> | The parent Alert Definition for the Alert Definition Entities.   |
+| `order` | <center>`str`</center> | <center>Optional</center> | The order to list Alert Definition Entities in.  **(Choices: `desc`, `asc`; Default: `asc`)** |
+| `order_by` | <center>`str`</center> | <center>Optional</center> | The attribute to order Alert Definition Entities by.   |
+| [`filters` (sub-options)](#filters) | <center>`list`</center> | <center>Optional</center> | A list of filters to apply to the resulting Alert Definition Entities.   |
 | `count` | <center>`int`</center> | <center>Optional</center> | The number of Alert Definition Entities to return. If undefined, all results will be returned.   |
+
+### filters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `name` | <center>`str`</center> | <center>**Required**</center> | The name of the field to filter on. Valid filterable fields can be found [here](TODO).   |
+| `values` | <center>`list`</center> | <center>**Required**</center> | A list of values to allow for this field. Fields will pass this filter if at least one of these values matches.   |
 
 ## Return Values
 

--- a/docs/modules/monitor_alert_definition_entities_list.md
+++ b/docs/modules/monitor_alert_definition_entities_list.md
@@ -1,0 +1,66 @@
+# monitor_alert_definition_entities_list
+
+List and filter on Alert Definition Entities.
+
+WARNING! This module makes use of beta endpoints and requires the C(api_version) field be explicitly set to C(v4beta).
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: List all entities for a specific alert definition
+  linode.cloud.monitor_alert_definition_entities_list:
+    service_type: dbaas
+    id: 12345
+    api_version: v4beta
+```
+
+
+## Parameters
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `service_type` | <center>`str`</center> | <center>**Required**</center> | The parent Service Type for the Alert Definition Entities.   |
+| `id` | <center>`int`</center> | <center>**Required**</center> | The parent Alert Definition for the Alert Definition Entities.   |
+| `count` | <center>`int`</center> | <center>Optional</center> | The number of Alert Definition Entities to return. If undefined, all results will be returned.   |
+
+## Return Values
+
+- `alert_definition_entities` - The returned Alert Definition Entities.
+
+    - Sample Response:
+        ```json
+        [
+            {
+              "id": "1",
+              "label": "mydatabase-1",
+              "url": "/v4/databases/mysql/instances/1",
+              "type": "dbaas"
+            },
+            {
+              "id": "2",
+              "label": "mydatabase-2",
+              "url": "/v4/databases/mysql/instances/2",
+              "type": "dbaas"
+            },
+            {
+              "id": "3",
+              "label": "mydatabase-3",
+              "url": "/v4/databases/mysql/instances/3",
+              "type": "dbaas"
+            }
+          ]
+        
+        ```
+    - See the [Linode API response documentation](TODO) for a list of returned fields
+
+

--- a/docs/modules/monitor_services_alert_definition.md
+++ b/docs/modules/monitor_services_alert_definition.md
@@ -67,6 +67,8 @@ Manage an alert definition for a specific service type. Akamai refers to these a
 | `description` | <center>`str`</center> | <center>Optional</center> | An additional description for the alert definition.  **(Updatable)** |
 | `entity_ids` | <center>`list`</center> | <center>Optional</center> | The id for each individual entity from a service_type. Get this value by running the list operation for the appropriate entity. For example, if your entity is one of your PostgreSQL databases, run the List PostgreSQL Managed Databases operation and store the id for the appropriate database from the response. You also need read_only access to the scope for the service_type for each of the entity_ids.  **(Updatable)** |
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique identifier assigned to the alert definition. Run the List alert definitions operation and store the id for the applicable alert definition. Required for updating.   |
+| `scope` | <center>`str`</center> | <center>Optional</center> | The alert scope. Supported values include account, entity, and region. Defaults to entity.  **(Choices: `account`, `entity`, `region`)** |
+| `regions` | <center>`list`</center> | <center>Optional</center> | The regions to monitor for this alert definition.  **(Updatable)** |
 | `status` | <center>`str`</center> | <center>Optional</center> | The current status of the alert.  **(Choices: `enabled`, `disabled`; Updatable)** |
 | `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the alert definition ready (not in progress).  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for the alert definition.  **(Default: `600`)** |
@@ -111,30 +113,27 @@ Manage an alert definition for a specific service type. Akamai refers to these a
     - Sample Response:
         ```json
         {
+          "id": 12345,
+          "label": "Test Alert for DBAAS",
+          "service_type": "dbaas",
+          "severity": 1,
+          "type": "user",
+          "description": "A test alert for dbaas service",
+          "scope": "entity",
+          "regions": [],
+          "entities": {
+            "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+            "count": 1,
+            "has_more_resources": false
+          },
           "alert_channels": [
             {
               "id": 10000,
               "label": "Read-Write Channel",
-              "type": "alert-channels",
+              "type": "email",
               "url": "/monitor/alert-channels/10000"
             }
           ],
-          "class": "dedicated",
-          "created": "2025-03-20T01:42:11",
-          "created_by": "system",
-          "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-          "entity_ids": [
-            "126905",
-            "126906",
-            "137435",
-            "141496",
-            "190003",
-            "257625",
-            "257626"
-          ],
-          "has_more_resources": false,
-          "id": 10000,
-          "label": "High Memory Usage Plan Dedicated",
           "rule_criteria": {
             "rules": [
               {
@@ -147,26 +146,25 @@ Manage an alert definition for a specific service type. Akamai refers to these a
                     "value": "primary"
                   }
                 ],
-                "label": "Memory Usage",
-                "metric": "memory_usage",
+                "label": "High CPU Usage",
+                "metric": "cpu_usage",
                 "operator": "gt",
-                "threshold": 95,
+                "threshold": 90,
                 "unit": "percent"
               }
             ]
           },
-          "service_type": "dbaas",
-          "severity": 2,
-          "status": "enabled",
           "trigger_conditions": {
             "criteria_condition": "ALL",
             "evaluation_period_seconds": 300,
-            "polling_interval_seconds": 300,
+            "polling_interval_seconds": 60,
             "trigger_occurrences": 3
           },
-          "type": "system",
-          "updated": "2025-03-20T01:42:11",
-          "updated_by": "system"
+          "class": "alert",
+          "status": "active",
+          "created": "2024-01-01T00:00:00",
+          "updated": "2024-01-01T00:00:00",
+          "updated_by": "tester"
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-alert-definition) for a list of returned fields

--- a/docs/modules/monitor_services_alert_definition_by_service_type_list.md
+++ b/docs/modules/monitor_services_alert_definition_by_service_type_list.md
@@ -39,120 +39,58 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
         ```json
         [
             {
-              "alert_channels": [
-                {
-                  "id": 10000,
-                  "label": "Read-Write Channel",
-                  "type": "alert-channels",
-                  "url": "/monitor/alert-channels/10000"
-                }
-              ],
-              "class": "dedicated",
-              "created": "2025-03-20T01:42:11",
-              "created_by": "system",
-              "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-              "entity_ids": [
-                "126905",
-                "126906",
-                "137435",
-                "141496",
-                "190003",
-                "257625",
-                "257626"
-              ],
-              "has_more_resources": false,
-              "id": 10000,
-              "label": "High Memory Usage Plan Dedicated",
-              "rule_criteria": {
-                "rules": [
-                  {
-                    "aggregate_function": "avg",
-                    "dimension_filters": [
-                      {
-                        "dimension_label": "node_type",
-                        "label": "Node Type",
-                        "operator": "eq",
-                        "value": "primary"
-                      }
-                    ],
-                    "label": "Memory Usage",
-                    "metric": "memory_usage",
-                    "operator": "gt",
-                    "threshold": 95,
-                    "unit": "percent"
-                  }
-                ]
-              },
+              "id": 12345,
+              "label": "Test Alert for DBAAS",
               "service_type": "dbaas",
-              "severity": 2,
-              "status": "enabled",
-              "trigger_conditions": {
-                "criteria_condition": "ALL",
-                "evaluation_period_seconds": 300,
-                "polling_interval_seconds": 300,
-                "trigger_occurrences": 3
-              },
-              "type": "system",
-              "updated": "2025-03-20T01:42:11",
-              "updated_by": "system"
-            },
-            {
-              "alert_channels": [
-                {
-                  "id": 10000,
-                  "label": "Read-Write Channel",
-                  "type": "alert-channels",
-                  "url": "/monitor/alert-channels/10000"
-                }
-              ],
-              "class": null,
-              "created": "2025-03-20T02:15:18",
-              "created_by": "John Q. Linode",
-              "description": "Custom alert set up for high memory usage for shared plan nodes.",
-              "entity_ids": [
-                "126907",
-                "126908",
-                "137436",
-                "141497",
-                "190004",
-                "257627",
-                "257628"
-              ],
-              "has_more_resources": false,
-              "id": 10001,
-              "label": "High Memory Usage Plan Shared",
-              "rule_criteria": {
-                "rules": [
-                  {
-                    "aggregate_function": "avg",
-                    "dimension_filters": [
-                      {
-                        "dimension_label": "node_type",
-                        "label": "Node Type",
-                        "operator": "eq",
-                        "value": "primary"
-                      }
-                    ],
-                    "label": "Memory Usage",
-                    "metric": "memory_usage",
-                    "operator": "gt",
-                    "threshold": 95,
-                    "unit": "percent"
-                  }
-                ]
-              },
-              "service_type": "dbaas",
-              "severity": 2,
-              "status": "enabled",
-              "trigger_conditions": {
-                "criteria_condition": "ALL",
-                "evaluation_period_seconds": 300,
-                "polling_interval_seconds": 300,
-                "trigger_occurrences": 3
-              },
+              "severity": 1,
               "type": "user",
-              "updated": "2025-03-20T02:15:18",
-              "updated_by": "John Q. Linode"
+              "description": "A test alert for dbaas service",
+              "scope": "entity",
+              "regions": [],
+              "entities": {
+                "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+                "count": 1,
+                "has_more_resources": false
+              },
+              "alert_channels": [
+                {
+                  "id": 10000,
+                  "label": "Read-Write Channel",
+                  "type": "email",
+                  "url": "/monitor/alert-channels/10000"
+                }
+              ],
+              "rule_criteria": {
+                "rules": [
+                  {
+                    "aggregate_function": "avg",
+                    "dimension_filters": [
+                      {
+                        "dimension_label": "node_type",
+                        "label": "Node Type",
+                        "operator": "eq",
+                        "value": "primary"
+                      }
+                    ],
+                    "label": "High CPU Usage",
+                    "metric": "cpu_usage",
+                    "operator": "gt",
+                    "threshold": 90,
+                    "unit": "percent"
+                  }
+                ]
+              },
+              "trigger_conditions": {
+                "criteria_condition": "ALL",
+                "evaluation_period_seconds": 300,
+                "polling_interval_seconds": 60,
+                "trigger_occurrences": 3
+              },
+              "class": "alert",
+              "status": "active",
+              "created": "2024-01-01T00:00:00",
+              "updated": "2024-01-01T00:00:00",
+              "updated_by": "tester"
             }
           ]
         

--- a/docs/modules/monitor_services_alert_definition_info.md
+++ b/docs/modules/monitor_services_alert_definition_info.md
@@ -36,30 +36,27 @@ Get info about a Linode Alert Definition.
     - Sample Response:
         ```json
         {
+          "id": 12345,
+          "label": "Test Alert for DBAAS",
+          "service_type": "dbaas",
+          "severity": 1,
+          "type": "user",
+          "description": "A test alert for dbaas service",
+          "scope": "entity",
+          "regions": [],
+          "entities": {
+            "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+            "count": 1,
+            "has_more_resources": false
+          },
           "alert_channels": [
             {
               "id": 10000,
               "label": "Read-Write Channel",
-              "type": "alert-channels",
+              "type": "email",
               "url": "/monitor/alert-channels/10000"
             }
           ],
-          "class": "dedicated",
-          "created": "2025-03-20T01:42:11",
-          "created_by": "system",
-          "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-          "entity_ids": [
-            "126905",
-            "126906",
-            "137435",
-            "141496",
-            "190003",
-            "257625",
-            "257626"
-          ],
-          "has_more_resources": false,
-          "id": 10000,
-          "label": "High Memory Usage Plan Dedicated",
           "rule_criteria": {
             "rules": [
               {
@@ -72,26 +69,25 @@ Get info about a Linode Alert Definition.
                     "value": "primary"
                   }
                 ],
-                "label": "Memory Usage",
-                "metric": "memory_usage",
+                "label": "High CPU Usage",
+                "metric": "cpu_usage",
                 "operator": "gt",
-                "threshold": 95,
+                "threshold": 90,
                 "unit": "percent"
               }
             ]
           },
-          "service_type": "dbaas",
-          "severity": 2,
-          "status": "enabled",
           "trigger_conditions": {
             "criteria_condition": "ALL",
             "evaluation_period_seconds": 300,
-            "polling_interval_seconds": 300,
+            "polling_interval_seconds": 60,
             "trigger_occurrences": 3
           },
-          "type": "system",
-          "updated": "2025-03-20T01:42:11",
-          "updated_by": "system"
+          "class": "alert",
+          "status": "active",
+          "created": "2024-01-01T00:00:00",
+          "updated": "2024-01-01T00:00:00",
+          "updated_by": "tester"
         }
         ```
     - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-alert-definition) for a list of returned fields

--- a/docs/modules/monitor_services_alert_definition_list.md
+++ b/docs/modules/monitor_services_alert_definition_list.md
@@ -47,120 +47,58 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
         ```json
         [
             {
-              "alert_channels": [
-                {
-                  "id": 10000,
-                  "label": "Read-Write Channel",
-                  "type": "alert-channels",
-                  "url": "/monitor/alert-channels/10000"
-                }
-              ],
-              "class": "dedicated",
-              "created": "2025-03-20T01:42:11",
-              "created_by": "system",
-              "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-              "entity_ids": [
-                "126905",
-                "126906",
-                "137435",
-                "141496",
-                "190003",
-                "257625",
-                "257626"
-              ],
-              "has_more_resources": false,
-              "id": 10000,
-              "label": "High Memory Usage Plan Dedicated",
-              "rule_criteria": {
-                "rules": [
-                  {
-                    "aggregate_function": "avg",
-                    "dimension_filters": [
-                      {
-                        "dimension_label": "node_type",
-                        "label": "Node Type",
-                        "operator": "eq",
-                        "value": "primary"
-                      }
-                    ],
-                    "label": "Memory Usage",
-                    "metric": "memory_usage",
-                    "operator": "gt",
-                    "threshold": 95,
-                    "unit": "percent"
-                  }
-                ]
-              },
+              "id": 12345,
+              "label": "Test Alert for DBAAS",
               "service_type": "dbaas",
-              "severity": 2,
-              "status": "enabled",
-              "trigger_conditions": {
-                "criteria_condition": "ALL",
-                "evaluation_period_seconds": 300,
-                "polling_interval_seconds": 300,
-                "trigger_occurrences": 3
-              },
-              "type": "system",
-              "updated": "2025-03-20T01:42:11",
-              "updated_by": "system"
-            },
-            {
-              "alert_channels": [
-                {
-                  "id": 10000,
-                  "label": "Read-Write Channel",
-                  "type": "alert-channels",
-                  "url": "/monitor/alert-channels/10000"
-                }
-              ],
-              "class": null,
-              "created": "2025-03-20T02:15:18",
-              "created_by": "John Q. Linode",
-              "description": "Custom alert set up for high memory usage for shared plan nodes.",
-              "entity_ids": [
-                "126907",
-                "126908",
-                "137436",
-                "141497",
-                "190004",
-                "257627",
-                "257628"
-              ],
-              "has_more_resources": false,
-              "id": 10001,
-              "label": "High Memory Usage Plan Shared",
-              "rule_criteria": {
-                "rules": [
-                  {
-                    "aggregate_function": "avg",
-                    "dimension_filters": [
-                      {
-                        "dimension_label": "node_type",
-                        "label": "Node Type",
-                        "operator": "eq",
-                        "value": "primary"
-                      }
-                    ],
-                    "label": "Memory Usage",
-                    "metric": "memory_usage",
-                    "operator": "gt",
-                    "threshold": 95,
-                    "unit": "percent"
-                  }
-                ]
-              },
-              "service_type": "dbaas",
-              "severity": 2,
-              "status": "enabled",
-              "trigger_conditions": {
-                "criteria_condition": "ALL",
-                "evaluation_period_seconds": 300,
-                "polling_interval_seconds": 300,
-                "trigger_occurrences": 3
-              },
+              "severity": 1,
               "type": "user",
-              "updated": "2025-03-20T02:15:18",
-              "updated_by": "John Q. Linode"
+              "description": "A test alert for dbaas service",
+              "scope": "entity",
+              "regions": [],
+              "entities": {
+                "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+                "count": 1,
+                "has_more_resources": false
+              },
+              "alert_channels": [
+                {
+                  "id": 10000,
+                  "label": "Read-Write Channel",
+                  "type": "email",
+                  "url": "/monitor/alert-channels/10000"
+                }
+              ],
+              "rule_criteria": {
+                "rules": [
+                  {
+                    "aggregate_function": "avg",
+                    "dimension_filters": [
+                      {
+                        "dimension_label": "node_type",
+                        "label": "Node Type",
+                        "operator": "eq",
+                        "value": "primary"
+                      }
+                    ],
+                    "label": "High CPU Usage",
+                    "metric": "cpu_usage",
+                    "operator": "gt",
+                    "threshold": 90,
+                    "unit": "percent"
+                  }
+                ]
+              },
+              "trigger_conditions": {
+                "criteria_condition": "ALL",
+                "evaluation_period_seconds": 300,
+                "polling_interval_seconds": 60,
+                "trigger_occurrences": 3
+              },
+              "class": "alert",
+              "status": "active",
+              "created": "2024-01-01T00:00:00",
+              "updated": "2024-01-01T00:00:00",
+              "updated_by": "tester"
             }
           ]
         

--- a/plugins/module_utils/doc_fragments/alert_definition.py
+++ b/plugins/module_utils/doc_fragments/alert_definition.py
@@ -35,30 +35,27 @@ specdoc_examples = ['''
   register: delete''']
 
 result_aclp_alert_definition_sample = ['''{
+  "id": 12345,
+  "label": "Test Alert for DBAAS",
+  "service_type": "dbaas",
+  "severity": 1,
+  "type": "user",
+  "description": "A test alert for dbaas service",
+  "scope": "entity",
+  "regions": [],
+  "entities": {
+    "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+    "count": 1,
+    "has_more_resources": false
+  },
   "alert_channels": [
     {
       "id": 10000,
       "label": "Read-Write Channel",
-      "type": "alert-channels",
+      "type": "email",
       "url": "/monitor/alert-channels/10000"
     }
   ],
-  "class": "dedicated",
-  "created": "2025-03-20T01:42:11",
-  "created_by": "system",
-  "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-  "entity_ids": [
-    "126905",
-    "126906",
-    "137435",
-    "141496",
-    "190003",
-    "257625",
-    "257626"
-  ],
-  "has_more_resources": false,
-  "id": 10000,
-  "label": "High Memory Usage Plan Dedicated",
   "rule_criteria": {
     "rules": [
       {
@@ -71,24 +68,23 @@ result_aclp_alert_definition_sample = ['''{
             "value": "primary"
           }
         ],
-        "label": "Memory Usage",
-        "metric": "memory_usage",
+        "label": "High CPU Usage",
+        "metric": "cpu_usage",
         "operator": "gt",
-        "threshold": 95,
+        "threshold": 90,
         "unit": "percent"
       }
     ]
   },
-  "service_type": "dbaas",
-  "severity": 2,
-  "status": "enabled",
   "trigger_conditions": {
     "criteria_condition": "ALL",
     "evaluation_period_seconds": 300,
-    "polling_interval_seconds": 300,
+    "polling_interval_seconds": 60,
     "trigger_occurrences": 3
   },
-  "type": "system",
-  "updated": "2025-03-20T01:42:11",
-  "updated_by": "system"
+  "class": "alert",
+  "status": "active",
+  "created": "2024-01-01T00:00:00",
+  "updated": "2024-01-01T00:00:00",
+  "updated_by": "tester"
 }''']

--- a/plugins/module_utils/doc_fragments/alert_definition_entities_list.py
+++ b/plugins/module_utils/doc_fragments/alert_definition_entities_list.py
@@ -1,0 +1,30 @@
+"""Documentation fragments for the monitor_alert_definition_entities_list module"""
+
+specdoc_examples = ['''
+- name: List all entities for a specific alert definition
+  linode.cloud.monitor_alert_definition_entities_list:
+    service_type: dbaas
+    id: 12345
+    api_version: v4beta''']
+
+result_alert_definition_entities_samples = ['''[
+    {
+      "id": "1",
+      "label": "mydatabase-1",
+      "url": "/v4/databases/mysql/instances/1",
+      "type": "dbaas"
+    },
+    {
+      "id": "2",
+      "label": "mydatabase-2",
+      "url": "/v4/databases/mysql/instances/2",
+      "type": "dbaas"
+    },
+    {
+      "id": "3",
+      "label": "mydatabase-3",
+      "url": "/v4/databases/mysql/instances/3",
+      "type": "dbaas"
+    }
+  ]
+''']

--- a/plugins/module_utils/doc_fragments/alert_definition_info.py
+++ b/plugins/module_utils/doc_fragments/alert_definition_info.py
@@ -7,30 +7,27 @@ specdoc_examples = ['''
     api_version: v4beta''']
 
 result_alert_definition_samples = ['''{
+  "id": 12345,
+  "label": "Test Alert for DBAAS",
+  "service_type": "dbaas",
+  "severity": 1,
+  "type": "user",
+  "description": "A test alert for dbaas service",
+  "scope": "entity",
+  "regions": [],
+  "entities": {
+    "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+    "count": 1,
+    "has_more_resources": false
+  },
   "alert_channels": [
     {
       "id": 10000,
       "label": "Read-Write Channel",
-      "type": "alert-channels",
+      "type": "email",
       "url": "/monitor/alert-channels/10000"
     }
   ],
-  "class": "dedicated",
-  "created": "2025-03-20T01:42:11",
-  "created_by": "system",
-  "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-  "entity_ids": [
-    "126905",
-    "126906",
-    "137435",
-    "141496",
-    "190003",
-    "257625",
-    "257626"
-  ],
-  "has_more_resources": false,
-  "id": 10000,
-  "label": "High Memory Usage Plan Dedicated",
   "rule_criteria": {
     "rules": [
       {
@@ -43,24 +40,23 @@ result_alert_definition_samples = ['''{
             "value": "primary"
           }
         ],
-        "label": "Memory Usage",
-        "metric": "memory_usage",
+        "label": "High CPU Usage",
+        "metric": "cpu_usage",
         "operator": "gt",
-        "threshold": 95,
+        "threshold": 90,
         "unit": "percent"
       }
     ]
   },
-  "service_type": "dbaas",
-  "severity": 2,
-  "status": "enabled",
   "trigger_conditions": {
     "criteria_condition": "ALL",
     "evaluation_period_seconds": 300,
-    "polling_interval_seconds": 300,
+    "polling_interval_seconds": 60,
     "trigger_occurrences": 3
   },
-  "type": "system",
-  "updated": "2025-03-20T01:42:11",
-  "updated_by": "system"
+  "class": "alert",
+  "status": "active",
+  "created": "2024-01-01T00:00:00",
+  "updated": "2024-01-01T00:00:00",
+  "updated_by": "tester"
 }''']

--- a/plugins/module_utils/doc_fragments/alert_definitions_by_service_type_list.py
+++ b/plugins/module_utils/doc_fragments/alert_definitions_by_service_type_list.py
@@ -8,120 +8,58 @@ specdoc_examples = ['''
 
 result_alert_definitions_by_service_type_samples = ['''[
     {
-      "alert_channels": [
-        {
-          "id": 10000,
-          "label": "Read-Write Channel",
-          "type": "alert-channels",
-          "url": "/monitor/alert-channels/10000"
-        }
-      ],
-      "class": "dedicated",
-      "created": "2025-03-20T01:42:11",
-      "created_by": "system",
-      "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-      "entity_ids": [
-        "126905",
-        "126906",
-        "137435",
-        "141496",
-        "190003",
-        "257625",
-        "257626"
-      ],
-      "has_more_resources": false,
-      "id": 10000,
-      "label": "High Memory Usage Plan Dedicated",
-      "rule_criteria": {
-        "rules": [
-          {
-            "aggregate_function": "avg",
-            "dimension_filters": [
-              {
-                "dimension_label": "node_type",
-                "label": "Node Type",
-                "operator": "eq",
-                "value": "primary"
-              }
-            ],
-            "label": "Memory Usage",
-            "metric": "memory_usage",
-            "operator": "gt",
-            "threshold": 95,
-            "unit": "percent"
-          }
-        ]
-      },
+      "id": 12345,
+      "label": "Test Alert for DBAAS",
       "service_type": "dbaas",
-      "severity": 2,
-      "status": "enabled",
-      "trigger_conditions": {
-        "criteria_condition": "ALL",
-        "evaluation_period_seconds": 300,
-        "polling_interval_seconds": 300,
-        "trigger_occurrences": 3
-      },
-      "type": "system",
-      "updated": "2025-03-20T01:42:11",
-      "updated_by": "system"
-    },
-    {
-      "alert_channels": [
-        {
-          "id": 10000,
-          "label": "Read-Write Channel",
-          "type": "alert-channels",
-          "url": "/monitor/alert-channels/10000"
-        }
-      ],
-      "class": null,
-      "created": "2025-03-20T02:15:18",
-      "created_by": "John Q. Linode",
-      "description": "Custom alert set up for high memory usage for shared plan nodes.",
-      "entity_ids": [
-        "126907",
-        "126908",
-        "137436",
-        "141497",
-        "190004",
-        "257627",
-        "257628"
-      ],
-      "has_more_resources": false,
-      "id": 10001,
-      "label": "High Memory Usage Plan Shared",
-      "rule_criteria": {
-        "rules": [
-          {
-            "aggregate_function": "avg",
-            "dimension_filters": [
-              {
-                "dimension_label": "node_type",
-                "label": "Node Type",
-                "operator": "eq",
-                "value": "primary"
-              }
-            ],
-            "label": "Memory Usage",
-            "metric": "memory_usage",
-            "operator": "gt",
-            "threshold": 95,
-            "unit": "percent"
-          }
-        ]
-      },
-      "service_type": "dbaas",
-      "severity": 2,
-      "status": "enabled",
-      "trigger_conditions": {
-        "criteria_condition": "ALL",
-        "evaluation_period_seconds": 300,
-        "polling_interval_seconds": 300,
-        "trigger_occurrences": 3
-      },
+      "severity": 1,
       "type": "user",
-      "updated": "2025-03-20T02:15:18",
-      "updated_by": "John Q. Linode"
+      "description": "A test alert for dbaas service",
+      "scope": "entity",
+      "regions": [],
+      "entities": {
+        "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+        "count": 1,
+        "has_more_resources": false
+      },
+      "alert_channels": [
+        {
+          "id": 10000,
+          "label": "Read-Write Channel",
+          "type": "email",
+          "url": "/monitor/alert-channels/10000"
+        }
+      ],
+      "rule_criteria": {
+        "rules": [
+          {
+            "aggregate_function": "avg",
+            "dimension_filters": [
+              {
+                "dimension_label": "node_type",
+                "label": "Node Type",
+                "operator": "eq",
+                "value": "primary"
+              }
+            ],
+            "label": "High CPU Usage",
+            "metric": "cpu_usage",
+            "operator": "gt",
+            "threshold": 90,
+            "unit": "percent"
+          }
+        ]
+      },
+      "trigger_conditions": {
+        "criteria_condition": "ALL",
+        "evaluation_period_seconds": 300,
+        "polling_interval_seconds": 60,
+        "trigger_occurrences": 3
+      },
+      "class": "alert",
+      "status": "active",
+      "created": "2024-01-01T00:00:00",
+      "updated": "2024-01-01T00:00:00",
+      "updated_by": "tester"
     }
   ]
 ''']

--- a/plugins/module_utils/doc_fragments/alert_definitions_list.py
+++ b/plugins/module_utils/doc_fragments/alert_definitions_list.py
@@ -7,120 +7,58 @@ specdoc_examples = ['''
 
 result_alert_definitions_samples = ['''[
     {
-      "alert_channels": [
-        {
-          "id": 10000,
-          "label": "Read-Write Channel",
-          "type": "alert-channels",
-          "url": "/monitor/alert-channels/10000"
-        }
-      ],
-      "class": "dedicated",
-      "created": "2025-03-20T01:42:11",
-      "created_by": "system",
-      "description": "Alert triggers when dedicated plan nodes consistently reach critical memory usage, risking application performance degradation.",
-      "entity_ids": [
-        "126905",
-        "126906",
-        "137435",
-        "141496",
-        "190003",
-        "257625",
-        "257626"
-      ],
-      "has_more_resources": false,
-      "id": 10000,
-      "label": "High Memory Usage Plan Dedicated",
-      "rule_criteria": {
-        "rules": [
-          {
-            "aggregate_function": "avg",
-            "dimension_filters": [
-              {
-                "dimension_label": "node_type",
-                "label": "Node Type",
-                "operator": "eq",
-                "value": "primary"
-              }
-            ],
-            "label": "Memory Usage",
-            "metric": "memory_usage",
-            "operator": "gt",
-            "threshold": 95,
-            "unit": "percent"
-          }
-        ]
-      },
+      "id": 12345,
+      "label": "Test Alert for DBAAS",
       "service_type": "dbaas",
-      "severity": 2,
-      "status": "enabled",
-      "trigger_conditions": {
-        "criteria_condition": "ALL",
-        "evaluation_period_seconds": 300,
-        "polling_interval_seconds": 300,
-        "trigger_occurrences": 3
-      },
-      "type": "system",
-      "updated": "2025-03-20T01:42:11",
-      "updated_by": "system"
-    },
-    {
-      "alert_channels": [
-        {
-          "id": 10000,
-          "label": "Read-Write Channel",
-          "type": "alert-channels",
-          "url": "/monitor/alert-channels/10000"
-        }
-      ],
-      "class": null,
-      "created": "2025-03-20T02:15:18",
-      "created_by": "John Q. Linode",
-      "description": "Custom alert set up for high memory usage for shared plan nodes.",
-      "entity_ids": [
-        "126907",
-        "126908",
-        "137436",
-        "141497",
-        "190004",
-        "257627",
-        "257628"
-      ],
-      "has_more_resources": false,
-      "id": 10001,
-      "label": "High Memory Usage Plan Shared",
-      "rule_criteria": {
-        "rules": [
-          {
-            "aggregate_function": "avg",
-            "dimension_filters": [
-              {
-                "dimension_label": "node_type",
-                "label": "Node Type",
-                "operator": "eq",
-                "value": "primary"
-              }
-            ],
-            "label": "Memory Usage",
-            "metric": "memory_usage",
-            "operator": "gt",
-            "threshold": 95,
-            "unit": "percent"
-          }
-        ]
-      },
-      "service_type": "dbaas",
-      "severity": 2,
-      "status": "enabled",
-      "trigger_conditions": {
-        "criteria_condition": "ALL",
-        "evaluation_period_seconds": 300,
-        "polling_interval_seconds": 300,
-        "trigger_occurrences": 3
-      },
+      "severity": 1,
       "type": "user",
-      "updated": "2025-03-20T02:15:18",
-      "updated_by": "John Q. Linode"
+      "description": "A test alert for dbaas service",
+      "scope": "entity",
+      "regions": [],
+      "entities": {
+        "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
+        "count": 1,
+        "has_more_resources": false
+      },
+      "alert_channels": [
+        {
+          "id": 10000,
+          "label": "Read-Write Channel",
+          "type": "email",
+          "url": "/monitor/alert-channels/10000"
+        }
+      ],
+      "rule_criteria": {
+        "rules": [
+          {
+            "aggregate_function": "avg",
+            "dimension_filters": [
+              {
+                "dimension_label": "node_type",
+                "label": "Node Type",
+                "operator": "eq",
+                "value": "primary"
+              }
+            ],
+            "label": "High CPU Usage",
+            "metric": "cpu_usage",
+            "operator": "gt",
+            "threshold": 90,
+            "unit": "percent"
+          }
+        ]
+      },
+      "trigger_conditions": {
+        "criteria_condition": "ALL",
+        "evaluation_period_seconds": 300,
+        "polling_interval_seconds": 60,
+        "trigger_occurrences": 3
+      },
+      "class": "alert",
+      "status": "active",
+      "created": "2024-01-01T00:00:00",
+      "updated": "2024-01-01T00:00:00",
+      "updated_by": "tester"
     }
   ]
 ''']

--- a/plugins/modules/monitor_alert_definition_entities_list.py
+++ b/plugins/modules/monitor_alert_definition_entities_list.py
@@ -36,8 +36,6 @@ module = ListModule(
             type=FieldType.integer,
         ),
     ],
-    # filtering is currently not supported by this endpoint
-    disable_filters=True,
 )
 
 SPECDOC_META = module.spec

--- a/plugins/modules/monitor_alert_definition_entities_list.py
+++ b/plugins/modules/monitor_alert_definition_entities_list.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""This module allows users to list entities associated with a specific
+ACLP Monitor Service Alert Definition.
+NOTE: This module is under v4beta."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    alert_definition_entities_list as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_list import (
+    ListModule,
+    ListModuleParam,
+)
+from ansible_specdoc.objects import FieldType
+
+module = ListModule(
+    result_display_name="Alert Definition Entities",
+    result_field_name="alert_definition_entities",
+    endpoint_template="/monitor/services/{service_type}/alert-definitions/{id}/entities",
+    result_docs_url="TODO",
+    examples=docs.specdoc_examples,
+    result_samples=docs.result_alert_definition_entities_samples,
+    requires_beta=True,
+    params=[
+        ListModuleParam(
+            display_name="Service Type",
+            name="service_type",
+            type=FieldType.string,
+        ),
+        ListModuleParam(
+            display_name="Alert Definition",
+            name="id",
+            type=FieldType.integer,
+        ),
+    ],
+    # filtering is currently not supported by this endpoint
+    disable_filters=True,
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/plugins/modules/monitor_services_alert_definition.py
+++ b/plugins/modules/monitor_services_alert_definition.py
@@ -368,6 +368,10 @@ class LinodeMonitorServicesAlertDefinition(LinodeModuleBase):
         if regions is not None:
             create_kwargs["regions"] = regions
 
+        entity_ids = params.get("entity_ids")
+        if entity_ids is not None:
+            create_kwargs["entity_ids"] = entity_ids
+
         try:
             self.register_action(
                 "Created alert definition for service type {0}".format(

--- a/plugins/modules/monitor_services_alert_definition.py
+++ b/plugins/modules/monitor_services_alert_definition.py
@@ -207,6 +207,21 @@ spec: dict = {
             "Required for updating."
         ],
     ),
+    "scope": SpecField(
+        type=FieldType.string,
+        choices=["account", "entity", "region"],
+        description=[
+            "The alert scope. "
+            "Supported values include account, entity, and region. "
+            "Defaults to entity."
+        ],
+    ),
+    "regions": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        editable=True,
+        description=["The regions to monitor for this alert definition."],
+    ),
     "status": SpecField(
         type=FieldType.string,
         editable=True,
@@ -259,6 +274,7 @@ MUTABLE_FIELDS = {
     "description",
     "entity_ids",
     "label",
+    "regions",
     "rule_criteria",
     "severity",
     "status",
@@ -334,21 +350,31 @@ class LinodeMonitorServicesAlertDefinition(LinodeModuleBase):
         params = self.module.params
         service_type = params.pop("service_type")
 
+        create_kwargs: dict = {
+            "service_type": service_type,
+            "label": params.pop("label"),
+            "severity": params.pop("severity"),
+            "description": params.pop("description"),
+            "channel_ids": params.pop("channel_ids"),
+            "rule_criteria": params.pop("rule_criteria"),
+            "trigger_conditions": params.pop("trigger_conditions"),
+        }
+
+        scope = params.get("scope")
+        if scope is not None:
+            create_kwargs["scope"] = scope
+
+        regions = params.get("regions")
+        if regions is not None:
+            create_kwargs["regions"] = regions
+
         try:
             self.register_action(
                 "Created alert definition for service type {0}".format(
                     service_type
                 )
             )
-            return self.client.monitor.create_alert_definition(
-                service_type=service_type,
-                label=params.pop("label"),
-                severity=params.pop("severity"),
-                description=params.pop("description"),
-                channel_ids=params.pop("channel_ids"),
-                rule_criteria=params.pop("rule_criteria"),
-                trigger_conditions=params.pop("trigger_conditions"),
-            )
+            return self.client.monitor.create_alert_definition(**create_kwargs)
         except Exception as exception:
             return self.fail(
                 msg="failed to create alert definition: {0}".format(exception)

--- a/plugins/modules/monitor_services_alert_definition.py
+++ b/plugins/modules/monitor_services_alert_definition.py
@@ -354,11 +354,14 @@ class LinodeMonitorServicesAlertDefinition(LinodeModuleBase):
             "service_type": service_type,
             "label": params.pop("label"),
             "severity": params.pop("severity"),
-            "description": params.pop("description"),
             "channel_ids": params.pop("channel_ids"),
             "rule_criteria": params.pop("rule_criteria"),
             "trigger_conditions": params.pop("trigger_conditions"),
         }
+
+        description = params.get("description")
+        if description is not None:
+            create_kwargs["description"] = description
 
         scope = params.get("scope")
         if scope is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# linode_api4>= 5.42.0
-git+https://github.com/linode/linode_api4-python.git@dev
-
+linode_api4>= 5.43.0
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-linode_api4>= 5.42.0
+# linode_api4>= 5.42.0
+git+https://github.com/linode/linode_api4-python.git@dev
+
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/monitor_alert_definition_entities_list/tasks/main.yaml
+++ b/tests/integration/targets/monitor_alert_definition_entities_list/tasks/main.yaml
@@ -1,0 +1,31 @@
+- name: monitor_alert_definition_entities_list
+  block:
+    - name: List available alert definitions by service type
+      linode.cloud.monitor_services_alert_definition_by_service_type_list:
+        service_type: 'dbaas'
+      register: alert_definitions_list
+
+    - name: Assert alert_definitions_list response
+      assert:
+        that:
+          - alert_definitions_list.alert_definitions | length > 0
+
+    - name: List entities for the alert definition
+      linode.cloud.monitor_alert_definition_entities_list:
+        service_type: 'dbaas'
+        id: '{{ alert_definitions_list.alert_definitions[0].id }}'
+      register: entities_list
+
+    - name: Assert entities list response
+      assert:
+        that:
+          - entities_list.alert_definition_entities is defined
+          - entities_list.alert_definition_entities | type_debug == 'list'
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'
+

--- a/tests/integration/targets/monitor_services_alert_definition/tasks/main.yaml
+++ b/tests/integration/targets/monitor_services_alert_definition/tasks/main.yaml
@@ -19,6 +19,8 @@
             description: 'An alert definition for ansible test'
             label: '{{ label }}'
             severity: 1
+            scope: 'entity'
+            regions: []
             rule_criteria:
               rules:
                 - aggregate_function: 'avg'
@@ -45,6 +47,9 @@
               - create.alert_definition.description == 'An alert definition for ansible test'
               - create.alert_definition.label == label
               - create.alert_definition.severity == 1
+              - create.alert_definition.scope == 'entity'
+              - create.alert_definition.regions is defined
+              - create.alert_definition.entities is not none
               - create.alert_definition.rule_criteria.rules[0].aggregate_function == 'avg'
               - create.alert_definition.rule_criteria.rules[0].dimension_filters[0].dimension_label == 'node_type'
               - create.alert_definition.trigger_conditions.criteria_condition == 'ALL'


### PR DESCRIPTION
## 📝 Description

Add support for alert definition scope and regions. Introduce a new list module to retrieve entities associated with an alert definition.

## ✔️ How to Test

```
make test-int TEST_SUITE=monitor_services_alert_definition 
```

```
make test-int TEST_SUITE=monitor_alert_definition_entities_list
```
