### PR TITLE
Fixed several VPC integration test issues

### DIFF
--- a/tests/integration/targets/vpc_ipv4/tasks/main.yaml
+++ b/tests/integration/targets/vpc_ipv4/tasks/main.yaml
@@ -16,7 +16,7 @@
       assert:
         that:
           - create_vpc.changed
-          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.label == 'ansible-test-' + (r | string)
           - create_vpc.vpc.region == 'no-osl-1'
           - create_vpc.vpc.ipv4 | length == 1
           - create_vpc.vpc.ipv4[0].range == "10.0.0.0/16"
@@ -34,7 +34,7 @@
       assert:
         that:
           - update_vpc.changed
-          - update_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - update_vpc.vpc.label == 'ansible-test-' + (r | string)
           - update_vpc.vpc.region == 'no-osl-1'
           - update_vpc.vpc.ipv4 | length == 1
           - update_vpc.vpc.ipv4[0].range == "10.1.0.0/16"
@@ -69,6 +69,9 @@
       linode.cloud.vpc_info:
         label: '{{ create_vpc.vpc.label }}'
       register: vpc_info_label
+      retries: 10
+      delay: 2
+      until: vpc_info_label.vpc is defined
 
     - name: Assert results
       assert:

--- a/tests/integration/targets/vpc_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/vpc_ipv6/tasks/main.yaml
@@ -16,10 +16,18 @@
       assert:
         that:
           - create_vpc.changed
-          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.label == 'ansible-test-' + (r | string)
           - create_vpc.vpc.region == 'no-osl-1'
           - create_vpc.vpc.ipv6 | length == 1
           - create_vpc.vpc.ipv6[0].range.endswith('/52')
+
+    - name: Wait for VPC to be findable by label
+      linode.cloud.vpc_info:
+        label: '{{ create_vpc.vpc.label }}'
+      register: vpc_wait
+      retries: 10
+      delay: 2
+      until: vpc_wait.vpc is defined
 
     - name: Attempt to update the IPv6 range's prefix
       linode.cloud.vpc:

--- a/tests/integration/targets/vpc_subnet/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet/tasks/main.yaml
@@ -15,7 +15,7 @@
       assert:
         that:
           - create_vpc.changed
-          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.label == 'ansible-test-' + (r | string)
           - create_vpc.vpc.region == 'us-mia'
           - create_vpc.vpc.description == 'test description'
 
@@ -44,7 +44,7 @@
         ipv4: '10.0.0.0/24'
         state: present
       register: invalid_subnet
-      failed_when: "'Must only use ASCII letters, numbers, and dashes' not in invalid_subnet.msg"
+      failed_when: "'Must only use ASCII letters, numbers, and underscores' not in invalid_subnet.msg"
 
     - name: List Subnets
       linode.cloud.vpc_subnet_list:

--- a/tests/integration/targets/vpc_subnet_ipv6/tasks/main.yaml
+++ b/tests/integration/targets/vpc_subnet_ipv6/tasks/main.yaml
@@ -16,7 +16,7 @@
       assert:
         that:
           - create_vpc.changed
-          - create_vpc.vpc.label == 'ansible-test-{{ r }}'
+          - create_vpc.vpc.label == 'ansible-test-' + (r | string)
           - create_vpc.vpc.region == 'no-osl-1'
           - create_vpc.vpc.ipv6 | length == 1
           - create_vpc.vpc.ipv6[0].range.endswith('/52')


### PR DESCRIPTION
## 📝 Description

Fixed some issues in several VPC integration tests that were causing failures.

## ✔️ How to Test

`make test-int TEST_SUITE="vpc_ipv4"`
`make test-int TEST_SUITE="vpc_ipv6"`
`make test-int TEST_SUITE="vpc_subnet"`
`make test-int TEST_SUITE="vpc_subnet_ipv6"`
