### PR TITLE
TPT-4534: Flaky smoke tests fixes

### DIFF
--- a/plugins/modules/database_mysql_v2.py
+++ b/plugins/modules/database_mysql_v2.py
@@ -486,14 +486,14 @@ class Module(LinodeModuleBase):
             if len(engine_components) < 2:
                 raise ValueError(f"Invalid engine: {engine}")
 
-            major_version = int(engine_components[1])
+            major_version = engine_components[1].split(".")[0]
 
             # Evil hack to correct for the API returning a three-part value for the
             # `version` field while the user specifies the major version, while still
             # using handle_updates.
             #
             # If anyone can think of a better way to do this, please correct it :)
-            if int(database.version.split(".")[0]) != major_version:
+            if database.version.split(".")[0] != major_version:
                 params["version"] = major_version
 
         # The `updates` field is returned with an additional `pending` key that isn't

--- a/plugins/modules/database_postgresql_v2.py
+++ b/plugins/modules/database_postgresql_v2.py
@@ -641,9 +641,9 @@ class Module(LinodeModuleBase):
             if len(engine_components) < 2:
                 raise ValueError(f"Invalid engine: {engine}")
 
-            major_version = int(engine_components[1])
+            major_version = engine_components[1].split(".")[0]
 
-            if int(database.version.split(".")[0]) != major_version:
+            if database.version.split(".")[0] != major_version:
                 params["version"] = major_version
 
         # The `updates` field is returned with an additional `pending` key that isn't

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -436,10 +436,11 @@ class Module(LinodeModuleBase):
         # Force lazy-loading
         user._api_get()
 
-        self.results["user"] = user._raw_json
+        user_json = user._raw_json
+        self.results["user"] = user_json
 
         # Fetching grants for unrestricted users is not permitted
-        if self.results["user"]["restricted"]:
+        if user_json["restricted"]:
             self.results["grants"] = self._get_raw_grants(user)
 
     def _handle_absent(self) -> None:
@@ -448,10 +449,11 @@ class Module(LinodeModuleBase):
         user = self._get_user_by_username(username)
 
         if user is not None:
-            self.results["user"] = user._raw_json
+            user_json = user._raw_json
+            self.results["user"] = user_json
 
             # Fetching grants for unrestricted users is not permitted
-            if self.results["user"]["restricted"]:
+            if user_json["restricted"]:
                 self.results["grants"] = self._get_raw_grants(user)
 
             user.delete()

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -437,7 +437,10 @@ class Module(LinodeModuleBase):
         user._api_get()
 
         self.results["user"] = user._raw_json
-        self.results["grants"] = self._get_raw_grants(user)
+
+        # Fetching grants for unrestricted users is not permitted
+        if self.results["user"]["restricted"]:
+            self.results["grants"] = self._get_raw_grants(user)
 
     def _handle_absent(self) -> None:
         username: str = self.module.params.get("username")
@@ -446,7 +449,11 @@ class Module(LinodeModuleBase):
 
         if user is not None:
             self.results["user"] = user._raw_json
-            self.results["grants"] = self._get_raw_grants(user)
+
+            # Fetching grants for unrestricted users is not permitted
+            if self.results["user"]["restricted"]:
+                self.results["grants"] = self._get_raw_grants(user)
+
             user.delete()
             self.register_action("Deleted user {0}".format(user.username))
 

--- a/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_basic/tasks/main.yaml
@@ -24,7 +24,7 @@
 
     - set_fact:
         engine_id: "{{ available_engines.database_engines[0]['id'] }}"
-        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
+        engine_version: "{{ (available_engines.database_engines[0]['version'] | split('.'))[0] }}"
 
     - name: Create a database
       linode.cloud.database_mysql_v2:

--- a/tests/integration/targets/database_mysql_v2_complex/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_complex/tasks/main.yaml
@@ -24,7 +24,7 @@
 
     - set_fact:
         engine_id: "{{ available_engines.database_engines[0]['id'] }}"
-        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
+        engine_version: "{{ (available_engines.database_engines[0]['version'] | split('.'))[0] }}"
 
     - name: Create a database
       linode.cloud.database_mysql_v2:

--- a/tests/integration/targets/database_mysql_v2_complex/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_complex/tasks/main.yaml
@@ -153,7 +153,7 @@
       linode.cloud.database_mysql_v2:
         label: "ansible-test-{{ r }}-forked"
         region: us-mia
-        engine: mysql/8
+        engine: "{{ engine_id }}"
         type: g6-nanode-1
         fork:
           source: "{{ db_refresh.database.id }}"

--- a/tests/integration/targets/database_mysql_v2_vpc/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_vpc/tasks/main.yaml
@@ -24,8 +24,6 @@
 
     - set_fact:
         engine_id: "{{ available_engines.database_engines[0]['id'] }}"
-        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
-
 
     - name: Create a VPC
       linode.cloud.vpc:

--- a/tests/integration/targets/database_mysql_v2_vpc_detach/tasks/main.yaml
+++ b/tests/integration/targets/database_mysql_v2_vpc_detach/tasks/main.yaml
@@ -24,8 +24,6 @@
 
     - set_fact:
         engine_id: "{{ available_engines.database_engines[0]['id'] }}"
-        engine_version: "{{ available_engines.database_engines[0]['version'] }}"
-
 
     - name: Create a VPC
       linode.cloud.vpc:

--- a/tests/integration/targets/mysql_basic/tasks/main.yaml
+++ b/tests/integration/targets/mysql_basic/tasks/main.yaml
@@ -21,7 +21,7 @@
         engine_version: "{{ available_engines.database_engines[0]['version'] }}"
 
     - name: Create a database
-      linode.cloud.database_mysql:
+      linode.cloud.database_mysql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{engine_id}}'
@@ -73,7 +73,7 @@
 
 
     - name: Update the database
-      linode.cloud.database_mysql:
+      linode.cloud.database_mysql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: "{{ engine_id }}"
@@ -117,7 +117,7 @@
 #          - resolve_dbs.databases[0].label == db_create.database.label
 
     - name: Update the database
-      linode.cloud.database_mysql:
+      linode.cloud.database_mysql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: "{{ engine_id }}"
@@ -133,7 +133,7 @@
     - ignore_errors: true
       block:
         - name: Delete mysql db
-          linode.cloud.database_mysql:
+          linode.cloud.database_mysql_v2:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/mysql_complex/tasks/main.yaml
+++ b/tests/integration/targets/mysql_complex/tasks/main.yaml
@@ -21,7 +21,7 @@
         engine_version: "{{ available_engines.database_engines[0]['version'] }}"
 
     - name: Validation check
-      linode.cloud.database_mysql:
+      linode.cloud.database_mysql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: "{{ engine_id }}"
@@ -33,7 +33,7 @@
       failed_when: '"Invalid CIDR format for IP" not in allow_list_validation.msg'
 
     - name: Create a database
-      linode.cloud.database_mysql:
+      linode.cloud.database_mysql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: "{{ engine_id }}"
@@ -78,7 +78,7 @@
     - ignore_errors: true
       block:
         - name: Delete mysql database
-          linode.cloud.database_mysql:
+          linode.cloud.database_mysql_v2:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/object_basic/tasks/main.yaml
+++ b/tests/integration/targets/object_basic/tasks/main.yaml
@@ -2,33 +2,36 @@
   block:
     - set_fact:
         r: "{{ 1000000000 | random }}"
+        region: "us-ord"
 
-    - name: Get info about clusters in us-ord
+    - name: Get info about clusters in {{ region }}
       linode.cloud.object_cluster_info:
-        region: us-ord
+        region: '{{ region }}'
       register: info_by_region
 
     - name: Assert cluster information is valid
       assert:
         that:
-          - info_by_region.clusters[0].id == 'us-ord-1'
-          - info_by_region.clusters[0].region == 'us-ord'
+          - info_by_region.clusters[0].id == '{{ region }}-1'
+          - info_by_region.clusters[0].region == '{{ region }}'
 
-    - name: Get info about cluster id us-ord-1
+    - name: Get info about cluster id {{ region }}-1
       linode.cloud.object_cluster_info:
-        id: us-ord-1
+        id: '{{ region }}-1'
       register: info_by_id
 
     - name: Assert cluster information is valid
       assert:
         that:
-          - info_by_id.clusters[0].id == 'us-ord-1'
-          - info_by_id.clusters[0].region == 'us-ord'
+          - info_by_id.clusters[0].id == '{{ region }}-1'
+          - info_by_id.clusters[0].region == '{{ region }}'
 
     - name: Create a Linode key
       linode.cloud.object_keys:
         label: 'test-ansible-key-{{ r }}'
         state: present
+        regions:
+          - '{{ region }}'
       register: create_key
 
     - name: Assert key created
@@ -57,10 +60,10 @@
       linode.cloud.object_keys:
         label: 'test-ansible-key-access-{{ r }}'
         access:
-          - region: us-ord
+          - region: '{{ region }}'
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_write
-          - region: us-ord
+          - region: '{{ region }}'
             bucket_name: '{{ create_bucket.name }}'
             permissions: read_only
         state: present
@@ -71,9 +74,9 @@
         that:
           - create_access.changed
           - 'not "REDACTED" in create_access.key.secret_key'
-          - create_access.key.bucket_access[0].cluster == 'us-ord-1'
+          - create_access.key.bucket_access[0].cluster == '{{ region }}-1'
           - create_access.key.bucket_access[0].bucket_name == create_bucket.name
-          - create_access.key.bucket_access[1].cluster == 'us-ord-1'
+          - create_access.key.bucket_access[1].cluster == '{{ region }}-1'
           - create_access.key.bucket_access[1].bucket_name == create_bucket.name
           - "['read_only', 'read_write'] | sort == (create_access.key.bucket_access | map(attribute='permissions') | sort)"
 

--- a/tests/integration/targets/postgresql_basic/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_basic/tasks/main.yaml
@@ -21,7 +21,7 @@
         engine_version: "{{ available_engines.database_engines[0]['version'] }}"
 
     - name: Create a database
-      linode.cloud.database_postgresql:
+      linode.cloud.database_postgresql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{ engine_id }}'
@@ -68,7 +68,7 @@
           - by_id.database.type == 'g6-standard-1'
 
     - name: Update the database
-      linode.cloud.database_postgresql:
+      linode.cloud.database_postgresql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{ engine_id }}'
@@ -85,7 +85,7 @@
           - db_update.database.allow_list[0] == '10.0.0.1/32'
 
     - name: Update the database
-      linode.cloud.database_postgresql:
+      linode.cloud.database_postgresql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{ engine_id }}'
@@ -101,7 +101,7 @@
     - ignore_errors: true
       block:
         - name: Delete postgres db
-          linode.cloud.database_postgresql:
+          linode.cloud.database_postgresql_v2:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/postgresql_complex/tasks/main.yaml
+++ b/tests/integration/targets/postgresql_complex/tasks/main.yaml
@@ -21,7 +21,7 @@
         engine_version: "{{ available_engines.database_engines[0]['version'] }}"
 
     - name: Validation check
-      linode.cloud.database_postgresql:
+      linode.cloud.database_postgresql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{ engine_id }}'
@@ -33,7 +33,7 @@
       failed_when: '"Invalid CIDR format for IP" not in allow_list_validation.msg'
 
     - name: Create a database
-      linode.cloud.database_postgresql:
+      linode.cloud.database_postgresql_v2:
         label: 'ansible-test-{{ r }}'
         region: us-ord
         engine: '{{ engine_id }}'
@@ -80,7 +80,7 @@
     - ignore_errors: true
       block:
         - name: Delete postgres db
-          linode.cloud.database_postgresql:
+          linode.cloud.database_postgresql_v2:
             label: '{{ db_create.database.label }}'
             state: absent
 

--- a/tests/integration/targets/vpc_basic/tasks/main.yaml
+++ b/tests/integration/targets/vpc_basic/tasks/main.yaml
@@ -26,7 +26,7 @@
           description: test description
           state: present
       register: invalid_label
-      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in invalid_label.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and underscores' not in invalid_label.msg"
 
     - name: Update the VPC
       linode.cloud.vpc:
@@ -50,7 +50,7 @@
         description: test description updated
         state: present
       register: modify_vpc
-      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in modify_vpc.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and underscores' not in modify_vpc.msg"
 
     - name: Don't update the VPC
       linode.cloud.vpc:


### PR DESCRIPTION
## 📝 Description

This PRs covers fixes for failing nightly smoke tests. 

Additionally, following modules have been refactored:
- `plugins/modules/user.py` - currently, grants cannot be retrieved for unrestricted users so "user_basic" playbook was failing on "Update the Linode User" task as it runs "_get_raw_grants" in the background. Decided to check if user is restricted first.
- `plugins/modules/database_mysql_v2.py` , `plugins/modules/database_postgresql_v2.py` - currently available version of mysql engine is in X.Y format so it cannot be converted into integer and properly used as major_version. Decided to split it and use string type instead of int

## ✔️ How to Test

Tested with TPT test user

`make test-int TEST_SUITE="instance_basic"`
`make test-int TEST_SUITE="object_basic"`
`make test-int TEST_SUITE="user_basic"`
`make test-int TEST_SUITE="vpc_basic"`

`make test-int TEST_SUITE="database_mysql_v2_basic"`
`make test-int TEST_SUITE="database_mysql_v2_complex"`
`make test-int TEST_SUITE="database_mysql_v2_vpc"`
`make test-int TEST_SUITE="database_mysql_v2_vpc_detach"`
