### PR TITLE
TPT-4551: Only get obj quota usage when has_usage is true

### DIFF
--- a/plugins/modules/object_storage_quota_info.py
+++ b/plugins/modules/object_storage_quota_info.py
@@ -5,16 +5,36 @@
 
 from __future__ import absolute_import, division, print_function
 
+from typing import Any
+
 from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
     object_storage_quota_info as docs,
 )
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleAttr,
+    InfoModuleParam,
     InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType
-from linode_api4 import ObjectStorageQuota
+from linode_api4 import LinodeClient, ObjectStorageQuota
+
+
+def get_quota_usage(
+    client: LinodeClient,
+    object_storage_quota: dict[str, Any],
+    params: list[InfoModuleParam],
+) -> dict[str, Any] | None:
+    """Return quota usage details for a quota when usage is available."""
+    if not object_storage_quota["has_usage"]:
+        return None
+
+    return (
+        ObjectStorageQuota(client, object_storage_quota["quota_id"])
+        .usage()
+        .dict
+    )
+
 
 module = InfoModule(
     examples=docs.specdoc_examples,
@@ -33,11 +53,7 @@ module = InfoModule(
             docs_url="https://techdocs.akamai.com/linode-api/reference"
             "/get-object-storage-quota-usage",
             samples=docs.result_object_storage_quota_usage_samples,
-            get=lambda client, object_storage_quota, params: ObjectStorageQuota(
-                client, object_storage_quota["quota_id"]
-            )
-            .usage()
-            .dict,
+            get=get_quota_usage,
         ),
     ],
     attributes=[

--- a/plugins/modules/object_storage_quota_info.py
+++ b/plugins/modules/object_storage_quota_info.py
@@ -13,7 +13,6 @@ from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import 
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
     InfoModule,
     InfoModuleAttr,
-    InfoModuleParam,
     InfoModuleResult,
 )
 from ansible_specdoc.objects import FieldType
@@ -23,7 +22,7 @@ from linode_api4 import LinodeClient, ObjectStorageQuota
 def get_quota_usage(
     client: LinodeClient,
     object_storage_quota: dict[str, Any],
-    params: list[InfoModuleParam],
+    _: dict | None,
 ) -> dict[str, Any] | None:
     """Return quota usage details for a quota when usage is available."""
     if not object_storage_quota["has_usage"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ line_length = 80
 [tool.black]
 line-length = 80
 target-version = [
-    "py39",
     "py310",
     "py311",
     "py312",
+    "py313",
+    "py314",
 ]
 exclude = "plugins/module_utils/doc_fragments"
 
@@ -56,5 +57,5 @@ disable = [
     "fixme",
 ]
 max-positional-arguments = 12
-py-version = "3.9"
+py-version = "3.10"
 extension-pkg-whitelist = "math"

--- a/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
@@ -18,7 +18,7 @@
       assert:
         that:
           - obj_quota.object_storage_quota.quota_id == obj_quota_list.object_storage_quotas[0].quota_id
-          - obj_quota.quota_usage.quota_limit
+          - not (obj_quota.object_storage_quota.has_usage | bool) or (obj_quota.quota_usage.quota_limit is integer)
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'

--- a/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
+++ b/tests/integration/targets/object_storage_quota_info/tasks/main.yaml
@@ -18,7 +18,7 @@
       assert:
         that:
           - obj_quota.object_storage_quota.quota_id == obj_quota_list.object_storage_quotas[0].quota_id
-          - not (obj_quota.object_storage_quota.has_usage | bool) or (obj_quota.quota_usage.quota_limit is integer)
+          - ((obj_quota.object_storage_quota.has_usage | bool) and (obj_quota.quota_usage.quota_limit is integer)) or ((not (obj_quota.object_storage_quota.has_usage | bool)) and (obj_quota.quota_usage is none))
 
   environment:
     LINODE_UA_PREFIX: '{{ ua_prefix }}'


### PR DESCRIPTION
## 📝 Description

Keep the behavior consistent with the global quota modules. Only to get and return the usage when `has_usage` is true.

## ✔️ How to Test
```bash
make integration-test TEST_SUITE=object_storage_quota_info
```