### PR TITLE
TPT-4474: Configurable VPC IPv4 Prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Name | Description |
 [linode.cloud.user_info](./docs/modules/user_info.md)|Get info about a Linode User.|
 [linode.cloud.vlan_info](./docs/modules/vlan_info.md)|Get info about a Linode VLAN.|
 [linode.cloud.volume_info](./docs/modules/volume_info.md)|Get info about a Linode Volume.|
+[linode.cloud.vpc_default_ranges_info](./docs/modules/vpc_default_ranges_info.md)|Get info about a Linode VPC Default Ranges.|
 [linode.cloud.vpc_info](./docs/modules/vpc_info.md)|Get info about a Linode VPC.|
 [linode.cloud.vpc_subnet_info](./docs/modules/vpc_subnet_info.md)|Get info about a Linode VPC Subnet.|
 

--- a/docs/modules/vpc.md
+++ b/docs/modules/vpc.md
@@ -35,6 +35,17 @@ Create, read, and update a Linode VPC.
 ```
 
 ```yaml
+# NOTE: IPv4 VPCs may not currently be available to all users.
+- name: Create a VPC with an IPv4 range
+  linode.cloud.vpc:
+    label: my-vpc
+    region: us-east
+    ipv4:
+    - range: 10.1.0.0/16
+    state: present
+```
+
+```yaml
 - name: Delete a VPC
   linode.cloud.vpc:
     label: my-vpc
@@ -51,6 +62,7 @@ Create, read, and update a Linode VPC.
 | `description` | <center>`str`</center> | <center>Optional</center> | A description describing this VPC.   |
 | `region` | <center>`str`</center> | <center>Optional</center> | The region this VPC is located in.   |
 | [`ipv6` (sub-options)](#ipv6) | <center>`list`</center> | <center>Optional</center> | A list of IPv6 ranges in CIDR notation. NOTE: IPv6 VPCs may not currently be available to all users.   |
+| [`ipv4` (sub-options)](#ipv4) | <center>`list`</center> | <center>Optional</center> | A list of IPv4 ranges in CIDR notation. NOTE: IPv4 VPCs may not currently be available to all users.   |
 
 ### ipv6
 
@@ -58,6 +70,12 @@ Create, read, and update a Linode VPC.
 |-----------|------|----------|------------------------------------------------------------------------------|
 | `range` | <center>`str`</center> | <center>Optional</center> | The IPv6 range assigned to this VPC.   |
 | `allocation_class` | <center>`str`</center> | <center>Optional</center> | The labeled IPv6 Inventory that the VPC Prefix should be allocated from.   |
+
+### ipv4
+
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+| `range` | <center>`str`</center> | <center>Optional</center> | The IPv4 range assigned to this VPC.   |
 
 ## Return Values
 
@@ -72,6 +90,11 @@ Create, read, and update a Linode VPC.
             "ipv6": [
                 {
                     "range": "2001:db8:acad:0::/52"
+                }
+            ],
+            "ipv4": [
+                {
+                    "range": "10.1.0.0/16"
                 }
             ],
             "label": "my-vpc",

--- a/docs/modules/vpc_default_ranges_info.md
+++ b/docs/modules/vpc_default_ranges_info.md
@@ -1,0 +1,49 @@
+# vpc_default_ranges_info
+
+Get info about a Linode VPC Default Ranges.
+
+- [Minimum Required Fields](#minimum-required-fields)
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Minimum Required Fields
+| Field       | Type  | Required     | Description                                                                                                                                                                                                              |
+|-------------|-------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_token` | `str` | **Required** | The Linode account personal access token. It is necessary to run the module. <br/>It can be exposed by the environment variable `LINODE_API_TOKEN` instead. <br/>See details in [Usage](https://github.com/linode/ansible_linode?tab=readme-ov-file#usage). |
+
+## Examples
+
+```yaml
+- name: Get info about the default and forbidden IPv4 address ranges for VPCs
+  linode.cloud.vpc_default_ranges_info:
+
+```
+
+
+## Return Values
+
+- `vpc_default_ranges` - The returned VPC Default Ranges.
+
+    - Sample Response:
+        ```json
+        
+        {
+          "default_ipv4_ranges": [
+            "10.0.0.0/8",
+            "172.16.0.0/12",
+            "192.168.0.0/17"
+          ],
+          "forbidden_ipv4_ranges": [
+            "0.0.0.0/8",
+            "10.64.12.199/24",
+            "172.21.89.19/15",
+            "192.168.128.0/17",
+            "203.0.113.190/32"
+          ]
+        }
+        
+        ```
+    - See the [Linode API response documentation](https://techdocs.akamai.com/linode-api/reference/get-vpcs-default-ranges) for a list of returned fields
+
+

--- a/docs/modules/vpc_info.md
+++ b/docs/modules/vpc_info.md
@@ -49,6 +49,11 @@ Get info about a Linode VPC.
                     "range": "2001:db8:acad:0::/52"
                 }
             ],
+            "ipv4": [
+                {
+                    "range": "10.1.0.0/16"
+                }
+            ],
             "label": "my-vpc",
             "region": "us-east",
             "subnets": [],

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -60,6 +60,11 @@ List and filter on VPCs.
                         "range": "2001:db8:acad:0::/52"
                     }
                 ],
+                "ipv6": [
+                    {
+                        "range": "10.0.0.1/16"
+                    }
+                ],
                 "label": "my-vpc",
                 "region": "us-east",
                 "subnets": [],

--- a/docs/modules/vpc_list.md
+++ b/docs/modules/vpc_list.md
@@ -60,9 +60,9 @@ List and filter on VPCs.
                         "range": "2001:db8:acad:0::/52"
                     }
                 ],
-                "ipv6": [
+                "ipv4": [
                     {
-                        "range": "10.0.0.1/16"
+                        "range": "10.0.0.0/16"
                     }
                 ],
                 "label": "my-vpc",

--- a/plugins/module_utils/doc_fragments/vpc.py
+++ b/plugins/module_utils/doc_fragments/vpc.py
@@ -17,6 +17,15 @@ specdoc_examples = ['''
     - range: auto
     state: present''',
 '''
+# NOTE: IPv4 VPCs may not currently be available to all users.
+- name: Create a VPC with an IPv4 range
+  linode.cloud.vpc:
+    label: my-vpc
+    region: us-east
+    ipv4:
+    - range: 10.1.0.0/16
+    state: present''',
+'''
 - name: Delete a VPC
   linode.cloud.vpc:
     label: my-vpc
@@ -29,6 +38,11 @@ result_vpc_samples = ['''{
     "ipv6": [
         {
             "range": "2001:db8:acad:0::/52"
+        }
+    ],
+    "ipv4": [
+        {
+            "range": "10.1.0.0/16"
         }
     ],
     "label": "my-vpc",

--- a/plugins/module_utils/doc_fragments/vpc_default_ranges.py
+++ b/plugins/module_utils/doc_fragments/vpc_default_ranges.py
@@ -1,0 +1,23 @@
+"""Documentation fragments for the vpc_default_ranges_info module"""
+
+specdoc_examples = ['''
+- name: Get info about the default and forbidden IPv4 address ranges for VPCs
+  linode.cloud.vpc_default_ranges_info:
+''']
+
+result_samples = ['''
+{
+  "default_ipv4_ranges": [
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/17"
+  ],
+  "forbidden_ipv4_ranges": [
+    "0.0.0.0/8",
+    "10.64.12.199/24",
+    "172.21.89.19/15",
+    "192.168.128.0/17",
+    "203.0.113.190/32"
+  ]
+}
+''']

--- a/plugins/module_utils/doc_fragments/vpc_list.py
+++ b/plugins/module_utils/doc_fragments/vpc_list.py
@@ -19,6 +19,11 @@ result_vpc_samples = ['''[
                 "range": "2001:db8:acad:0::/52"
             }
         ],
+        "ipv6": [
+            {
+                "range": "10.0.0.1/16"
+            }
+        ],
         "label": "my-vpc",
         "region": "us-east",
         "subnets": [],

--- a/plugins/module_utils/doc_fragments/vpc_list.py
+++ b/plugins/module_utils/doc_fragments/vpc_list.py
@@ -19,9 +19,9 @@ result_vpc_samples = ['''[
                 "range": "2001:db8:acad:0::/52"
             }
         ],
-        "ipv6": [
+        "ipv4": [
             {
-                "range": "10.0.0.1/16"
+                "range": "10.0.0.0/16"
             }
         ],
         "label": "my-vpc",

--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Any, Optional
+from typing import Any, Iterable, Optional, Set, Tuple
 
 import ansible_collections.linode.cloud.plugins.module_utils.doc_fragments.vpc as docs
 from ansible_collections.linode.cloud.plugins.module_utils.linode_common import (
@@ -75,6 +75,20 @@ SPEC = {
             ),
         },
     ),
+    "ipv4": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.dict,
+        description=[
+            "A list of IPv4 ranges in CIDR notation.",
+            "NOTE: IPv4 VPCs may not currently be available to all users.",
+        ],
+        suboptions={
+            "range": SpecField(
+                type=FieldType.string,
+                description="The IPv4 range assigned to this VPC.",
+            )
+        },
+    ),
 }
 
 SPECDOC_META = SpecDocMeta(
@@ -95,8 +109,8 @@ SPECDOC_META = SpecDocMeta(
     },
 )
 
-CREATE_FIELDS = {"label", "region", "description", "ipv6"}
-MUTABLE_FIELDS = {"description"}
+CREATE_FIELDS = {"label", "region", "description", "ipv6", "ipv4"}
+MUTABLE_FIELDS = {"description", "ipv4"}
 
 DOCUMENTATION = r"""
 """
@@ -116,6 +130,25 @@ class Module(LinodeModuleBase):
         super().__init__(
             module_arg_spec=self.module_arg_spec,
             required_if=[("state", "present", ["region"])],
+        )
+
+    @staticmethod
+    def _diff_ipv4(
+        _key: str,
+        old_value: Any,
+        new_value: Any,
+    ) -> Tuple[bool, Any]:
+
+        def normalize(
+            values: Optional[Iterable[dict[str, Any]]],
+        ) -> Set[Tuple[Tuple[str, Any], ...]]:
+            if not values:
+                return set()
+            return {tuple(sorted(v.items())) for v in values}
+
+        return (
+            normalize(old_value) != normalize(new_value),
+            new_value,
         )
 
     def __ipv6_updated(self, vpc: VPC) -> bool:
@@ -159,6 +192,9 @@ class Module(LinodeModuleBase):
             MUTABLE_FIELDS,
             self.register_action,
             ignore_keys={"ipv6"},
+            diff_overrides={
+                "ipv4": self._diff_ipv4,
+            },
         )
 
         if self.__ipv6_updated(vpc):

--- a/plugins/modules/vpc_default_ranges_info.py
+++ b/plugins/modules/vpc_default_ranges_info.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""Implementation for linode.cloud.vpc_default_ranges_info module."""
+
+from __future__ import absolute_import, division, print_function
+
+from ansible_collections.linode.cloud.plugins.module_utils.doc_fragments import (
+    vpc_default_ranges as docs,
+)
+from ansible_collections.linode.cloud.plugins.module_utils.linode_common_info import (
+    InfoModule,
+    InfoModuleResult,
+)
+from ansible_specdoc.objects import FieldType
+
+module = InfoModule(
+    examples=docs.specdoc_examples,
+    primary_result=InfoModuleResult(
+        display_name="VPC Default Ranges",
+        field_name="vpc_default_ranges",
+        field_type=FieldType.dict,
+        docs_url="https://techdocs.akamai.com/linode-api/reference/get-vpcs-default-ranges",
+        samples=docs.result_samples,
+        get=lambda client, params: client.vpcs.default_ranges()._serialize(),
+    ),
+)
+
+SPECDOC_META = module.spec
+
+DOCUMENTATION = r"""
+"""
+EXAMPLES = r"""
+"""
+RETURN = r"""
+"""
+
+if __name__ == "__main__":
+    module.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode_api4>= 5.45.0
+linode_api4>= 5.46.0
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/vpc_default_ranges_info/tasks/main.yaml
+++ b/tests/integration/targets/vpc_default_ranges_info/tasks/main.yaml
@@ -1,0 +1,19 @@
+- name: vpc_default_ranges_info
+  block:
+    - name: Get VPC default ranges
+      linode.cloud.vpc_default_ranges_info:
+      register: ranges
+
+    - name: Assert response structure
+      assert:
+        that:
+          - ranges.vpc_default_ranges is defined
+          - ranges.vpc_default_ranges.default_ipv4_ranges | length > 0
+          - ranges.vpc_default_ranges.forbidden_ipv4_ranges | length > 0
+
+  environment:
+    LINODE_UA_PREFIX: "{{ ua_prefix }}"
+    LINODE_API_TOKEN: "{{ api_token }}"
+    LINODE_API_URL: "{{ api_url }}"
+    LINODE_API_VERSION: "{{ api_version }}"
+    LINODE_CA: "{{ ca_file or '' }}"

--- a/tests/integration/targets/vpc_ipv4/tasks/main.yaml
+++ b/tests/integration/targets/vpc_ipv4/tasks/main.yaml
@@ -1,0 +1,98 @@
+- name: vpc_ipv4
+  block:
+    - set_fact:
+        r: "{{ 1000000000 | random }}"
+
+    - name: Create a VPC
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: no-osl-1
+        ipv4:
+          - range: "10.0.0.0/16"
+        state: present
+      register: create_vpc
+
+    - name: Assert VPC created
+      assert:
+        that:
+          - create_vpc.changed
+          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.region == 'no-osl-1'
+          - create_vpc.vpc.ipv4 | length == 1
+          - create_vpc.vpc.ipv4[0].range == "10.0.0.0/16"
+
+    - name: Update the IPv4 range
+      linode.cloud.vpc:
+        label: 'ansible-test-{{ r }}'
+        region: no-osl-1
+        ipv4:
+          - range: "10.1.0.0/16"
+        state: present
+      register: update_vpc
+
+    - name: Assert VPC updated
+      assert:
+        that:
+          - update_vpc.changed
+          - update_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - update_vpc.vpc.region == 'no-osl-1'
+          - update_vpc.vpc.ipv4 | length == 1
+          - update_vpc.vpc.ipv4[0].range == "10.1.0.0/16"
+
+    - name: List VPCs
+      linode.cloud.vpc_list:
+        filters:
+          - name: label
+            values: '{{ create_vpc.vpc.label }}'
+      register: list_vpc
+      until:
+        - list_vpc.vpcs | length == 1
+        - list_vpc.vpcs[0].ipv4 | length == 1
+        - list_vpc.vpcs[0].ipv4[0].range == "10.1.0.0/16"
+      retries: 10
+      delay: 2
+
+    - name: Assert VPC is returned with ipv4 range
+      assert:
+        that:
+          - list_vpc.vpcs | length == 1
+          - list_vpc.vpcs[0].id == create_vpc.vpc.id
+          - list_vpc.vpcs[0].ipv4 | length == 1
+          - list_vpc.vpcs[0].ipv4[0].range == "10.1.0.0/16"
+
+    - name: Get information about the VPC by ID
+      linode.cloud.vpc_info:
+        id: '{{ create_vpc.vpc.id }}'
+      register: vpc_info_id
+
+    - name: Get information about the VPC by label
+      linode.cloud.vpc_info:
+        label: '{{ create_vpc.vpc.label }}'
+      register: vpc_info_label
+
+    - name: Assert results
+      assert:
+        that:
+          - vpc_info_id.vpc.id == create_vpc.vpc.id
+          - vpc_info_id.vpc.id == vpc_info_label.vpc.id
+          - vpc_info_id.vpc.ipv4 | length == 1
+          - vpc_info_id.vpc.ipv4[0].range == "10.1.0.0/16"
+          - vpc_info_label.vpc.ipv4 | length == 1
+          - vpc_info_label.vpc.ipv4[0].range == "10.1.0.0/16"
+
+  always:
+    - ignore_errors: yes
+      block:
+        - name: Delete a VPC
+          linode.cloud.vpc:
+            label: '{{ create_vpc.vpc.label }}'
+            state: absent
+          register: delete_vpc
+
+  environment:
+    LINODE_UA_PREFIX: '{{ ua_prefix }}'
+    LINODE_API_TOKEN: '{{ api_token }}'
+    LINODE_API_URL: '{{ api_url }}'
+    LINODE_API_VERSION: '{{ api_version }}'
+
+    LINODE_CA: '{{ ca_file or "" }}'


### PR DESCRIPTION
## 📝 Description

Added support for the Configurable VPC IPv4 Prefixes project.

## ✔️ How to Test
`make test-int TEST_SUITE="vpc_ipv4"`
`make test-int TEST_SUITE="vpc_default_ranges_info"`
