### PR TITLE
TPT-4558: Mask sensitive module fields

### DIFF
--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -70,6 +70,7 @@ MIN_DEVICE_LIMIT = 8
 linode_instance_metadata_spec = {
     "user_data": SpecField(
         type=FieldType.string,
+        no_log=True,
         description=[
             "The user-defined data to supply for the Linode through the Metadata service."
         ],
@@ -117,6 +118,7 @@ linode_instance_disk_spec = {
     ),
     "root_pass": SpecField(
         type=FieldType.string,
+        no_log=True,
         description=["The root user’s password on the newly-created Linode."],
     ),
     "size": SpecField(
@@ -135,6 +137,7 @@ linode_instance_disk_spec = {
     ),
     "stackscript_data": SpecField(
         type=FieldType.dict,
+        no_log=True,
         description=[
             "An object containing arguments to any User Defined Fields present in "
             "the StackScript used when creating the instance.",
@@ -456,6 +459,7 @@ linode_instance_spec = {
     ),
     "stackscript_data": SpecField(
         type=FieldType.dict,
+        no_log=True,
         description=[
             "An object containing arguments to any User Defined Fields present in "
             "the StackScript used when creating the instance.",

--- a/plugins/modules/monitor_logs_destination.py
+++ b/plugins/modules/monitor_logs_destination.py
@@ -40,6 +40,7 @@ from linode_api4 import (
 authentication_details_spec: dict = {
     "basic_authentication_password": SpecField(
         type=FieldType.string,
+        no_log=True,
         editable=True,
         description=[
             "The password tied to the basic_authentication_user, for basic authentication."
@@ -94,6 +95,7 @@ client_certificate_details_spec: dict = {
     ),
     "client_private_key": SpecField(
         type=FieldType.string,
+        no_log=True,
         editable=True,
         description=[
             "The private key in the non-encrypted PKCS8 format that authenticates "

--- a/plugins/modules/nodebalancer.py
+++ b/plugins/modules/nodebalancer.py
@@ -217,6 +217,7 @@ linode_configs_spec = {
     "ssl_key": SpecField(
         type=FieldType.string,
         required=False,
+        no_log=True,
         editable=True,
         description=[
             "The PEM-formatted private key for the SSL certificate "


### PR DESCRIPTION
## Summary

- Mark passwords, private keys, StackScript data, and instance user data with `no_log=True`.
- Cover the reported fields in the Instance and Monitor Logs Destination modules.
- Also protect Instance metadata user data and the NodeBalancer SSL private key found during the audit.