### PR TITLE
Refactor instance_basic testing playbook

### DIFF
--- a/plugins/modules/reserved_ip.py
+++ b/plugins/modules/reserved_ip.py
@@ -36,14 +36,16 @@ reserved_ip_spec = {
         type=FieldType.string,
         description=[
             "The Region in which to reserve the IP address.",
-            "Required when creating a new reservation (state=present without an existing address).",
+            "Required when creating a new reservation (state=present "
+            "without an existing address).",
         ],
     ),
     "address": SpecField(
         type=FieldType.string,
         description=[
             "The reserved IPv4 address.",
-            "Required when deleting (state=absent) or updating an existing reserved IP.",
+            "Required when deleting (state=absent) or updating an existing "
+            "reserved IP.",
         ],
     ),
     "tags": SpecField(

--- a/plugins/modules/reserved_ip.py
+++ b/plugins/modules/reserved_ip.py
@@ -36,16 +36,14 @@ reserved_ip_spec = {
         type=FieldType.string,
         description=[
             "The Region in which to reserve the IP address.",
-            "Required when creating a new reservation (state=present "
-            "without an existing address).",
+            "Required when creating a new reservation (state=present without an existing address).",
         ],
     ),
     "address": SpecField(
         type=FieldType.string,
         description=[
             "The reserved IPv4 address.",
-            "Required when deleting (state=absent) or updating an existing "
-            "reserved IP.",
+            "Required when deleting (state=absent) or updating an existing reserved IP.",
         ],
     ),
     "tags": SpecField(

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -136,24 +136,27 @@
              else 'linode/migrate' }}
           
     - set_fact:
-        updated_label: '{{ create.instance.label }}-updated'
+        instance_tags: ["testing", "ansible-test"]
 
     - name: Update the instance
       linode.cloud.instance:
-        label: '{{ updated_label }}'
+        label: '{{ create.instance.label }}'
         region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
         maintenance_policy: '{{ toggled_maintenance_policy }}'
         state: present
+        tags: '{{ instance_tags }}'
       register: update
 
     - name: Assert update
       assert:
         that:
+          - update.changed
           - update.instance.maintenance_policy == toggled_maintenance_policy
-          - update.instance.label == updated_label
+          - update.instance.tags[0] == 'ansible-test'
+          - update.instance.tags[1] == 'testing'
 
     - name: Get info about the instance by id
       linode.cloud.instance_info:
@@ -168,11 +171,13 @@
           - info_id.configs|length == 1
           - info_id.networking.ipv4.public[0].address != None
           - info_id.instance.capabilities == create.instance.capabilities
-          - info_id.instance.maintenance_policy == account_info.account_settings.maintenance_policy
+          - info_id.instance.maintenance_policy == toggled_maintenance_policy
+          - info_id.instance.tags[0] == 'ansible-test'
+          - info_id.instance.tags[1] == 'testing'
 
     - name: Get info about the instance by label
       linode.cloud.instance_info:
-        label: '{{ updated_label }}'
+        label: '{{ create.instance.label }}'
       register: info_label
 
     - name: Assert instance info
@@ -212,7 +217,7 @@
       block:
         - name: Delete a Linode instance
           linode.cloud.instance:
-            label: '{{ update.instance.label }}'
+            label: '{{ create.instance.label }}'
             state: absent
           register: delete_nopass
 

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -155,8 +155,9 @@
         that:
           - update.changed
           - update.instance.maintenance_policy == toggled_maintenance_policy
-          - update.instance.tags[0] == 'ansible-test'
-          - update.instance.tags[1] == 'testing'
+          - update.instance.tags|length == 2
+          - "'ansible-test' in update.instance.tags"
+          - "'testing' in update.instance.tags"
 
     - name: Get info about the instance by id
       linode.cloud.instance_info:
@@ -172,8 +173,9 @@
           - info_id.networking.ipv4.public[0].address != None
           - info_id.instance.capabilities == create.instance.capabilities
           - info_id.instance.maintenance_policy == toggled_maintenance_policy
-          - info_id.instance.tags[0] == 'ansible-test'
-          - info_id.instance.tags[1] == 'testing'
+          - info_id.instance.tags|length == 2
+          - "'ansible-test' in info_id.instance.tags"
+          - "'testing' in info_id.instance.tags"
 
     - name: Get info about the instance by label
       linode.cloud.instance_info:


### PR DESCRIPTION
## 📝 Description

Existing playbook tries to update an instance using updated label, however it creates a new instance as label is not a mutable field. Moreover, the playbook doesn't delete the original instance at the end (dangling resource). 

This commit reverts/refactors the changes merged in https://github.com/linode/ansible_linode/pull/691 using tags instead of label to update existing instance.

**Note:
It depends on https://github.com/linode/ansible_linode/pull/788**

## ✔️ How to Test

`make TEST_SUITE="instance_basic" test-int
`