### PR TITLE
TPT-4259: Added support for SLADE + CLEO features

### DIFF
--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -30,6 +30,8 @@ Manage Linode Instances, Configs, and Disks.
       variable: value
     tags:
       - env=prod
+    boot_size: 8192
+    kernel: "linode/latest-64bit"
     state: present
 ```
 
@@ -227,10 +229,10 @@ Manage Linode Instances, Configs, and Disks.
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type of the Linode you are creating.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |
 | `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.  **(Conflicts With: `disks`,`configs`)** |
-| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user.   |
-| `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames.   |
+| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
+| `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
 | `maintenance_policy` | <center>`str`</center> | <center>Optional</center> | The slug of the maintenance policy to apply during maintenance.  **(Choices: `linode/migrate`, `linode/power_off_on`)** |
-| `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If not specified, one will be generated. This generated password will be available in the task success JSON.   |
+| `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of a Firewall this Linode to assign this Linode to.   |
@@ -258,6 +260,8 @@ Manage Linode Instances, Configs, and Disks.
 | [`placement_group` (sub-options)](#placement_group) | <center>`dict`</center> | <center>Optional</center> | A Placement Group to create this Linode under.   |
 | `disk_encryption` | <center>`str`</center> | <center>Optional</center> | The disk encryption status of this Linode.  **(Choices: `enabled`, `disabled`)** |
 | `swap_size` | <center>`int`</center> | <center>Optional</center> | When deploying from an Image, this field is optional, otherwise it is ignored. This is used to set the swap disk size for the newly-created Linode.   |
+| `kernel` | <center>`str`</center> | <center>Optional</center> | The kernel to deploy with when creating a Linode.   |
+| `boot_size` | <center>`int`</center> | <center>Optional</center> | The size of the boot disk in MB for the newly-created Linode.  Must be at least 8192 MB.   |
 
 ### configs
 

--- a/docs/modules/instance.md
+++ b/docs/modules/instance.md
@@ -229,10 +229,10 @@ Manage Linode Instances, Configs, and Disks.
 | `type` | <center>`str`</center> | <center>Optional</center> | The Linode Type of the Linode you are creating.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The location to deploy the instance in. See the [Linode API documentation](https://api.linode.com/v4/regions).   |
 | `image` | <center>`str`</center> | <center>Optional</center> | The image ID to deploy the instance disk from.  **(Conflicts With: `disks`,`configs`)** |
-| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
-| `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
+| `authorized_keys` | <center>`list`</center> | <center>Optional</center> | A list of SSH public key parts to deploy for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users is required.   |
+| `authorized_users` | <center>`list`</center> | <center>Optional</center> | A list of usernames. If image is provided, one of root_pass, authorized_keys, or authorized_users is required.   |
 | `maintenance_policy` | <center>`str`</center> | <center>Optional</center> | The slug of the maintenance policy to apply during maintenance.  **(Choices: `linode/migrate`, `linode/power_off_on`)** |
-| `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users  is required.   |
+| `root_pass` | <center>`str`</center> | <center>Optional</center> | The password for the root user. If image is provided, one of root_pass, authorized_keys, or authorized_users is required.   |
 | `stackscript_id` | <center>`int`</center> | <center>Optional</center> | The ID of the StackScript to use when creating the instance. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `stackscript_data` | <center>`dict`</center> | <center>Optional</center> | An object containing arguments to any User Defined Fields present in the StackScript used when creating the instance. Only valid when a stackscript_id is provided. See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).   |
 | `firewall_id` | <center>`int`</center> | <center>Optional</center> | The ID of a Firewall this Linode to assign this Linode to.   |

--- a/plugins/module_utils/doc_fragments/instance.py
+++ b/plugins/module_utils/doc_fragments/instance.py
@@ -16,6 +16,8 @@ specdoc_examples = ['''
       variable: value
     tags:
       - env=prod
+    boot_size: 8192
+    kernel: "linode/latest-64bit"
     state: present''', '''
 - name: Create a new Linode instance with an additional public IPv4 address.
   linode.cloud.instance:

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -418,7 +418,7 @@ linode_instance_spec = {
         description=[
             "A list of SSH public key parts to deploy for the root user.",
             "If image is provided, one of root_pass, authorized_keys, or authorized_users",
-            " is required.",
+            "is required.",
         ],
     ),
     "authorized_users": SpecField(
@@ -427,7 +427,7 @@ linode_instance_spec = {
         description=[
             "A list of usernames.",
             "If image is provided, one of root_pass, authorized_keys, or authorized_users",
-            " is required.",
+            "is required.",
         ],
     ),
     "maintenance_policy": SpecField(
@@ -443,7 +443,7 @@ linode_instance_spec = {
         description=[
             "The password for the root user.",
             "If image is provided, one of root_pass, authorized_keys, or authorized_users",
-            " is required.",
+            "is required.",
         ],
     ),
     "stackscript_id": SpecField(
@@ -1024,8 +1024,8 @@ class LinodeInstance(LinodeModuleBase):
         response = self.client.linode.instance_create(ltype, region, **params)
 
         result["instance"] = response
-        # Return the explicit root_pass provided by the caller, or an empty string.
-        result["root_pass"] = params.get("root_pass", "") or ""
+        # API-generated passwords are no longer supported; avoid echoing the caller-provided secret.
+        result["root_pass"] = ""
 
         return result
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -416,13 +416,19 @@ linode_instance_spec = {
         type=FieldType.list,
         element_type=FieldType.string,
         description=[
-            "A list of SSH public key parts to deploy for the root user."
+            "A list of SSH public key parts to deploy for the root user.",
+            "If image is provided, one of root_pass, authorized_keys, or authorized_users",
+            " is required.",
         ],
     ),
     "authorized_users": SpecField(
         type=FieldType.list,
         element_type=FieldType.string,
-        description=["A list of usernames."],
+        description=[
+            "A list of usernames.",
+            "If image is provided, one of root_pass, authorized_keys, or authorized_users",
+            " is required.",
+        ],
     ),
     "maintenance_policy": SpecField(
         type=FieldType.string,
@@ -436,8 +442,8 @@ linode_instance_spec = {
         no_log=True,
         description=[
             "The password for the root user.",
-            "If not specified, one will be generated.",
-            "This generated password will be available in the task success JSON.",
+            "If image is provided, one of root_pass, authorized_keys, or authorized_users",
+            " is required.",
         ],
     ),
     "stackscript_id": SpecField(
@@ -657,6 +663,19 @@ linode_instance_spec = {
         description=[
             "When deploying from an Image, this field is optional, otherwise it is ignored. "
             "This is used to set the swap disk size for the newly-created Linode."
+        ],
+    ),
+    "kernel": SpecField(
+        type=FieldType.string,
+        description=[
+            "The kernel to deploy with when creating a Linode.",
+        ],
+    ),
+    "boot_size": SpecField(
+        type=FieldType.integer,
+        description=[
+            "The size of the boot disk in MB for the newly-created Linode. ",
+            "Must be at least 8192 MB.",
         ],
     ),
 }
@@ -950,7 +969,7 @@ class LinodeInstance(LinodeModuleBase):
         """Creates a Linode instance"""
         params = copy.deepcopy(self.module.params)
 
-        if "root_pass" in params.keys() and params.get("root_pass") is None:
+        if "root_pass" in params and params.get("root_pass") is None:
             params.pop("root_pass")
 
         ltype = params.pop("type")
@@ -977,16 +996,36 @@ class LinodeInstance(LinodeModuleBase):
 
             params["interfaces"] = _linode_interfaces
 
+        # If deploying from an image, require at least one authentication
+        # option to be explicitly provided by the caller. This prevents
+        # silently relying on API-generated passwords when the user did not
+        # intend to receive them.
+        if params.get("image") is not None:
+            has_root_pass = "root_pass" in params and params.get("root_pass")
+            has_auth_users = (
+                params.get("authorized_users") is not None
+                and len(params.get("authorized_users") or []) > 0
+            )
+            has_auth_keys = (
+                params.get("authorized_keys") is not None
+                and len(params.get("authorized_keys") or []) > 0
+            )
+
+            if not (has_root_pass or has_auth_users or has_auth_keys):
+                self.fail(
+                    msg=(
+                        "When deploying from an image, one of 'root_pass',"
+                        " 'authorized_users', or 'authorized_keys' must be provided"
+                    )
+                )
+
         result = {"instance": None, "root_pass": ""}
 
         response = self.client.linode.instance_create(ltype, region, **params)
 
-        # Weird variable return type
-        if isinstance(response, tuple):
-            result["instance"] = response[0]
-            result["root_pass"] = response[1]
-        else:
-            result["instance"] = response
+        result["instance"] = response
+        # Return the explicit root_pass provided by the caller, or an empty string.
+        result["root_pass"] = params.get("root_pass", "") or ""
 
         return result
 
@@ -1072,6 +1111,28 @@ class LinodeInstance(LinodeModuleBase):
 
     def _create_disk_register(self, **params: Any) -> None:
         size = params.pop("size")
+
+        if "root_pass" in params and params.get("root_pass") is None:
+            params.pop("root_pass")
+
+        if params.get("image") is not None:
+            has_root_pass = "root_pass" in params and params.get("root_pass")
+            has_auth_users = (
+                params.get("authorized_users") is not None
+                and len(params.get("authorized_users") or []) > 0
+            )
+            has_auth_keys = (
+                params.get("authorized_keys") is not None
+                and len(params.get("authorized_keys") or []) > 0
+            )
+
+            if not (has_root_pass or has_auth_users or has_auth_keys):
+                self.fail(
+                    msg=(
+                        "When creating a disk from an image, one of 'root_pass',"
+                        " 'authorized_users', or 'authorized_keys' must be provided"
+                    )
+                )
 
         stackscript_id = params.pop("stackscript_id", None)
         if stackscript_id is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode_api4>= 5.43.0
+linode_api4>= 5.44.0
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/consumer_image_share_group_image_list/tasks/main.yaml
+++ b/tests/integration/targets/consumer_image_share_group_image_list/tasks/main.yaml
@@ -28,6 +28,7 @@
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
         image: linode/alpine3.19
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_one_create
@@ -50,6 +51,7 @@
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
         image: linode/alpine3.19
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_two_create

--- a/tests/integration/targets/firewall_basic/tasks/main.yaml
+++ b/tests/integration/targets/firewall_basic/tasks/main.yaml
@@ -7,7 +7,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
       register: create_instance
 
@@ -16,7 +17,8 @@
         label: 'ansible-test-{{ r }}-2'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
       register: create_instance_2
 

--- a/tests/integration/targets/firewall_device/tasks/main.yaml
+++ b/tests/integration/targets/firewall_device/tasks/main.yaml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
       register: inst
 

--- a/tests/integration/targets/firewall_icmp/tasks/main.yaml
+++ b/tests/integration/targets/firewall_icmp/tasks/main.yaml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
       register: create_instance
 

--- a/tests/integration/targets/image_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_basic/tasks/main.yaml
@@ -16,7 +16,8 @@
         label: 'ansible-test-{{ r }}'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_create

--- a/tests/integration/targets/image_share_group_basic/tasks/main.yaml
+++ b/tests/integration/targets/image_share_group_basic/tasks/main.yaml
@@ -16,7 +16,8 @@
         label: 'ansible-test-{{ r }}-one'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_one_create
@@ -34,7 +35,8 @@
         label: 'ansible-test-{{ r }}-two'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_two_create

--- a/tests/integration/targets/image_share_group_image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_share_group_image_list/tasks/main.yaml
@@ -16,7 +16,8 @@
         label: 'ansible-test-{{ r }}-one'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_one_create
@@ -34,7 +35,8 @@
         label: 'ansible-test-{{ r }}-two'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_two_create

--- a/tests/integration/targets/image_share_group_list/tasks/main.yaml
+++ b/tests/integration/targets/image_share_group_list/tasks/main.yaml
@@ -16,7 +16,8 @@
         label: 'ansible-test-{{ r }}'
         region: '{{ capable_regions[1] }}'
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_create

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -14,6 +14,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu24.04
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -31,6 +32,7 @@
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu24.04
+        root_pass: Fn$$oobar123
         wait: true
         state: present
         backups_enabled: true
@@ -49,6 +51,7 @@
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu24.04
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         backups_enabled: False
@@ -66,6 +69,7 @@
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu24.04
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         backups_enabled: True

--- a/tests/integration/targets/instance_basic/tasks/main.yaml
+++ b/tests/integration/targets/instance_basic/tasks/main.yaml
@@ -15,13 +15,14 @@
         state: 'present'
       register: account_info
 
-    - name: Create a Linode instance without a root password
+    - name: Create a Linode instance
       linode.cloud.instance:
         label: 'ansible-test-nopass-{{ r }}'
         region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -35,13 +36,14 @@
           - create.networking.ipv4.public[0].address != None
           - create.instance.maintenance_policy == account_info.account_settings.maintenance_policy
 
-    - name: Create a Linode instance with additional ips and without a root password
+    - name: Create a Linode instance with additional ips
       linode.cloud.instance:
         label: 'ansible-test-additional-ips-nopass-{{ r }}'
         region: '{{ pg_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         additional_ipv4:
@@ -63,6 +65,7 @@
         type: g6-standard-2
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         state: present
       register: invalid_update
       failed_when:
@@ -75,6 +78,7 @@
         type: g6-standard-2
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         state: present
       register: invalid_update
       failed_when:
@@ -87,6 +91,7 @@
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         additional_ipv4:
@@ -103,6 +108,7 @@
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         wait: false
         state: present
       register: invalid_update_remove_ips
@@ -114,7 +120,7 @@
         toggled_maintenance_policy: >-
           {{ 'linode/power_off_on' if account_info.account_settings.maintenance_policy == 'linode/migrate'
              else 'linode/migrate' }}
-          
+
     - set_fact:
         updated_label: '{{ create.instance.label }}-updated'
 
@@ -125,6 +131,7 @@
         type: g6-standard-1
         image: linode/ubuntu22.04
         private_ip: true
+        root_pass: Fn$$oobar123
         maintenance_policy: '{{ toggled_maintenance_policy }}'
         state: present
       register: update
@@ -194,25 +201,25 @@
           linode.cloud.instance:
             label: '{{ update.instance.label }}'
             state: absent
-          register: delete_nopass
+          register: delete
 
         - name: Assert instance delete succeeded
           assert:
             that:
-              - delete_nopass.changed
-              - delete_nopass.instance.id == update.instance.id
+              - delete.changed
+              - delete.instance.id == update.instance.id
 
         - name: Delete a Linode instance
           linode.cloud.instance:
             label: '{{ create_additional_ips.instance.label }}'
             state: absent
-          register: delete_nopass_ips
+          register: delete_ips
 
         - name: Assert instance delete succeeded
           assert:
             that:
-              - delete_nopass_ips.changed
-              - delete_nopass_ips.instance.id == create_additional_ips.instance.id
+              - delete_ips.changed
+              - delete_ips.instance.id == create_additional_ips.instance.id
 
         - name: Delete a Linode instance
           linode.cloud.instance:

--- a/tests/integration/targets/instance_config_disk/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk/tasks/main.yaml
@@ -164,6 +164,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/alpine3.19
+        root_pass: Fn$$oobar123
         booted: false
         disks:
           - label: test-disk
@@ -184,7 +185,8 @@
 
           - label: boot-disk
             size: 4096
-            image: linode/alpine3.19
+            image: linode/arch
+            root_pass: Fn$$oobar123
 
         configs:
           - label: boot-config

--- a/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
+++ b/tests/integration/targets/instance_config_disk_private/tasks/main.yaml
@@ -38,6 +38,7 @@
             filesystem: raw
             image: '{{ image_create.image.id }}'
             size: 5000
+            root_pass: Fn$$oobar123
           - label: swap
             filesystem: swap
             size: 4000

--- a/tests/integration/targets/instance_disk_encryption/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_encryption/tasks/main.yaml
@@ -16,6 +16,7 @@
         region: '{{ lde_region }}'
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         private_ip: true
         wait: false
         state: present

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -7,7 +7,7 @@
       linode.cloud.stackscript:
         label: "ansible-test-{{ r }}"
         images:
-          - "linode/alpine3.19"
+          - "linode/arch"
         script: |
           #!/bin/ash
           # <UDF name="package" label="System Package to Install" example="nginx">
@@ -23,8 +23,9 @@
         booted: false
         disks:
           - label: test-disk
-            size: 1024
-            image: linode/alpine3.19
+            size: 2517
+            image: linode/arch
+            root_pass: Fn$$oobar123
             stackscript_id: "{{ stackscript_create.stackscript.id }}"
             stackscript_data:
               package: cowsay
@@ -37,7 +38,7 @@
         that:
           - instance_create.changed
           - instance_create.disks[0].label == "test-disk"
-          - instance_create.disks[0].size == 1024
+          - instance_create.disks[0].size == 2517
           - instance_create.disks[0].filesystem == "ext4"
 
     - name: Get info about the StackScript

--- a/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
+++ b/tests/integration/targets/instance_disk_stackscript/tasks/main.yaml
@@ -9,9 +9,9 @@
         images:
           - "linode/arch"
         script: |
-          #!/bin/ash
+          #!/bin/bash
           # <UDF name="package" label="System Package to Install" example="nginx">
-          apk add $PACKAGE
+          pacman -Syu --noconfirm "$PACKAGE"
         state: present
       register: stackscript_create
 

--- a/tests/integration/targets/instance_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vlan
             label: really-cool-vlan
@@ -33,6 +34,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         private_ip: true
         interfaces:
           - purpose: vlan

--- a/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc/tasks/main.yaml
@@ -25,6 +25,7 @@
         region: us-mia
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vpc
             subnet_id: '{{ create_subnet.subnet.id }}'
@@ -57,6 +58,7 @@
         region: us-mia
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: public
             primary: true
@@ -102,6 +104,7 @@
         region: us-mia
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: public
             primary: true

--- a/tests/integration/targets/instance_interfaces_vpc_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/instance_interfaces_vpc_ipv6/tasks/main.yaml
@@ -28,6 +28,7 @@
         region: no-osl-1
         type: g6-nanode-1
         image: linode/alpine3.21
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vpc
             subnet_id: '{{ create_subnet.subnet.id }}'
@@ -66,6 +67,7 @@
         region: no-osl-1
         type: g6-nanode-1
         image: linode/alpine3.21
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vpc
             subnet_id: '{{ create_subnet.subnet.id }}'
@@ -101,6 +103,7 @@
         region: no-osl-1
         type: g6-nanode-1
         image: linode/alpine3.21
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vpc
             subnet_id: '{{ create_subnet.subnet.id }}'

--- a/tests/integration/targets/instance_list/tasks/main.yaml
+++ b/tests/integration/targets/instance_list/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         private_ip: true
         wait: false
         state: present

--- a/tests/integration/targets/instance_metadata/tasks/main.yaml
+++ b/tests/integration/targets/instance_metadata/tasks/main.yaml
@@ -10,6 +10,7 @@
         region: "{{ region }}"
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         wait: false
         metadata:
           user_data: cool

--- a/tests/integration/targets/instance_multiple_auth/tasks/main.yaml
+++ b/tests/integration/targets/instance_multiple_auth/tasks/main.yaml
@@ -130,7 +130,7 @@
 
         - name: Delete a Linode instance
           linode.cloud.instance:
-            label: '{{ create_authorized_keys.instance.label }}'
+            label: '{{ create_multi_auth.instance.label }}'
             state: absent
           register: delete_multi_auth
 

--- a/tests/integration/targets/instance_multiple_auth/tasks/main.yaml
+++ b/tests/integration/targets/instance_multiple_auth/tasks/main.yaml
@@ -1,0 +1,157 @@
+- name: instance_multiple_auth
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+        ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCloBr83q7v2/kipfpChnN1cPr+DA++JN3RdLBid3tFjy5UmAelpRmKO9Uhija7ElC9/x187t13smc35NGaDOG+s+zrSMlSfygqA6pf8njEPDRBhvyp12Fjwb8i+ILFXiU1GYaVprbQwpgdApwqieoCZ4pathc/HdPvznX/Aqgyiq+5+dSRa5GUftAPWrt3ScFXttlfihU+0wIanyxoxnrtPcqNshs39dRg8UP2zrB5aK+9nPurO/6qSWDqVnIVlparlqXxZdwKl+Gfiq93pGicrPgVEy49Tbl75Y8Nxj7zDsJsQuO0UlRk9IUoe1asAy5DXqQ6foOb6vR9rld6owqRHCG/tjYDpuw1uYCYj5xm+DDfkNRowWJktIgnajzaYqZ3ytWzg31m8a7X2Wol8foxlFrUqqqesJ05I28A3JvLIU5s4vSzi1hK4cWKSi15UFdxX1f1a+pRsRgY446k+i3uWcFZVybzp5tDRdjUMRO6XQrbjrxFnKurRY0+S1NeRF0="
+
+    - name: Upload ssh key
+      linode.cloud.ssh_key:
+        api_token: "{{ api_token }}"
+        ua_prefix: "{{ ua_prefix }}"
+        state: present
+        label: "test-key-{{ r }}"
+        ssh_key: "{{ ssh_pub_key }}"
+      register: create_ssh_key
+
+    - name: Assert ssh key uploaded
+      assert:
+        that:
+          - create_ssh_key.changed
+          - create_ssh_key.ssh_key.label == "test-key-" ~ r
+          - create_ssh_key.ssh_key.ssh_key == ssh_pub_key
+
+    - name: Attempt to create a Linode instance without authentication (should fail)
+      linode.cloud.instance:
+        label: "ansible-test-no-auth-{{ r }}"
+        region: us-ord
+        type: g6-standard-1
+        image: linode/debian12
+        kernel: linode/6.15.7-x86_64-linode169
+        boot_size: 9000
+        state: present
+        firewall_id: "{{ firewall_id }}"
+      register: create_no_auth_attempt
+      failed_when: false
+
+    - name: Assert instance creation without authentication fails
+      assert:
+        that:
+          - create_no_auth_attempt.msg is defined
+          - "'root_pass' in create_no_auth_attempt.msg"
+          - "'authorized_users' in create_no_auth_attempt.msg"
+          - "'authorized_keys' in create_no_auth_attempt.msg"
+
+    - name: Create a Linode instance with a root_pass
+      linode.cloud.instance:
+        label: 'ansible-test-{{ r }}'
+        region: us-ord
+        type: g6-standard-1
+        image: linode/debian12
+        root_pass: Fn$$oobar123
+        kernel: linode/6.15.7-x86_64-linode169
+        boot_size: 9000
+        state: present
+        firewall_id: '{{ firewall_id }}'
+      register: create_root_pass
+
+    - name: Assert instance with only root_pass was created
+      assert:
+        that:
+          - create_root_pass.changed
+          - create_root_pass.instance.id is defined
+
+    - name: Create a Linode instance with only authorized_keys
+      linode.cloud.instance:
+        label: "ansible-test-auth-keys-{{ r }}"
+        region: us-ord
+        type: g6-standard-1
+        image: linode/debian12
+        authorized_keys:
+          - "{{ ssh_pub_key }}"
+        kernel: linode/6.15.7-x86_64-linode169
+        boot_size: 9000
+        state: present
+        firewall_id: "{{ firewall_id }}"
+      register: create_authorized_keys
+
+    - name: Assert instance with only authorized_keys was created
+      assert:
+        that:
+          - create_authorized_keys.changed
+          - create_authorized_keys.instance.id is defined
+
+    - name: Create a Linode instance with both root_pass and authorized_keys
+      linode.cloud.instance:
+        label: "ansible-test-both-auth-{{ r }}"
+        region: us-ord
+        type: g6-standard-1
+        image: linode/debian12
+        root_pass: Fn$$oobar123
+        authorized_keys:
+          - "{{ ssh_pub_key }}"
+        kernel: linode/6.15.7-x86_64-linode169
+        boot_size: 9000
+        state: present
+        firewall_id: "{{ firewall_id }}"
+      register: create_multi_auth
+
+    - name: Assert instance with multiple auth methods was created
+      assert:
+        that:
+          - create_multi_auth.changed
+          - create_multi_auth.instance.id is defined
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_root_pass.instance.label }}'
+            state: absent
+          register: delete_root_pass
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_root_pass.changed
+              - delete_root_pass.instance.id == create_root_pass.instance.id
+
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_authorized_keys.instance.label }}'
+            state: absent
+          register: delete_authorized_keys
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_authorized_keys.changed
+              - delete_authorized_keys.instance.id == create_authorized_keys.instance.id
+
+        - name: Delete a Linode instance
+          linode.cloud.instance:
+            label: '{{ create_authorized_keys.instance.label }}'
+            state: absent
+          register: delete_multi_auth
+
+        - name: Assert instance delete succeeded
+          assert:
+            that:
+              - delete_multi_auth.changed
+              - delete_multi_auth.instance.id == create_multi_auth.instance.id
+
+        - name: Delete Key
+          linode.cloud.ssh_key:
+            api_token: "{{ api_token }}"
+            ua_prefix: "{{ ua_prefix }}"
+
+            label: "test-key-{{ r }}"
+            state: absent
+
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+    LINODE_CA: '{{ ca_file or "" }}'

--- a/tests/integration/targets/instance_region_migration/tasks/main.yaml
+++ b/tests/integration/targets/instance_region_migration/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-mia
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create
@@ -25,6 +26,7 @@
         region: us-iad
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         migration_type: cold
         state: present
       register: migrated

--- a/tests/integration/targets/instance_timeout/tasks/main.yaml
+++ b/tests/integration/targets/instance_timeout/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         wait: yes
         wait_timeout: 0
         booted: yes

--- a/tests/integration/targets/instance_type_change/tasks/main.yaml
+++ b/tests/integration/targets/instance_type_change/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-mia
         type: g6-nanode-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create
@@ -32,6 +33,7 @@
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         auto_disk_resize: true
         state: present
       register: resize_disks
@@ -49,6 +51,7 @@
         region: us-mia
         type: g6-standard-2
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         migration_type: warm
         state: present
       register: resize_disks

--- a/tests/integration/targets/ip_assign/tasks/main.yml
+++ b/tests/integration/targets/ip_assign/tasks/main.yml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create_instance
@@ -18,7 +19,8 @@
         label: 'ansible-test-{{ r }}-2'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create_instance_2

--- a/tests/integration/targets/ip_basic/tasks/main.yaml
+++ b/tests/integration/targets/ip_basic/tasks/main.yaml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         state: present
         firewall_id: '{{ firewall_id }}'
       register: create_instance

--- a/tests/integration/targets/ip_info/tasks/main.yaml
+++ b/tests/integration/targets/ip_info/tasks/main.yaml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         wait: no
         state: present
         firewall_id: '{{ firewall_id }}'

--- a/tests/integration/targets/ip_rdns/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         wait: no
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -18,7 +19,7 @@
       linode.cloud.ip_info:
         address: '{{ instance_create.instance.ipv4[0] }}'
       register: ip_info
-    
+
     - set_fact:
         new_rdns: '{{ instance_create.instance.ipv4[0] }}.nip.io'
 

--- a/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/ip_rdns_ipv6/tasks/main.yaml
@@ -9,6 +9,7 @@
         region: us-ord
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         wait: no
         state: present
         firewall_id: '{{ firewall_id }}'

--- a/tests/integration/targets/ip_share/tasks/main.yaml
+++ b/tests/integration/targets/ip_share/tasks/main.yaml
@@ -1,4 +1,4 @@
-  
+
 - name: ip_share
   block:
     - set_fact:
@@ -10,7 +10,8 @@
         label: 'ansible-test-{{ r1 }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         wait: false
         state: present
       register: instance_create
@@ -20,7 +21,8 @@
         label: 'ansible-test-{{ r2 }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         wait: false
         state: present
         firewall_id: '{{ firewall_id }}'
@@ -82,7 +84,7 @@
           - ip_shared.ips[0] == ip_shared_address
           - ip_already_shared.changed == false
           - ip_unshared.ips == []
-          
+
   always:
     - ignore_errors: true
       block:

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -8,21 +8,23 @@
         label: 'ansible-test-{{ r }}'
         region: us-ord
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         wait: no
         state: present
         firewall_id: '{{ firewall_id }}'
       register: instance_create
 
     - set_fact:
-        ipv6_body: >
-          {"linode_id": {{ instance_create.instance.id }}, "prefix_length": 64}
+        ipv6_body:
+          linode_id: "{{ instance_create.instance.id }}"
+          prefix_length: 64
 
     - name: Assign an IPv6 range to the instance
       linode.cloud.api_request:
         path: networking/ipv6/ranges
         method: POST
-        body_json: '{{ ipv6_body | to_json }}'
+        body_json: "{{ ipv6_body }}"
       register: range_create
 
     - name: Get ipv6_range_info about the IPv6 range

--- a/tests/integration/targets/vlan_basic/tasks/main.yaml
+++ b/tests/integration/targets/vlan_basic/tasks/main.yaml
@@ -9,9 +9,10 @@
         region: us-southeast
         type: g6-standard-1
         image: linode/ubuntu22.04
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vlan
-            label: really-cool-vlan
+            label: 'really-cool-vlan-{{ r }}'
         private_ip: true
         wait: false
         state: present
@@ -25,12 +26,12 @@
           - create_instance.instance.ipv4|length > 1
 
           - create_instance.configs[0].interfaces[0].purpose == 'vlan'
-          - create_instance.configs[0].interfaces[0].label == 'really-cool-vlan'
+          - create_instance.configs[0].interfaces[0].label == 'really-cool-vlan-' ~ r
 
     - name: Get information about the VLAN
       linode.cloud.vlan_info:
         api_version: v4beta
-        label: 'really-cool-vlan'
+        label: 'really-cool-vlan-{{ r }}'
       register: vlan_info
 
     - name: Assert VLAN information
@@ -38,7 +39,7 @@
         that:
           - vlan_info.changed == false
           - vlan_info.vlan.region == 'us-southeast'
-          - vlan_info.vlan.label == 'really-cool-vlan'
+          - vlan_info.vlan.label == 'really-cool-vlan-' ~ r
 
   always:
     - ignore_errors: yes

--- a/tests/integration/targets/vlan_list/tasks/main.yaml
+++ b/tests/integration/targets/vlan_list/tasks/main.yaml
@@ -8,7 +8,8 @@
         label: 'ansible-test-{{ r }}-i'
         region: us-southeast
         type: g6-standard-1
-        image: linode/alpine3.19
+        image: linode/arch
+        root_pass: Fn$$oobar123
         interfaces:
           - purpose: vlan
             label: really-cool-vlan


### PR DESCRIPTION
## 📝 Description

Added support for SLADE + CLEO features. Updated integration tests to no longer rely on automatic password generation as this is no longer supported.

## ✔️ How to Test
 
After checking this PR out locally and building, run the following script:

```
#!/usr/bin/env bash

LOG_FILE="integration_test_results_$(date +%Y%m%d_%H%M%S).log"

TEST_SUITES=(
consumer_image_share_group_image_list
firewall_basic
firewall_device
firewall_icmp
image_basic
image_share_group_basic
image_share_group_image_list
image_share_group_list
instance_backup_enabled
instance_basic
instance_config_disk
instance_config_disk_private
instance_disk_encryption
instance_disk_stackscript
instance_interfaces
instance_interfaces_vpc
instance_interfaces_vpc_ipv6
instance_list
instance_metadata
instance_multiple_auth
instance_region_migration
instance_timeout
instance_type_change
ip_assign
ip_basic
ip_info
ip_rdns
ip_rdns_ipv6
ip_share
ipv6_range_info
vlan_basic
vlan_list
)

echo "Starting test run at $(date)" | tee "$LOG_FILE"

FAILED_TESTS=()

for suite in "${TEST_SUITES[@]}"; do
    echo "" | tee -a "$LOG_FILE"
    echo "==================================================" | tee -a "$LOG_FILE"
    echo "Running: $suite" | tee -a "$LOG_FILE"
    echo "Started: $(date)" | tee -a "$LOG_FILE"
    echo "==================================================" | tee -a "$LOG_FILE"

    make test-int TEST_SUITE="$suite" >> "$LOG_FILE" 2>&1
    EXIT_CODE=$?

    if [ $EXIT_CODE -eq 0 ]; then
        echo "[PASS] $suite" | tee -a "$LOG_FILE"
    else
        echo "[FAIL] $suite (exit code $EXIT_CODE)" | tee -a "$LOG_FILE"
        FAILED_TESTS+=("$suite")
    fi

    echo "Finished: $(date)" | tee -a "$LOG_FILE"
done

echo "" | tee -a "$LOG_FILE"
echo "==================================================" | tee -a "$LOG_FILE"
echo "TEST RUN COMPLETE" | tee -a "$LOG_FILE"
echo "==================================================" | tee -a "$LOG_FILE"

if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
echo "All tests passed." | tee -a "$LOG_FILE"
else
echo "Failed tests:" | tee -a "$LOG_FILE"
for test in "${FAILED_TESTS[@]}"; do
echo "  - $test" | tee -a "$LOG_FILE"
done
fi

echo ""
echo "Results saved to: $LOG_FILE"
```

Observe any failures if they occur.