### PR TITLE
TPT-4609: Address test failures blocking v0.49.0 release

### DIFF
--- a/tests/integration/targets/image_list/tasks/main.yaml
+++ b/tests/integration/targets/image_list/tasks/main.yaml
@@ -13,6 +13,9 @@
         that:
           - no_filter.images | length == 5
 
+    - set_fact:
+        target_image: "{{ no_filter.images[0] }}"
+
     - name: List image_list with filter on label
       linode.cloud.image_list:
         count: 1
@@ -20,14 +23,14 @@
         order: desc
         filters:
           - name: label
-            values: Alpine 3.19
+            values: "{{ target_image.label }}"
       register: filter
 
     - name: Assert image_list with filter on label
       assert:
         that:
           - filter.images | length == 1
-          - filter.images[0].id == 'linode/alpine3.19'
+          - filter.images[0].label == target_image.label
 
     - name: List image_list with empty filter
       linode.cloud.image_list:

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -63,9 +63,9 @@
           - update_backups_canceled.changed
           - update_backups_canceled.instance.backups.enabled == False
 
-    - name: Re-enable backups on instance
+    - name: Enable backups on the backups-less instance
       linode.cloud.instance:
-        label: '{{ create_backups_enabled.instance.label }}'
+        label: '{{ create_no_set_backup.instance.label }}'
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu24.04

--- a/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
+++ b/tests/integration/targets/instance_backup_enabled/tasks/main.yaml
@@ -65,7 +65,7 @@
 
     - name: Re-enable backups on instance
       linode.cloud.instance:
-        label: '{{ create_no_set_backup.instance.label }}'
+        label: '{{ create_backups_enabled.instance.label }}'
         region: us-mia
         type: g6-standard-1
         image: linode/ubuntu24.04
@@ -111,4 +111,3 @@
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
     E2E_FIREWALL_ID: '{{ firewall_id }}'
-

--- a/tests/integration/targets/ipv6_range_info/tasks/main.yaml
+++ b/tests/integration/targets/ipv6_range_info/tasks/main.yaml
@@ -17,14 +17,14 @@
 
     - set_fact:
         ipv6_body:
-          linode_id: "{{ instance_create.instance.id }}"
+          linode_id: "{{ instance_create.instance.id | int }}"
           prefix_length: 64
 
     - name: Assign an IPv6 range to the instance
       linode.cloud.api_request:
         path: networking/ipv6/ranges
         method: POST
-        body_json: "{{ ipv6_body }}"
+        body: "{{ ipv6_body }}"
       register: range_create
 
     - name: Get ipv6_range_info about the IPv6 range
@@ -60,4 +60,3 @@
     LINODE_API_URL: '{{ api_url }}'
     LINODE_API_VERSION: '{{ api_version }}'
     LINODE_CA: '{{ ca_file or "" }}'
-


### PR DESCRIPTION
## 📝 Description

This pull request resolves a few integration test failures that are currently blocking the v0.49.0 release.

## ✔️ How to Test

### Integration Testing

```
make test-int TEST_ARGS="-v image_list instance_backup_enabled ipv6_range_info"
```
