### PR TITLE
TPT-4573: add group_by parameter to alert definitions for metric aggregation

### DIFF
--- a/docs/modules/monitor_services_alert_definition.md
+++ b/docs/modules/monitor_services_alert_definition.md
@@ -39,6 +39,8 @@ Manage an alert definition for a specific service type. Akamai refers to these a
       evaluation_period_seconds: 300
       polling_interval_seconds: 300
       trigger_occurrences: 1
+    group_by:
+      - entity_id
     channel_ids: '{{ alert_channels }}'
     state: present
 ```
@@ -69,6 +71,7 @@ Manage an alert definition for a specific service type. Akamai refers to these a
 | `id` | <center>`int`</center> | <center>Optional</center> | The unique identifier assigned to the alert definition. Run the List alert definitions operation and store the id for the applicable alert definition. Required for updating.   |
 | `scope` | <center>`str`</center> | <center>Optional</center> | The alert scope. Supported values include account, entity, and region. Defaults to entity.  **(Choices: `account`, `entity`, `region`)** |
 | `regions` | <center>`list`</center> | <center>Optional</center> | The regions to monitor for this alert definition.  **(Updatable)** |
+| `group_by` | <center>`list`</center> | <center>Optional</center> | Aggregates metric data by dimension so that alert conditions are evaluated independently for each dimension value.  **(Updatable)** |
 | `status` | <center>`str`</center> | <center>Optional</center> | The current status of the alert.  **(Choices: `enabled`, `disabled`; Updatable)** |
 | `wait` | <center>`bool`</center> | <center>Optional</center> | Wait for the alert definition ready (not in progress).  **(Default: `False`)** |
 | `wait_timeout` | <center>`int`</center> | <center>Optional</center> | The amount of time, in seconds, to wait for the alert definition.  **(Default: `600`)** |
@@ -121,6 +124,9 @@ Manage an alert definition for a specific service type. Akamai refers to these a
           "description": "A test alert for dbaas service",
           "scope": "entity",
           "regions": [],
+          "group_by": [
+            "entity_id"
+          ],
           "entities": {
             "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
             "count": 1,

--- a/docs/modules/monitor_services_alert_definition_by_service_type_list.md
+++ b/docs/modules/monitor_services_alert_definition_by_service_type_list.md
@@ -47,6 +47,9 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
               "description": "A test alert for dbaas service",
               "scope": "entity",
               "regions": [],
+              "group_by": [
+                "entity_id"
+              ],
               "entities": {
                 "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
                 "count": 1,

--- a/docs/modules/monitor_services_alert_definition_info.md
+++ b/docs/modules/monitor_services_alert_definition_info.md
@@ -44,6 +44,9 @@ Get info about a Linode Alert Definition.
           "description": "A test alert for dbaas service",
           "scope": "entity",
           "regions": [],
+          "group_by": [
+            "entity_id"
+          ],
           "entities": {
             "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
             "count": 1,

--- a/docs/modules/monitor_services_alert_definition_list.md
+++ b/docs/modules/monitor_services_alert_definition_list.md
@@ -55,6 +55,9 @@ WARNING! This module makes use of beta endpoints and requires the C(api_version)
               "description": "A test alert for dbaas service",
               "scope": "entity",
               "regions": [],
+              "group_by": [
+                "entity_id"
+              ],
               "entities": {
                 "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
                 "count": 1,

--- a/plugins/module_utils/doc_fragments/alert_definition.py
+++ b/plugins/module_utils/doc_fragments/alert_definition.py
@@ -25,6 +25,8 @@ specdoc_examples = ['''
       evaluation_period_seconds: 300
       polling_interval_seconds: 300
       trigger_occurrences: 1
+    group_by:
+      - entity_id
     channel_ids: '{{ alert_channels }}'
     state: present''',  '''
 - name: Delete alert definition
@@ -43,6 +45,9 @@ result_aclp_alert_definition_sample = ['''{
   "description": "A test alert for dbaas service",
   "scope": "entity",
   "regions": [],
+  "group_by": [
+    "entity_id"
+  ],
   "entities": {
     "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
     "count": 1,

--- a/plugins/module_utils/doc_fragments/alert_definition_info.py
+++ b/plugins/module_utils/doc_fragments/alert_definition_info.py
@@ -15,6 +15,9 @@ result_alert_definition_samples = ['''{
   "description": "A test alert for dbaas service",
   "scope": "entity",
   "regions": [],
+  "group_by": [
+    "entity_id"
+  ],
   "entities": {
     "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
     "count": 1,

--- a/plugins/module_utils/doc_fragments/alert_definitions_by_service_type_list.py
+++ b/plugins/module_utils/doc_fragments/alert_definitions_by_service_type_list.py
@@ -16,6 +16,9 @@ result_alert_definitions_by_service_type_samples = ['''[
       "description": "A test alert for dbaas service",
       "scope": "entity",
       "regions": [],
+      "group_by": [
+        "entity_id"
+      ],
       "entities": {
         "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
         "count": 1,

--- a/plugins/module_utils/doc_fragments/alert_definitions_list.py
+++ b/plugins/module_utils/doc_fragments/alert_definitions_list.py
@@ -15,6 +15,9 @@ result_alert_definitions_samples = ['''[
       "description": "A test alert for dbaas service",
       "scope": "entity",
       "regions": [],
+      "group_by": [
+        "entity_id"
+      ],
       "entities": {
         "url": "/monitor/services/dbaas/alert-definitions/12345/entities",
         "count": 1,

--- a/plugins/modules/monitor_services_alert_definition.py
+++ b/plugins/modules/monitor_services_alert_definition.py
@@ -222,6 +222,15 @@ spec: dict = {
         editable=True,
         description=["The regions to monitor for this alert definition."],
     ),
+    "group_by": SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        editable=True,
+        description=[
+            "Aggregates metric data by dimension so that alert conditions "
+            "are evaluated independently for each dimension value."
+        ],
+    ),
     "status": SpecField(
         type=FieldType.string,
         editable=True,
@@ -273,6 +282,7 @@ MUTABLE_FIELDS = {
     "channel_ids",
     "description",
     "entity_ids",
+    "group_by",
     "label",
     "regions",
     "rule_criteria",
@@ -374,6 +384,10 @@ class LinodeMonitorServicesAlertDefinition(LinodeModuleBase):
         entity_ids = params.get("entity_ids")
         if entity_ids is not None:
             create_kwargs["entity_ids"] = entity_ids
+
+        group_by = params.get("group_by")
+        if group_by is not None:
+            create_kwargs["group_by"] = group_by
 
         try:
             self.register_action(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linode_api4>= 5.46.1
+linode_api4>=5.46.1
 polling==0.3.2
 ansible-specdoc>=0.0.20

--- a/tests/integration/targets/monitor_services_alert_definition/tasks/main.yaml
+++ b/tests/integration/targets/monitor_services_alert_definition/tasks/main.yaml
@@ -36,6 +36,8 @@
               evaluation_period_seconds: 300
               polling_interval_seconds: 300
               trigger_occurrences: 1
+            group_by:
+              - entity_id
             channel_ids: '{{ alert_channels }}'
             wait: yes
             state: present
@@ -49,6 +51,7 @@
               - create.alert_definition.severity == 1
               - create.alert_definition.scope == 'entity'
               - create.alert_definition.regions is defined
+              - create.alert_definition.group_by == ['entity_id']
               - create.alert_definition.entities is not none
               - create.alert_definition.rule_criteria.rules[0].aggregate_function == 'avg'
               - create.alert_definition.rule_criteria.rules[0].dimension_filters[0].dimension_label == 'node_type'
@@ -91,6 +94,7 @@
               - update.alert_definition.label == (label + '-updated')
               - update.alert_definition.description == 'An updated alert definition for ansible test'
               - update.alert_definition.rule_criteria.rules[0].aggregate_function == 'sum'
+              - update.alert_definition.group_by == ['entity_id']
 
         - name: Get alert definition information
           linode.cloud.monitor_services_alert_definition_info:


### PR DESCRIPTION
## 📝 Description

Add `group_by` parameter to alert definitions for metric aggregation.

## ✔️ How to Test

```bash
make test-int TEST_SUITE=monitor_services_alert_definition
```
